### PR TITLE
8282458: Update .jcheck/conf file for 8u move to git

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -1,2 +1,31 @@
-project=jdk8
-bugids=dup
+[general]
+project=jdk8u
+jbs=JDK
+version=openjdk8u342
+
+[checks]
+error=author,committer,reviewers,merge,issues,executable,symlink,message,hg-tag,whitespace
+
+[repository]
+tags=(?:jdk-(?:[1-9]([0-9]*)(?:\.(?:0|[1-9][0-9]*)){0,4})(?:\+(?:(?:[0-9]+))|(?:-ga)))|(?:jdk[4-9](?:u\d{1,3})?-(?:(?:b\d{2,3})|(?:ga)))|(?:hs\d\d(?:\.\d{1,2})?-b\d\d)
+branches=
+
+[census]
+version=0
+domain=openjdk.org
+
+[checks "whitespace"]
+files=.*\.cpp|.*\.hpp|.*\.c|.*\.h|.*\.java
+
+[checks "merge"]
+message=Merge
+
+[checks "reviewers"]
+reviewers=1
+ignore=duke
+
+[checks "committer"]
+role=committer
+
+[checks "issues"]
+pattern=^([124-8][0-9]{6}): (\S.*)$


### PR DESCRIPTION
This space deliberately left empty.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282458](https://bugs.openjdk.java.net/browse/JDK-8282458): Update .jcheck/conf file for 8u move to git


### Reviewers
 * [Severin Gehwolf](https://openjdk.java.net/census#sgehwolf) (@jerboaa - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk8u-dev pull/2/head:pull/2` \
`$ git checkout pull/2`

Update a local copy of the PR: \
`$ git checkout pull/2` \
`$ git pull https://git.openjdk.java.net/jdk8u-dev pull/2/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2`

View PR using the GUI difftool: \
`$ git pr show -t 2`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk8u-dev/pull/2.diff">https://git.openjdk.java.net/jdk8u-dev/pull/2.diff</a>

</details>
