### PR TITLE
8129572: Cleanup usage of getResourceAsStream in jaxp

### DIFF
--- a/jaxp/src/com/sun/org/apache/bcel/internal/util/SecuritySupport.java
+++ b/jaxp/src/com/sun/org/apache/bcel/internal/util/SecuritySupport.java
@@ -25,7 +25,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FilenameFilter;
-import java.io.InputStream;
 import java.lang.ClassLoader;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -114,33 +113,6 @@ public final class SecuritySupport {
         } catch (PrivilegedActionException e) {
             throw (FileNotFoundException) e.getException();
         }
-    }
-
-    /**
-     * Return resource using the same classloader for the ObjectFactory by
-     * default or bootclassloader when Security Manager is in place
-     */
-    public static InputStream getResourceAsStream(final String name) {
-        if (System.getSecurityManager() != null) {
-            return getResourceAsStream(null, name);
-        } else {
-            return getResourceAsStream(findClassLoader(), name);
-        }
-    }
-
-    public static InputStream getResourceAsStream(final ClassLoader cl,
-            final String name) {
-        return (InputStream) AccessController.doPrivileged(new PrivilegedAction() {
-            public Object run() {
-                InputStream ris;
-                if (cl == null) {
-                    ris = Object.class.getResourceAsStream("/" + name);
-                } else {
-                    ris = cl.getResourceAsStream(name);
-                }
-                return ris;
-            }
-        });
     }
 
     /**

--- a/jaxp/src/com/sun/org/apache/xalan/internal/utils/SecuritySupport.java
+++ b/jaxp/src/com/sun/org/apache/xalan/internal/utils/SecuritySupport.java
@@ -126,29 +126,10 @@ public final class SecuritySupport {
         }
     }
 
-    /**
-     * Return resource using the same classloader for the ObjectFactory by
-     * default or bootclassloader when Security Manager is in place
-     */
     public static InputStream getResourceAsStream(final String name) {
-        if (System.getSecurityManager()!=null) {
-            return getResourceAsStream(null, name);
-        } else {
-            return getResourceAsStream(ObjectFactory.findClassLoader(), name);
-        }
-    }
-
-    public static InputStream getResourceAsStream(final ClassLoader cl,
-            final String name) {
         return (InputStream) AccessController.doPrivileged(new PrivilegedAction() {
             public Object run() {
-                InputStream ris;
-                if (cl == null) {
-                    ris = Object.class.getResourceAsStream("/"+name);
-                } else {
-                    ris = cl.getResourceAsStream(name);
-                }
-                return ris;
+                return SecuritySupport.class.getResourceAsStream("/"+name);
             }
         });
     }

--- a/jaxp/src/com/sun/org/apache/xerces/internal/utils/SecuritySupport.java
+++ b/jaxp/src/com/sun/org/apache/xerces/internal/utils/SecuritySupport.java
@@ -118,34 +118,6 @@ public final class SecuritySupport {
             throw (FileNotFoundException)e.getException();
         }
     }
