### PR TITLE
8279669: test/jdk/com/sun/jdi/TestScaffold.java uses wrong condition

### DIFF
--- a/jdk/test/com/sun/jdi/TestScaffold.java
+++ b/jdk/test/com/sun/jdi/TestScaffold.java
@@ -532,9 +532,10 @@ abstract public class TestScaffold extends TargetAdapter {
                         Location loc = ((Locatable)event).location();
                         ReferenceType rt = loc.declaringType();
                         String name = rt.name();
-                        if (name.startsWith("java.") &&
-                                       !name.startsWith("sun.") &&
-                                       !name.startsWith("com.")) {
+                        if (name.startsWith("java.")
+                            || name.startsWith("sun.")
+                            || name.startsWith("com.")
+                            || name.startsWith("jdk.")) {
                             if (mainStartClass != null) {
                                 redefine(mainStartClass);
                             }


### PR DESCRIPTION
please review this backport.
It fixes: test/com/sun/jdi/RedefineCrossEvent.java test.
I manually ran all tests in test/com/sun/jdi and they passed for me with this patch applied (when originally created).

This is PR for backport posted to jdk8u-dev just before move to github:
https://mail.openjdk.java.net/pipermail/jdk8u-dev/2022-February/014578.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279669](https://bugs.openjdk.java.net/browse/JDK-8279669): test/jdk/com/sun/jdi/TestScaffold.java uses wrong condition


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)
 * [Severin Gehwolf](https://openjdk.java.net/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk8u-dev pull/6/head:pull/6` \
`$ git checkout pull/6`

Update a local copy of the PR: \
`$ git checkout pull/6` \
`$ git pull https://git.openjdk.java.net/jdk8u-dev pull/6/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6`

View PR using the GUI difftool: \
`$ git pr show -t 6`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk8u-dev/pull/6.diff">https://git.openjdk.java.net/jdk8u-dev/pull/6.diff</a>

</details>