-    /**
-     * Return resource using the same classloader for the ObjectFactory by default
-     * or bootclassloader when Security Manager is in place
-     */
-    public static InputStream getResourceAsStream(final String name) {
-        if (System.getSecurityManager()!=null) {
-            return getResourceAsStream(null, name);
-        } else {
-            return getResourceAsStream(ObjectFactory.findClassLoader(), name);
-        }
-    }
-
-    public static InputStream getResourceAsStream(final ClassLoader cl,
-            final String name)
-    {
-        return (InputStream)
-        AccessController.doPrivileged(new PrivilegedAction() {
-            public Object run() {
-                InputStream ris;
-                if (cl == null) {
-                    ris = Object.class.getResourceAsStream("/"+name);
-                } else {
-                    ris = cl.getResourceAsStream(name);
-                }
-                return ris;
-            }
-        });
-    }
 
     /**
      * Gets a resource bundle using the specified base name, the default locale, and the caller's class loader.

--- a/jaxp/src/com/sun/org/apache/xerces/internal/xinclude/SecuritySupport.java
+++ b/jaxp/src/com/sun/org/apache/xerces/internal/xinclude/SecuritySupport.java
@@ -24,7 +24,6 @@ package com.sun.org.apache.xerces.internal.xinclude;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.InputStream;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -112,23 +111,6 @@ final class SecuritySupport {
         } catch (PrivilegedActionException e) {
             throw (FileNotFoundException)e.getException();
         }
-    }
-
-    InputStream getResourceAsStream(final ClassLoader cl,
-            final String name)
-    {
-        return (InputStream)
-        AccessController.doPrivileged(new PrivilegedAction() {
-            public Object run() {
-                InputStream ris;
-                if (cl == null) {
-                    ris = ClassLoader.getSystemResourceAsStream(name);
-                } else {
-                    ris = cl.getResourceAsStream(name);
-                }
-                return ris;
-            }
-        });
     }
 
     boolean getFileExists(final File f) {

--- a/jaxp/src/com/sun/org/apache/xml/internal/serialize/SecuritySupport.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serialize/SecuritySupport.java
@@ -24,7 +24,6 @@ package com.sun.org.apache.xml.internal.serialize;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.InputStream;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -112,23 +111,6 @@ final class SecuritySupport {
         } catch (PrivilegedActionException e) {
             throw (FileNotFoundException)e.getException();
         }
-    }
-
-    InputStream getResourceAsStream(final ClassLoader cl,
-            final String name)
-    {
-        return (InputStream)
-        AccessController.doPrivileged(new PrivilegedAction() {
-            public Object run() {
-                InputStream ris;
-                if (cl == null) {
-                    ris = ClassLoader.getSystemResourceAsStream(name);
-                } else {
-                    ris = cl.getResourceAsStream(name);
-                }
-                return ris;
-            }
-        });
     }
 
     boolean getFileExists(final File f) {

--- a/jaxp/src/com/sun/org/apache/xpath/internal/functions/FuncSystemProperty.java
+++ b/jaxp/src/com/sun/org/apache/xpath/internal/functions/FuncSystemProperty.java
@@ -26,11 +26,9 @@ import java.io.InputStream;
 import java.util.Properties;
 
 import com.sun.org.apache.xpath.internal.XPathContext;
-import com.sun.org.apache.xpath.internal.objects.XNumber;
 import com.sun.org.apache.xpath.internal.objects.XObject;
 import com.sun.org.apache.xpath.internal.objects.XString;
 import com.sun.org.apache.xpath.internal.res.XPATHErrorResources;
-import com.sun.org.apache.xalan.internal.utils.ObjectFactory;
 import com.sun.org.apache.xalan.internal.utils.SecuritySupport;
 
 /**
@@ -68,7 +66,7 @@ public class FuncSystemProperty extends FunctionOneArg
     // property argument is to be looked for.
     Properties xsltInfo = new Properties();
 
-    loadPropertyFile(XSLT_PROPERTIES, xsltInfo);
+    loadPropertyFile(xsltInfo);
 
     if (indexOfNSSep > 0)
     {
@@ -158,25 +156,21 @@ public class FuncSystemProperty extends FunctionOneArg
   }
 
   /**
-   * Retrieve a propery bundle from a specified file
+   * Retrieve a property bundle from a XSLT_PROPERTIES
    *
-   * @param file The string name of the property file.  The name
-   * should already be fully qualified as path/filename
    * @param target The target property bag the file will be placed into.
    */
-  public void loadPropertyFile(String file, Properties target)
+  private void loadPropertyFile(Properties target)
   {
     try
     {
-      // Use SecuritySupport class to provide priveleged access to property file
-      InputStream is = SecuritySupport.getResourceAsStream(ObjectFactory.findClassLoader(),
-                                              file);
+      // Use SecuritySupport class to provide privileged access to property file
+      InputStream is = SecuritySupport.getResourceAsStream(XSLT_PROPERTIES);
 
       // get a buffered version
-      BufferedInputStream bis = new BufferedInputStream(is);
-
-      target.load(bis);  // and load up the property bag from this
-      bis.close();  // close out after reading
+      try (BufferedInputStream bis = new BufferedInputStream(is)) {
+          target.load(bis);  // and load up the property bag from this
+      }
     }
     catch (Exception ex)
     {

--- a/jaxp/src/javax/xml/datatype/SecuritySupport.java
+++ b/jaxp/src/javax/xml/datatype/SecuritySupport.java
@@ -26,9 +26,7 @@
 package javax.xml.datatype;
 
 import java.security.*;
-import java.net.*;
 import java.io.*;
-import java.util.*;
 
 /**
  * This class is duplicated for each JAXP subpackage so keep it in sync.
@@ -75,23 +73,6 @@ class SecuritySupport  {
         } catch (PrivilegedActionException e) {
             throw (FileNotFoundException)e.getException();
         }
-    }
-
-    InputStream getResourceAsStream(final ClassLoader cl,
-                                           final String name)
-    {
-        return (InputStream)
-            AccessController.doPrivileged(new PrivilegedAction() {
-                public Object run() {
-                    InputStream ris;
-                    if (cl == null) {
-                        ris = Object.class.getResourceAsStream(name);
-                    } else {
-                        ris = cl.getResourceAsStream(name);
-                    }
-                    return ris;
-                }
-            });
     }
 
     boolean doesFileExist(final File f) {

--- a/jaxp/src/javax/xml/parsers/SecuritySupport.java
+++ b/jaxp/src/javax/xml/parsers/SecuritySupport.java
@@ -26,9 +26,7 @@
 package javax.xml.parsers;
 
 import java.security.*;
-import java.net.*;
 import java.io.*;
-import java.util.*;
 
 /**
  * This class is duplicated for each JAXP subpackage so keep it in sync.
@@ -79,23 +77,6 @@ class SecuritySupport  {
         } catch (PrivilegedActionException e) {
             throw (FileNotFoundException)e.getException();
         }
-    }
-
-    InputStream getResourceAsStream(final ClassLoader cl,
-                                           final String name)
-    {
-        return (InputStream)
-            AccessController.doPrivileged(new PrivilegedAction() {
-                public Object run() {
-                    InputStream ris;
-                    if (cl == null) {
-                        ris = Object.class.getResourceAsStream(name);
-                    } else {
-                        ris = cl.getResourceAsStream(name);
-                    }
-                    return ris;
-                }
-            });
     }
 
     boolean doesFileExist(final File f) {

--- a/jaxp/src/javax/xml/stream/SecuritySupport.java
+++ b/jaxp/src/javax/xml/stream/SecuritySupport.java
@@ -26,9 +26,7 @@
 package javax.xml.stream;
 
 import java.security.*;
-import java.net.*;
 import java.io.*;
-import java.util.*;
 
 /**
  * This class is duplicated for each JAXP subpackage so keep it in sync.
@@ -79,23 +77,6 @@ class SecuritySupport  {
         } catch (PrivilegedActionException e) {
             throw (FileNotFoundException)e.getException();
         }
-    }
-
-    InputStream getResourceAsStream(final ClassLoader cl,
-                                           final String name)
-    {
-        return (InputStream)
-            AccessController.doPrivileged(new PrivilegedAction() {
-                public Object run() {
-                    InputStream ris;
-                    if (cl == null) {
-                        ris = Object.class.getResourceAsStream(name);
-                    } else {
-                        ris = cl.getResourceAsStream(name);
-                    }
-                    return ris;
-                }
-            });
     }
 
     boolean doesFileExist(final File f) {

--- a/jaxp/src/javax/xml/transform/SecuritySupport.java
+++ b/jaxp/src/javax/xml/transform/SecuritySupport.java
@@ -26,9 +26,7 @@
 package javax.xml.transform;
 
 import java.security.*;
-import java.net.*;
 import java.io.*;
-import java.util.*;
 
 /**
  * This class is duplicated for each JAXP subpackage so keep it in sync.
@@ -77,23 +75,6 @@ class SecuritySupport  {
         } catch (PrivilegedActionException e) {
             throw (FileNotFoundException)e.getException();
         }
-    }
-
-    InputStream getResourceAsStream(final ClassLoader cl,
-                                           final String name)
-    {
-        return (InputStream)
-            AccessController.doPrivileged(new PrivilegedAction() {
-                public Object run() {
-                    InputStream ris;
-                    if (cl == null) {
-                        ris = Object.class.getResourceAsStream(name);
-                    } else {
-                        ris = cl.getResourceAsStream(name);
-                    }
-                    return ris;
-                }
-            });
     }
 
     boolean doesFileExist(final File f) {

--- a/jaxp/src/javax/xml/validation/SecuritySupport.java
+++ b/jaxp/src/javax/xml/validation/SecuritySupport.java
@@ -28,7 +28,6 @@ package javax.xml.validation;
 import java.io.IOException;
 import java.net.URL;
 import java.security.*;
-import java.net.*;
 import java.io.*;
 import java.util.*;
 
@@ -132,23 +131,6 @@ class SecuritySupport  {
         }catch(PrivilegedActionException e){
             throw (IOException)e.getException();
         }
-    }
-
-    InputStream getResourceAsStream(final ClassLoader cl,
-                                           final String name)
-    {
-        return (InputStream)
-            AccessController.doPrivileged(new PrivilegedAction() {
-                public Object run() {
-                    InputStream ris;
-                    if (cl == null) {
-                        ris = Object.class.getResourceAsStream(name);
-                    } else {
-                        ris = cl.getResourceAsStream(name);
-                    }
-                    return ris;
-                }
-            });
     }
 
     boolean doesFileExist(final File f) {

--- a/jaxp/src/javax/xml/xpath/SecuritySupport.java
+++ b/jaxp/src/javax/xml/xpath/SecuritySupport.java
@@ -27,7 +27,6 @@ package javax.xml.xpath;
 
 import java.net.URL;
 import java.security.*;
-import java.net.*;
 import java.io.*;
 import java.util.*;
 
@@ -129,23 +128,6 @@ class SecuritySupport  {
         }catch(PrivilegedActionException e){
             throw (IOException)e.getException();
         }
-    }
-
-    InputStream getResourceAsStream(final ClassLoader cl,
-                                           final String name)
-    {
-        return (InputStream)
-            AccessController.doPrivileged(new PrivilegedAction() {
-                public Object run() {
-                    InputStream ris;
-                    if (cl == null) {
-                        ris = Object.class.getResourceAsStream(name);
-                    } else {
-                        ris = cl.getResourceAsStream(name);
-                    }
-                    return ris;
-                }
-            });
     }
 
     boolean doesFileExist(final File f) {

--- a/jaxp/src/org/xml/sax/helpers/SecuritySupport.java
+++ b/jaxp/src/org/xml/sax/helpers/SecuritySupport.java
@@ -87,7 +87,7 @@ class SecuritySupport  {
                 public Object run() {
                     InputStream ris;
                     if (cl == null) {
-                        ris = Object.class.getResourceAsStream(name);
+                        ris = SecuritySupport.class.getResourceAsStream(name);
                     } else {
                         ris = cl.getResourceAsStream(name);
                     }


### PR DESCRIPTION
Please review a backport of a JAXP cleanup.

Original commit [17b47acf5b3d](https://hg.openjdk.java.net/jdk9/jdk9/jaxp/rev/17b47acf5b3d) in jdk9.

Commit [4ebbfc9](https://github.com/openjdk/jdk11u-dev/commit/4ebbfc918f558e73c05f471cfd3ab2b11dcf5a75) in jdk11u-dev.

This cleanup should allow to backport other JAXP changes (like [JDK-8163121](https://bugs.openjdk.java.net/browse/JDK-8163121)) easier.

All code changes apply cleanly (with reshuffled paths) except [LSSerializerTest.java](https://github.com/openjdk/jdk11u-dev/blob/4ebbfc918f558e73c05f471cfd3ab2b11dcf5a75/jaxp/test/javax/xml/jaxp/unittest/org/w3c/dom/ls/LSSerializerTest.java) that was excluded. LSSerializerTest.java is not present in 8u, it was added with JDK-8043084 (not public, jdk9 commit [29ba77ad2a87](https://hg.openjdk.java.net/jdk9/jdk9/jaxp/rev/29ba77ad2a87)).

Testing:

 - [x] jtreg:javax/xml/jaxp
 - [x] jck:api/javax_xml

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8129572](https://bugs.openjdk.java.net/browse/JDK-8129572): Cleanup usage of getResourceAsStream in jaxp


### Reviewers
 * [Andrew John Hughes](https://openjdk.java.net/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk8u-dev pull/4/head:pull/4` \
`$ git checkout pull/4`

Update a local copy of the PR: \
`$ git checkout pull/4` \
`$ git pull https://git.openjdk.java.net/jdk8u-dev pull/4/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4`

View PR using the GUI difftool: \
`$ git pr show -t 4`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk8u-dev/pull/4.diff">https://git.openjdk.java.net/jdk8u-dev/pull/4.diff</a>

</details>
