### PR TITLE
Backport 38fdd0804030744b2804c35c97f843319a961799

### DIFF
--- a/jaxp/src/com/sun/org/apache/xalan/internal/xsltc/runtime/AbstractTranslet.java
+++ b/jaxp/src/com/sun/org/apache/xalan/internal/xsltc/runtime/AbstractTranslet.java
@@ -36,6 +36,7 @@ import com.sun.org.apache.xalan.internal.xsltc.runtime.output.TransletOutputHand
 import com.sun.org.apache.xml.internal.dtm.DTM;
 import com.sun.org.apache.xml.internal.dtm.DTMAxisIterator;
 import com.sun.org.apache.xml.internal.serializer.SerializationHandler;
+import com.sun.org.apache.xml.internal.serializer.ToStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -44,7 +45,6 @@ import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Vector;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.Templates;
@@ -75,7 +75,7 @@ public abstract class AbstractTranslet implements Translet {
     public String  _doctypeSystem = null;
     public boolean _indent = false;
     public String  _mediaType = null;
-    public Vector _cdata = null;
+    public ArrayList<String> _cdata = null;
     public int _indentamount = -1;
 
     public static final int FIRST_TRANSLET_VERSION = 100;
@@ -649,7 +649,7 @@ public abstract class AbstractTranslet implements Translet {
      */
     public void addCdataElement(String name) {
         if (_cdata == null) {
-            _cdata = new Vector();
+            _cdata = new ArrayList<>();
         }
 
         int lastColon = name.lastIndexOf(':');
@@ -657,11 +657,11 @@ public abstract class AbstractTranslet implements Translet {
         if (lastColon > 0) {
             String uri = name.substring(0, lastColon);
             String localName = name.substring(lastColon+1);
-            _cdata.addElement(uri);
-            _cdata.addElement(localName);
+            _cdata.add(uri);
+            _cdata.add(localName);
         } else {
-            _cdata.addElement(null);
-            _cdata.addElement(name);
+            _cdata.add(null);
+            _cdata.add(name);
         }
     }
 

--- a/jaxp/src/com/sun/org/apache/xalan/internal/xsltc/trax/TransformerImpl.java
+++ b/jaxp/src/com/sun/org/apache/xalan/internal/xsltc/trax/TransformerImpl.java
@@ -53,12 +53,12 @@ import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.UnknownServiceException;
+import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.StringTokenizer;
-import java.util.Vector;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -1046,7 +1046,7 @@ public final class TransformerImpl extends Transformer
             else if (name.equals(OutputKeys.CDATA_SECTION_ELEMENTS)) {
                 if (value != null) {
                     StringTokenizer e = new StringTokenizer(value);
-                    Vector uriAndLocalNames = null;
+                    ArrayList<String> uriAndLocalNames = null;
                     while (e.hasMoreTokens()) {
                         final String token = e.nextToken();
 
@@ -1066,11 +1066,11 @@ public final class TransformerImpl extends Transformer
                         }
 
                         if (uriAndLocalNames == null) {
-                            uriAndLocalNames = new Vector();
+                            uriAndLocalNames = new ArrayList<>();
                         }
                         // add the uri/localName as a pair, in that order
-                        uriAndLocalNames.addElement(uri);
-                        uriAndLocalNames.addElement(localName);
+                        uriAndLocalNames.add(uri);
+                        uriAndLocalNames.add(localName);
                     }
                     handler.setCdataSectionElements(uriAndLocalNames);
                 }

--- a/jaxp/src/com/sun/org/apache/xerces/internal/xpointer/ElementSchemePointer.java
+++ b/jaxp/src/com/sun/org/apache/xerces/internal/xpointer/ElementSchemePointer.java
@@ -557,11 +557,13 @@ final class ElementSchemePointer implements XPointerPart {
          * @param token The token string
          */
         private void addToken(String tokenStr) {
-            if (!fTokenNames.containsValue(tokenStr)) {
-                Integer tokenInt = new Integer(fTokenNames.size());
+            String str = fTokenNames.get(tokenStr);
+            Integer tokenInt = str == null ? null : Integer.parseInt(str);
+            if (tokenInt == null) {
+                tokenInt = new Integer(fTokenNames.size());
                 fTokenNames.put(tokenInt, tokenStr);
-                addToken(tokenInt.intValue());
             }
+            addToken(tokenInt.intValue());
         }
 
         /**

--- a/jaxp/src/com/sun/org/apache/xerces/internal/xpointer/XPointerHandler.java
+++ b/jaxp/src/com/sun/org/apache/xerces/internal/xpointer/XPointerHandler.java
@@ -524,11 +524,13 @@ public final class XPointerHandler extends XIncludeHandler implements
          * @param token The token string
          */
         private void addToken(String tokenStr) {
-            if (!fTokenNames.containsValue(tokenStr)) {
-                Integer tokenInt = new Integer(fTokenNames.size());
+            String str = fTokenNames.get(tokenStr);
+            Integer tokenInt = str == null ? null : Integer.parseInt(str);
+            if (tokenInt == null) {
+                tokenInt = new Integer(fTokenNames.size());
                 fTokenNames.put(tokenInt, tokenStr);
-                addToken(tokenInt.intValue());
             }
+            addToken(tokenInt.intValue());
         }
 
         /**

--- a/jaxp/src/com/sun/org/apache/xml/internal/serializer/EmptySerializer.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serializer/EmptySerializer.java
@@ -25,8 +25,8 @@ package com.sun.org.apache.xml.internal.serializer;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Writer;
+import java.util.ArrayList;
 import java.util.Properties;
-import java.util.Vector;
 import javax.xml.transform.SourceLocator;
 import javax.xml.transform.Transformer;
 import org.w3c.dom.Node;
@@ -143,9 +143,9 @@ public class EmptySerializer implements SerializationHandler
         couldThrowIOException();
     }
     /**
-     * @see SerializationHandler#setCdataSectionElements(java.util.Vector)
+     * @see SerializationHandler#setCdataSectionElements(java.util.ArrayList<String>)
      */
-    public void setCdataSectionElements(Vector URI_and_localNames)
+    public void setCdataSectionElements(ArrayList<String> URI_and_localNames)
     {
         aMethodIsCalled();
     }
@@ -746,6 +746,27 @@ public class EmptySerializer implements SerializationHandler
      * @see SerializationHandler#setDTDEntityExpansion(boolean)
      */
     public void setDTDEntityExpansion(boolean expand) {
+        aMethodIsCalled();
+
+    }
+
+
+    public String getOutputProperty(String name) {
+        aMethodIsCalled();
+        return null;
+    }
+
+    public String getOutputPropertyDefault(String name) {
+        aMethodIsCalled();
+        return null;
+    }
+
+    public void setOutputProperty(String name, String val) {
+        aMethodIsCalled();
+
+    }
+
+    public void setOutputPropertyDefault(String name, String val) {
         aMethodIsCalled();
 
     }

--- a/jaxp/src/com/sun/org/apache/xml/internal/serializer/ToHTMLStream.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serializer/ToHTMLStream.java
@@ -2,9 +2,11 @@
  * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
  */
 /*
- * Copyright 2001-2004 The Apache Software Foundation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the  "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -349,84 +351,84 @@ public final class ToHTMLStream extends ToStream
 
 
         // ----------------------------------------------
-        elemDesc = (ElemDesc) m_elementFlags.get("A");
+        elemDesc = (ElemDesc) m_elementFlags.get("a");
         elemDesc.setAttr("HREF", ElemDesc.ATTRURL);
         elemDesc.setAttr("NAME", ElemDesc.ATTRURL);
 
         // ----------------------------------------------
-        elemDesc = (ElemDesc) m_elementFlags.get("AREA");
+        elemDesc = (ElemDesc) m_elementFlags.get("area");
         elemDesc.setAttr("HREF", ElemDesc.ATTRURL);
         elemDesc.setAttr("NOHREF", ElemDesc.ATTREMPTY);
 
         // ----------------------------------------------
-        elemDesc = (ElemDesc) m_elementFlags.get("BASE");
+        elemDesc = (ElemDesc) m_elementFlags.get("base");
         elemDesc.setAttr("HREF", ElemDesc.ATTRURL);
 
         // ----------------------------------------------
-        elemDesc = (ElemDesc) m_elementFlags.get("BUTTON");
+        elemDesc = (ElemDesc) m_elementFlags.get("button");
         elemDesc.setAttr("DISABLED", ElemDesc.ATTREMPTY);
 
         // ----------------------------------------------
-        elemDesc = (ElemDesc) m_elementFlags.get("BLOCKQUOTE");
+        elemDesc = (ElemDesc) m_elementFlags.get("blockquote");
         elemDesc.setAttr("CITE", ElemDesc.ATTRURL);
 
         // ----------------------------------------------
-        elemDesc = (ElemDesc) m_elementFlags.get("DEL");
+        elemDesc = (ElemDesc) m_elementFlags.get("del");
         elemDesc.setAttr("CITE", ElemDesc.ATTRURL);
 
         // ----------------------------------------------
-        elemDesc = (ElemDesc) m_elementFlags.get("DIR");
+        elemDesc = (ElemDesc) m_elementFlags.get("dir");
         elemDesc.setAttr("COMPACT", ElemDesc.ATTREMPTY);
 
         // ----------------------------------------------
 
-        elemDesc = (ElemDesc) m_elementFlags.get("DIV");
+        elemDesc = (ElemDesc) m_elementFlags.get("div");
         elemDesc.setAttr("SRC", ElemDesc.ATTRURL); // Netscape 4 extension
         elemDesc.setAttr("NOWRAP", ElemDesc.ATTREMPTY); // Internet-Explorer extension
 
         // ----------------------------------------------
-        elemDesc = (ElemDesc) m_elementFlags.get("DL");
+        elemDesc = (ElemDesc) m_elementFlags.get("dl");
         elemDesc.setAttr("COMPACT", ElemDesc.ATTREMPTY);
 
         // ----------------------------------------------
-        elemDesc = (ElemDesc) m_elementFlags.get("FORM");
+        elemDesc = (ElemDesc) m_elementFlags.get("form");
         elemDesc.setAttr("ACTION", ElemDesc.ATTRURL);
 
         // ----------------------------------------------
         // Attribution to: "Voytenko, Dimitry" <DVoytenko@SECTORBASE.COM>
-        elemDesc = (ElemDesc) m_elementFlags.get("FRAME");
+        elemDesc = (ElemDesc) m_elementFlags.get("frame");
         elemDesc.setAttr("SRC", ElemDesc.ATTRURL);
         elemDesc.setAttr("LONGDESC", ElemDesc.ATTRURL);
         elemDesc.setAttr("NORESIZE",ElemDesc.ATTREMPTY);
 
         // ----------------------------------------------
-        elemDesc = (ElemDesc) m_elementFlags.get("HEAD");
+        elemDesc = (ElemDesc) m_elementFlags.get("head");
         elemDesc.setAttr("PROFILE", ElemDesc.ATTRURL);
 
         // ----------------------------------------------
-        elemDesc = (ElemDesc) m_elementFlags.get("HR");
+        elemDesc = (ElemDesc) m_elementFlags.get("hr");
         elemDesc.setAttr("NOSHADE", ElemDesc.ATTREMPTY);
 
         // ----------------------------------------------
         // HTML 4.0, section 16.5
-        elemDesc = (ElemDesc) m_elementFlags.get("IFRAME");
+        elemDesc = (ElemDesc) m_elementFlags.get("iframe");
         elemDesc.setAttr("SRC", ElemDesc.ATTRURL);
         elemDesc.setAttr("LONGDESC", ElemDesc.ATTRURL);
 
         // ----------------------------------------------
         // Netscape 4 extension
-        elemDesc = (ElemDesc) m_elementFlags.get("ILAYER");
+        elemDesc = (ElemDesc) m_elementFlags.get("ilayer");
         elemDesc.setAttr("SRC", ElemDesc.ATTRURL);
 
         // ----------------------------------------------
-        elemDesc = (ElemDesc) m_elementFlags.get("IMG");
+        elemDesc = (ElemDesc) m_elementFlags.get("img");
         elemDesc.setAttr("SRC", ElemDesc.ATTRURL);
         elemDesc.setAttr("LONGDESC", ElemDesc.ATTRURL);
         elemDesc.setAttr("USEMAP", ElemDesc.ATTRURL);
         elemDesc.setAttr("ISMAP", ElemDesc.ATTREMPTY);
 
         // ----------------------------------------------
-        elemDesc = (ElemDesc) m_elementFlags.get("INPUT");
+        elemDesc = (ElemDesc) m_elementFlags.get("input");
         elemDesc.setAttr("SRC", ElemDesc.ATTRURL);
         elemDesc.setAttr("USEMAP", ElemDesc.ATTRURL);
         elemDesc.setAttr("CHECKED", ElemDesc.ATTREMPTY);
@@ -435,24 +437,24 @@ public final class ToHTMLStream extends ToStream
         elemDesc.setAttr("READONLY", ElemDesc.ATTREMPTY);
 
         // ----------------------------------------------
-        elemDesc = (ElemDesc) m_elementFlags.get("INS");
+        elemDesc = (ElemDesc) m_elementFlags.get("ins");
         elemDesc.setAttr("CITE", ElemDesc.ATTRURL);
 
         // ----------------------------------------------
         // Netscape 4 extension
-        elemDesc = (ElemDesc) m_elementFlags.get("LAYER");
+        elemDesc = (ElemDesc) m_elementFlags.get("layer");
         elemDesc.setAttr("SRC", ElemDesc.ATTRURL);
 
         // ----------------------------------------------
-        elemDesc = (ElemDesc) m_elementFlags.get("LINK");
+        elemDesc = (ElemDesc) m_elementFlags.get("link");
         elemDesc.setAttr("HREF", ElemDesc.ATTRURL);
 
         // ----------------------------------------------
-        elemDesc = (ElemDesc) m_elementFlags.get("MENU");
+        elemDesc = (ElemDesc) m_elementFlags.get("menu");
         elemDesc.setAttr("COMPACT", ElemDesc.ATTREMPTY);
 
         // ----------------------------------------------
-        elemDesc = (ElemDesc) m_elementFlags.get("OBJECT");
+        elemDesc = (ElemDesc) m_elementFlags.get("object");
         elemDesc.setAttr("CLASSID", ElemDesc.ATTRURL);
         elemDesc.setAttr("CODEBASE", ElemDesc.ATTRURL);
         elemDesc.setAttr("DATA", ElemDesc.ATTRURL);
@@ -461,58 +463,58 @@ public final class ToHTMLStream extends ToStream
         elemDesc.setAttr("DECLARE", ElemDesc.ATTREMPTY);
 
         // ----------------------------------------------
-        elemDesc = (ElemDesc) m_elementFlags.get("OL");
+        elemDesc = (ElemDesc) m_elementFlags.get("ol");
         elemDesc.setAttr("COMPACT", ElemDesc.ATTREMPTY);
 
         // ----------------------------------------------
-        elemDesc = (ElemDesc) m_elementFlags.get("OPTGROUP");
+        elemDesc = (ElemDesc) m_elementFlags.get("optgroup");
         elemDesc.setAttr("DISABLED", ElemDesc.ATTREMPTY);
 
         // ----------------------------------------------
-        elemDesc = (ElemDesc) m_elementFlags.get("OPTION");
+        elemDesc = (ElemDesc) m_elementFlags.get("option");
         elemDesc.setAttr("SELECTED", ElemDesc.ATTREMPTY);
         elemDesc.setAttr("DISABLED", ElemDesc.ATTREMPTY);
 
         // ----------------------------------------------
-        elemDesc = (ElemDesc) m_elementFlags.get("Q");
+        elemDesc = (ElemDesc) m_elementFlags.get("q");
         elemDesc.setAttr("CITE", ElemDesc.ATTRURL);
 
         // ----------------------------------------------
-        elemDesc = (ElemDesc) m_elementFlags.get("SCRIPT");
+        elemDesc = (ElemDesc) m_elementFlags.get("script");
         elemDesc.setAttr("SRC", ElemDesc.ATTRURL);
         elemDesc.setAttr("FOR", ElemDesc.ATTRURL);
         elemDesc.setAttr("DEFER", ElemDesc.ATTREMPTY);
 
         // ----------------------------------------------
-        elemDesc = (ElemDesc) m_elementFlags.get("SELECT");
+        elemDesc = (ElemDesc) m_elementFlags.get("select");
         elemDesc.setAttr("DISABLED", ElemDesc.ATTREMPTY);
         elemDesc.setAttr("MULTIPLE", ElemDesc.ATTREMPTY);
 
         // ----------------------------------------------
-        elemDesc = (ElemDesc) m_elementFlags.get("TABLE");
+        elemDesc = (ElemDesc) m_elementFlags.get("table");
         elemDesc.setAttr("NOWRAP", ElemDesc.ATTREMPTY); // Internet-Explorer extension
 
         // ----------------------------------------------
-        elemDesc = (ElemDesc) m_elementFlags.get("TD");
+        elemDesc = (ElemDesc) m_elementFlags.get("td");
         elemDesc.setAttr("NOWRAP", ElemDesc.ATTREMPTY);
 
         // ----------------------------------------------
-        elemDesc = (ElemDesc) m_elementFlags.get("TEXTAREA");
+        elemDesc = (ElemDesc) m_elementFlags.get("textarea");
         elemDesc.setAttr("DISABLED", ElemDesc.ATTREMPTY);
         elemDesc.setAttr("READONLY", ElemDesc.ATTREMPTY);
 
         // ----------------------------------------------
-        elemDesc = (ElemDesc) m_elementFlags.get("TH");
+        elemDesc = (ElemDesc) m_elementFlags.get("th");
         elemDesc.setAttr("NOWRAP", ElemDesc.ATTREMPTY);
 
         // ----------------------------------------------
         // The nowrap attribute of a tr element is both
         // a Netscape and Internet-Explorer extension
-        elemDesc = (ElemDesc) m_elementFlags.get("TR");
+        elemDesc = (ElemDesc) m_elementFlags.get("tr");
         elemDesc.setAttr("NOWRAP", ElemDesc.ATTREMPTY);
 
         // ----------------------------------------------
-        elemDesc = (ElemDesc) m_elementFlags.get("UL");
+        elemDesc = (ElemDesc) m_elementFlags.get("ul");
         elemDesc.setAttr("COMPACT", ElemDesc.ATTREMPTY);
     }
 
@@ -1765,7 +1767,7 @@ public final class ToHTMLStream extends ToStream
              * lets determine if the current element is specified in the cdata-
              * section-elements list.
              */
-            if (m_cdataSectionElements != null)
+            if (m_StringOfCDATASections != null)
                 m_elemContext.m_isCdataSection = isCdataSection();
             if (m_doIndent)
             {
@@ -1779,54 +1781,7 @@ public final class ToHTMLStream extends ToStream
                 throw new SAXException(e);
             }
     }
-    /**
-     * Initialize the serializer with the specified output stream and output
-     * format. Must be called before calling any of the serialize methods.
-     *
-     * @param output The output stream to use
-     * @param format The output format
-     * @throws UnsupportedEncodingException The encoding specified   in the
-     * output format is not supported
-     */
-    protected synchronized void init(OutputStream output, Properties format)
-        throws UnsupportedEncodingException
-    {
-        if (null == format)
-        {
-            format = OutputPropertiesFactory.getDefaultMethodProperties(Method.HTML);
-         }
-        super.init(output,format, false);
-    }
 
-        /**
-         * Specifies an output stream to which the document should be
-         * serialized. This method should not be called while the
-         * serializer is in the process of serializing a document.
-         * <p>
-         * The encoding specified in the output properties is used, or
-         * if no encoding was specified, the default for the selected
-         * output method.
-         *
-         * @param output The output stream
-         */
-        public void setOutputStream(OutputStream output)
-        {
-
-            try
-            {
-                Properties format;
-                if (null == m_format)
-                    format = OutputPropertiesFactory.getDefaultMethodProperties(Method.HTML);
-                else
-                    format = m_format;
-                init(output, format, true);
-            }
-            catch (UnsupportedEncodingException uee)
-            {
-
-                // Should have been warned in init, I guess...
-            }
-        }
         /**
          * This method is used when a prefix/uri namespace mapping
          * is indicated after the element was started with a

--- a/jaxp/src/com/sun/org/apache/xml/internal/serializer/ToSAXHandler.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serializer/ToSAXHandler.java
@@ -22,7 +22,7 @@
  */
 package com.sun.org.apache.xml.internal.serializer;
 
-import java.util.Vector;
+import java.util.ArrayList;
 
 import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
@@ -234,9 +234,9 @@ public abstract class ToSAXHandler extends SerializerBase
     /**
      * Does nothing. The setting of CDATA section elements has an impact on
      * stream serializers.
-     * @see SerializationHandler#setCdataSectionElements(java.util.Vector)
+     * @see SerializationHandler#setCdataSectionElements(java.util.ArrayList<String>)
      */
-    public void setCdataSectionElements(Vector URI_and_localNames)
+    public void setCdataSectionElements(ArrayList<String> URI_and_localNames)
     {
         // do nothing
     }

--- a/jaxp/src/com/sun/org/apache/xml/internal/serializer/ToStream.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serializer/ToStream.java
@@ -2,9 +2,11 @@
  * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
  */
 /*
- * Copyright 2001-2004 The Apache Software Foundation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the  "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -24,11 +26,15 @@ package com.sun.org.apache.xml.internal.serializer;
 import com.sun.org.apache.xalan.internal.utils.SecuritySupport;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
 import java.io.Writer;
+import java.util.Enumeration;
+import java.util.Iterator;
 import java.util.Properties;
+import java.util.Set;
 import java.util.StringTokenizer;
-import java.util.Vector;
+import java.util.ArrayList;
 
 import javax.xml.transform.ErrorListener;
 import javax.xml.transform.OutputKeys;
@@ -187,9 +193,6 @@ abstract public class ToStream extends SerializerBase
        */
     boolean m_isUTF8 = false;
 
-    /** The xsl:output properties. */
-    protected Properties m_format;
-
     /**
      * remembers if we are in between the startCDATA() and endCDATA() callbacks
      */
@@ -308,6 +311,7 @@ abstract public class ToStream extends SerializerBase
         }
     }
 
+    OutputStream m_outputStream;
     /**
      * Get the output stream where the events will be serialized to.
      *
@@ -316,13 +320,7 @@ abstract public class ToStream extends SerializerBase
      */
     public OutputStream getOutputStream()
     {
-
-        if (m_writer instanceof WriterToUTF8Buffered)
-            return ((WriterToUTF8Buffered) m_writer).getOutputStream();
-        if (m_writer instanceof WriterToASCI)
-            return ((WriterToASCI) m_writer).getOutputStream();
-        else
-            return null;
+        return m_outputStream;
     }
 
     // Implement DeclHandler
@@ -421,8 +419,172 @@ abstract public class ToStream extends SerializerBase
      */
     protected final void outputLineSep() throws IOException
     {
-
         m_writer.write(m_lineSep, 0, m_lineSepLen);
+    }
+
+    void setProp(String name, String val, boolean defaultVal) {
+        if (val != null) {
+
+            char first = getFirstCharLocName(name);
+            switch (first) {
+            case 'c':
+                if (OutputKeys.CDATA_SECTION_ELEMENTS.equals(name)) {
+                    addCdataSectionElements(val); // val is cdataSectionNames
+                }
+                break;
+            case 'd':
+                if (OutputKeys.DOCTYPE_SYSTEM.equals(name)) {
+                    this.m_doctypeSystem = val;
+                } else if (OutputKeys.DOCTYPE_PUBLIC.equals(name)) {
+                    this.m_doctypePublic = val;
+                    if (val.startsWith("-//W3C//DTD XHTML"))
+                        m_spaceBeforeClose = true;
+                }
+                break;
+            case 'e':
+                String newEncoding = val;
+                if (OutputKeys.ENCODING.equals(name)) {
+                    String possible_encoding = Encodings.getMimeEncoding(val);
+                    if (possible_encoding != null) {
+                        // if the encoding is being set, try to get the
+                        // preferred
+                        // mime-name and set it too.
+                        super.setProp("mime-name", possible_encoding,
+                                defaultVal);
+                    }
+                    final String oldExplicitEncoding = getOutputPropertyNonDefault(OutputKeys.ENCODING);
+                    final String oldDefaultEncoding  = getOutputPropertyDefault(OutputKeys.ENCODING);
+                    if ( (defaultVal && ( oldDefaultEncoding == null || !oldDefaultEncoding.equalsIgnoreCase(newEncoding)))
+                            || ( !defaultVal && (oldExplicitEncoding == null || !oldExplicitEncoding.equalsIgnoreCase(newEncoding) ))) {
+                       // We are trying to change the default or the non-default setting of the encoding to a different value
+                       // from what it was
+
+                       EncodingInfo encodingInfo = Encodings.getEncodingInfo(newEncoding);
+                       if (newEncoding != null && encodingInfo.name == null) {
+                        // We tried to get an EncodingInfo for Object for the given
+                        // encoding, but it came back with an internall null name
+                        // so the encoding is not supported by the JDK, issue a message.
+                        final String msg = Utils.messages.createMessage(
+                                MsgKey.ER_ENCODING_NOT_SUPPORTED,new Object[]{ newEncoding });
+
+                        final String msg2 =
+                            "Warning: encoding \"" + newEncoding + "\" not supported, using "
+                                   + Encodings.DEFAULT_MIME_ENCODING;
+                        try {
+                                // Prepare to issue the warning message
+                                final Transformer tran = super.getTransformer();
+                                if (tran != null) {
+                                    final ErrorListener errHandler = tran
+                                            .getErrorListener();
+                                    // Issue the warning message
+                                    if (null != errHandler
+                                            && m_sourceLocator != null) {
+                                        errHandler
+                                                .warning(new TransformerException(
+                                                        msg, m_sourceLocator));
+                                        errHandler
+                                                .warning(new TransformerException(
+                                                        msg2, m_sourceLocator));
+                                    } else {
+                                        System.out.println(msg);
+                                        System.out.println(msg2);
+                                    }
+                                } else {
+                                    System.out.println(msg);
+                                    System.out.println(msg2);
+                                }
+                            } catch (Exception e) {
+                            }
+
+                            // We said we are using UTF-8, so use it
+                            newEncoding = Encodings.DEFAULT_MIME_ENCODING;
+                            val = Encodings.DEFAULT_MIME_ENCODING; // to store the modified value into the properties a little later
+                            encodingInfo = Encodings.getEncodingInfo(newEncoding);
+                        }
+                       // The encoding was good, or was forced to UTF-8 above
+
+
+                       // If there is already a non-default set encoding and we
+                       // are trying to set the default encoding, skip the this block
+                       // as the non-default value is already the one to use.
+                       if (defaultVal == false || oldExplicitEncoding == null) {
+                           m_encodingInfo = encodingInfo;
+                           if (newEncoding != null)
+                               m_isUTF8 = newEncoding.equals(Encodings.DEFAULT_MIME_ENCODING);
+
+                           // if there was a previously set OutputStream
+                           OutputStream os = getOutputStream();
+                           if (os != null) {
+                               Writer w = getWriter();
+
+                               // If the writer was previously set, but
+                               // set by the user, or if the new encoding is the same
+                               // as the old encoding, skip this block
+                               String oldEncoding = getOutputProperty(OutputKeys.ENCODING);
+                               if ((w == null || !m_writer_set_by_user)
+                                       && !newEncoding.equalsIgnoreCase(oldEncoding)) {
+                                   // Make the change of encoding in our internal
+                                   // table, then call setOutputStreamInternal
+                                   // which will stomp on the old Writer (if any)
+                                   // with a new Writer with the new encoding.
+                                   super.setProp(name, val, defaultVal);
+                                   setOutputStreamInternal(os,false);
+                               }
+                           }
+                       }
+                    }
+                }
+                break;
+            case 'i':
+                if (OutputPropertiesFactory.S_KEY_INDENT_AMOUNT.equals(name)) {
+                    setIndentAmount(Integer.parseInt(val));
+                } else if (OutputKeys.INDENT.equals(name)) {
+                    boolean b = "yes".equals(val) ? true : false;
+                    m_doIndent = b;
+                }
+
+                break;
+            case 'l':
+                if (OutputPropertiesFactory.S_KEY_LINE_SEPARATOR.equals(name)) {
+                    m_lineSep = val.toCharArray();
+                    m_lineSepLen = m_lineSep.length;
+                }
+
+                break;
+            case 'm':
+                if (OutputKeys.MEDIA_TYPE.equals(name)) {
+                    m_mediatype = val;
+                }
+                break;
+            case 'o':
+                if (OutputKeys.OMIT_XML_DECLARATION.equals(name)) {
+                    boolean b = "yes".equals(val) ? true : false;
+                    this.m_shouldNotWriteXMLHeader = b;
+                }
+                break;
+            case 's':
+                // if standalone was explicitly specified
+                if (OutputKeys.STANDALONE.equals(name)) {
+                    if (defaultVal) {
+                        setStandaloneInternal(val);
+                    } else {
+                        m_standaloneWasSpecified = true;
+                        setStandaloneInternal(val);
+                    }
+                }
+
+                break;
+            case 'v':
+                if (OutputKeys.VERSION.equals(name)) {
+                    m_version = val;
+                }
+                break;
+            default:
+                break;
+
+            }
+            super.setProp(name, val, defaultVal);
+        }
     }
 
     /**
@@ -436,114 +598,33 @@ abstract public class ToStream extends SerializerBase
      */
     public void setOutputFormat(Properties format)
     {
-
         boolean shouldFlush = m_shouldFlush;
 
-        init(m_writer, format, false, false);
-
-        m_shouldFlush = shouldFlush;
-    }
-
-    /**
-     * Initialize the serializer with the specified writer and output format.
-     * Must be called before calling any of the serialize methods.
-     * This method can be called multiple times and the xsl:output properties
-     * passed in the 'format' parameter are accumulated across calls.
-     *
-     * @param writer The writer to use
-     * @param format The output format
-     * @param shouldFlush True if the writer should be flushed at EndDocument.
-     */
-    private synchronized void init(
-        Writer writer,
-        Properties format,
-        boolean defaultProperties,
-        boolean shouldFlush)
-    {
-
-        m_shouldFlush = shouldFlush;
-
-
-        // if we are tracing events we need to trace what
-        // characters are written to the output writer.
-        if (m_tracer != null
-         && !(writer instanceof SerializerTraceWriter)  )
-            m_writer = new SerializerTraceWriter(writer, m_tracer);
-        else
-            m_writer = writer;
-
-
-        m_format = format;
-        //        m_cdataSectionNames =
-        //            OutputProperties.getQNameProperties(
-        //                OutputKeys.CDATA_SECTION_ELEMENTS,
-        //                format);
-        setCdataSectionElements(OutputKeys.CDATA_SECTION_ELEMENTS, format);
-
-        setIndentAmount(
-            OutputPropertyUtils.getIntProperty(
-                OutputPropertiesFactory.S_KEY_INDENT_AMOUNT,
-                format));
-        setIndent(
-            OutputPropertyUtils.getBooleanProperty(OutputKeys.INDENT, format));
-
+        if (format != null)
         {
-            String sep =
-                    format.getProperty(OutputPropertiesFactory.S_KEY_LINE_SEPARATOR);
-            if (sep != null) {
-                m_lineSep = sep.toCharArray();
-                m_lineSepLen = sep.length();
+            // Set the default values first,
+            // and the non-default values after that,
+            // just in case there is some unexpected
+            // residual values left over from over-ridden default values
+            Enumeration propNames;
+            propNames = format.propertyNames();
+            while (propNames.hasMoreElements())
+            {
+                String key = (String) propNames.nextElement();
+                // Get the value, possibly a default value
+                String value = format.getProperty(key);
+                // Get the non-default value (if any).
+                String explicitValue = (String) format.get(key);
+                if (explicitValue == null && value != null) {
+                    // This is a default value
+                    this.setOutputPropertyDefault(key,value);
+                }
+                if (explicitValue != null) {
+                    // This is an explicit non-default value
+                    this.setOutputProperty(key,explicitValue);
+                }
             }
         }
-
-        boolean shouldNotWriteXMLHeader =
-            OutputPropertyUtils.getBooleanProperty(
-                OutputKeys.OMIT_XML_DECLARATION,
-                format);
-        setOmitXMLDeclaration(shouldNotWriteXMLHeader);
-        setDoctypeSystem(format.getProperty(OutputKeys.DOCTYPE_SYSTEM));
-        String doctypePublic = format.getProperty(OutputKeys.DOCTYPE_PUBLIC);
-        setDoctypePublic(doctypePublic);
-
-        // if standalone was explicitly specified
-        if (format.get(OutputKeys.STANDALONE) != null)
-        {
-            String val = format.getProperty(OutputKeys.STANDALONE);
-            if (defaultProperties)
-                setStandaloneInternal(val);
-            else
-                setStandalone(val);
-        }
-
-        setMediaType(format.getProperty(OutputKeys.MEDIA_TYPE));
-
-        if (null != doctypePublic)
-        {
-            if (doctypePublic.startsWith("-//W3C//DTD XHTML"))
-                m_spaceBeforeClose = true;
-        }
-
-        /*
-         * This code is added for XML 1.1 Version output.
-         */
-        String version = getVersion();
-        if (null == version)
-        {
-            version = format.getProperty(OutputKeys.VERSION);
-            setVersion(version);
-        }
-
-        // initCharsMap();
-        String encoding = getEncoding();
-        if (null == encoding)
-        {
-            encoding =
-                Encodings.getMimeEncoding(
-                    format.getProperty(OutputKeys.ENCODING));
-            setEncoding(encoding);
-        }
-
-        m_isUTF8 = encoding.equals(Encodings.DEFAULT_MIME_ENCODING);
 
         // Access this only from the Hashtable level... we don't want to
         // get default properties.
@@ -559,107 +640,10 @@ abstract public class ToStream extends SerializerBase
             m_charInfo = CharInfo.getCharInfo(entitiesFileName, method);
         }
 
-    }
-
-    /**
-     * Initialize the serializer with the specified writer and output format.
-     * Must be called before calling any of the serialize methods.
-     *
-     * @param writer The writer to use
-     * @param format The output format
-     */
-    private synchronized void init(Writer writer, Properties format)
-    {
-        init(writer, format, false, false);
-    }
-    /**
-     * Initialize the serializer with the specified output stream and output
-     * format. Must be called before calling any of the serialize methods.
-     *
-     * @param output The output stream to use
-     * @param format The output format
-     * @param defaultProperties true if the properties are the default
-     * properties
-     *
-     * @throws UnsupportedEncodingException The encoding specified   in the
-     * output format is not supported
-     */
-    protected synchronized void init(
-        OutputStream output,
-        Properties format,
-        boolean defaultProperties)
-        throws UnsupportedEncodingException
-    {
-
-        String encoding = getEncoding();
-        if (encoding == null)
-        {
-            // if not already set then get it from the properties
-            encoding =
-                Encodings.getMimeEncoding(
-                    format.getProperty(OutputKeys.ENCODING));
-            setEncoding(encoding);
-        }
-
-        if (encoding.equalsIgnoreCase("UTF-8"))
-        {
-            m_isUTF8 = true;
-            //            if (output instanceof java.io.BufferedOutputStream)
-            //            {
-            //                init(new WriterToUTF8(output), format, defaultProperties, true);
-            //            }
-            //            else if (output instanceof java.io.FileOutputStream)
-            //            {
-            //                init(new WriterToUTF8Buffered(output), format, defaultProperties, true);
-            //            }
-            //            else
-            //            {
-            //                // Not sure what to do in this case.  I'm going to be conservative
-            //                // and not buffer.
-            //                init(new WriterToUTF8(output), format, defaultProperties, true);
-            //            }
 
 
-                init(
-                    new WriterToUTF8Buffered(output),
-                    format,
-                    defaultProperties,
-                    true);
 
-
-        }
-        else if (
-            encoding.equals("WINDOWS-1250")
-                || encoding.equals("US-ASCII")
-                || encoding.equals("ASCII"))
-        {
-            init(new WriterToASCI(output), format, defaultProperties, true);
-        }
-        else
-        {
-            Writer osw;
-
-            try
-            {
-                osw = Encodings.getWriter(output, encoding);
-            }
-            catch (UnsupportedEncodingException uee)
-            {
-                System.out.println(
-                    "Warning: encoding \""
-                        + encoding
-                        + "\" not supported"
-                        + ", using "
-                        + Encodings.DEFAULT_MIME_ENCODING);
-
-                encoding = Encodings.DEFAULT_MIME_ENCODING;
-                setEncoding(encoding);
-                osw = Encodings.getWriter(output, encoding);
-            }
-
-            init(osw, format, defaultProperties, true);
-        }
-
+        m_shouldFlush = shouldFlush;
     }
 
     /**
@@ -667,9 +651,26 @@ abstract public class ToStream extends SerializerBase
      *
      * @return The output format in use
      */
-    public Properties getOutputFormat()
-    {
-        return m_format;
+    public Properties getOutputFormat() {
+        Properties def = new Properties();
+        {
+            Set<String> s = getOutputPropDefaultKeys();
+            for (String key : s) {
+                String val = getOutputPropertyDefault(key);
+                def.put(key, val);
+            }
+        }
+
+        Properties props = new Properties(def);
+        {
+            Set<String> s = getOutputPropKeys();
+            for (String key : s) {
+                String val = getOutputPropertyNonDefault(key);
+                if (val != null)
+                    props.put(key, val);
+            }
+        }
+        return props;
     }
 
     /**
@@ -681,13 +682,28 @@ abstract public class ToStream extends SerializerBase
      */
     public void setWriter(Writer writer)
     {
+        setWriterInternal(writer, true);
+    }
+
+    private boolean m_writer_set_by_user;
+    private void setWriterInternal(Writer writer, boolean setByUser) {
+        m_writer_set_by_user = setByUser;
+        m_writer = writer;
         // if we are tracing events we need to trace what
         // characters are written to the output writer.
-        if (m_tracer != null
-         && !(writer instanceof SerializerTraceWriter)  )
-            m_writer = new SerializerTraceWriter(writer, m_tracer);
-        else
-            m_writer = writer;
+        if (m_tracer != null) {
+            boolean noTracerYet = true;
+            Writer w2 = m_writer;
+            while (w2 instanceof WriterChain) {
+                if (w2 instanceof SerializerTraceWriter) {
+                    noTracerYet = false;
+                    break;
+                }
+                w2 = ((WriterChain)w2).getWriter();
+            }
+            if (noTracerYet)
+                m_writer = new SerializerTraceWriter(m_writer, m_tracer);
+        }
     }
 
     /**
@@ -722,24 +738,67 @@ abstract public class ToStream extends SerializerBase
      */
     public void setOutputStream(OutputStream output)
     {
+        setOutputStreamInternal(output, true);
+    }
 
-        try
+    private void setOutputStreamInternal(OutputStream output, boolean setByUser)
+    {
+        m_outputStream = output;
+        String encoding = getOutputProperty(OutputKeys.ENCODING);
+        if (Encodings.DEFAULT_MIME_ENCODING.equalsIgnoreCase(encoding))
         {
-            Properties format;
-            if (null == m_format)
-                format =
-                    OutputPropertiesFactory.getDefaultMethodProperties(
-                        Method.XML);
-            else
-                format = m_format;
-            init(output, format, true);
+            // We wrap the OutputStream with a writer, but
+            // not one set by the user
+            try {
+                setWriterInternal(new WriterToUTF8Buffered(output), false);
+            } catch (UnsupportedEncodingException e) {
+                e.printStackTrace();
+            }
+        } else if (
+                "WINDOWS-1250".equals(encoding)
+                || "US-ASCII".equals(encoding)
+                || "ASCII".equals(encoding))
+        {
+            setWriterInternal(new WriterToASCI(output), false);
+        } else if (encoding != null) {
+            Writer osw = null;
+                try
+                {
+                    osw = Encodings.getWriter(output, encoding);
+                }
+                catch (UnsupportedEncodingException uee)
+                {
+                    osw = null;
+                }
+
+
+            if (osw == null) {
+                System.out.println(
+                    "Warning: encoding \""
+                        + encoding
+                        + "\" not supported"
+                        + ", using "
+                        + Encodings.DEFAULT_MIME_ENCODING);
+
+                encoding = Encodings.DEFAULT_MIME_ENCODING;
+                setEncoding(encoding);
+                try {
+                    osw = Encodings.getWriter(output, encoding);
+                } catch (UnsupportedEncodingException e) {
+                    // We can't really get here, UTF-8 is always supported
+                    // This try-catch exists to make the compiler happy
+                    e.printStackTrace();
+                }
+            }
+            setWriterInternal(osw,false);
         }
-        catch (UnsupportedEncodingException uee)
-        {
-
-            // Should have been warned in init, I guess...
+        else {
+            // don't have any encoding, but we have an OutputStream
+            Writer osw = new OutputStreamWriter(output);
+            setWriterInternal(osw,false);
         }
     }
+
 
     /**
      * @see SerializationHandler#setEscaping(boolean)
@@ -2462,7 +2521,7 @@ abstract public class ToStream extends SerializerBase
              * lets determine if the current element is specified in the cdata-
              * section-elements list.
              */
-            if (m_cdataSectionElements != null)
+            if (m_StringOfCDATASections != null)
                 m_elemContext.m_isCdataSection = isCdataSection();
 
             if (m_doIndent)
@@ -2539,12 +2598,12 @@ abstract public class ToStream extends SerializerBase
      * @param   key   the property key.
      * @param props the list of properties to search in.
      *
-     * Sets the vector of local-name/URI pairs of the cdata section elements
+     * Sets the ArrayList of local-name/URI pairs of the cdata section elements
      * specified in the cdata-section-elements property.
      *
      * This method is essentially a copy of getQNameProperties() from
      * OutputProperties. Eventually this method should go away and a call
-     * to setCdataSectionElements(Vector v) should be made directly.
+     * to setCdataSectionElements(ArrayList<String> v) should be made directly.
      */
     private void setCdataSectionElements(String key, Properties props)
     {
@@ -2553,11 +2612,11 @@ abstract public class ToStream extends SerializerBase
 
         if (null != s)
         {
-            // Vector of URI/LocalName pairs
-            Vector v = new Vector();
+            // ArrayList<String> of URI/LocalName pairs
+            ArrayList<String> v = new ArrayList<>();
             int l = s.length();
             boolean inCurly = false;
-            StringBuffer buf = new StringBuffer();
+            StringBuilder buf = new StringBuilder();
 
             // parse through string, breaking on whitespaces.  I do this instead
             // of a tokenizer so I can track whitespace inside of curly brackets,
@@ -2604,7 +2663,7 @@ abstract public class ToStream extends SerializerBase
      *
      * @return a QName object
      */
-    private void addCdataSectionElement(String URI_and_localName, Vector v)
+    private void addCdataSectionElement(String URI_and_localName, ArrayList<String> v)
     {
 
         StringTokenizer tokenizer =
@@ -2615,14 +2674,14 @@ abstract public class ToStream extends SerializerBase
         if (null == s2)
         {
             // add null URI and the local name
-            v.addElement(null);
-            v.addElement(s1);
+            v.add(null);
+            v.add(s1);
         }
         else
         {
             // add URI, then local name
-            v.addElement(s1);
-            v.addElement(s2);
+            v.add(s1);
+            v.add(s2);
         }
     }
 
@@ -2631,11 +2690,38 @@ abstract public class ToStream extends SerializerBase
      * The "official way to set URI and localName pairs.
      * This method should be used by both Xalan and XSLTC.
      *
-     * @param URI_and_localNames a vector of pairs of Strings (URI/local)
+     * @param URI_and_localNames an ArrayList of pairs of Strings (URI/local)
      */
-    public void setCdataSectionElements(Vector URI_and_localNames)
+    public void setCdataSectionElements(ArrayList<String> URI_and_localNames)
     {
-        m_cdataSectionElements = URI_and_localNames;
+        // convert to the new way.
+        if (URI_and_localNames != null)
+        {
+            final int len = URI_and_localNames.size() - 1;
+            if (len > 0)
+            {
+                final StringBuilder sb = new StringBuilder();
+                for (int i = 0; i < len; i += 2)
+                {
+                    // whitspace separated "{uri1}local1 {uri2}local2 ..."
+                    if (i != 0)
+                        sb.append(' ');
+                    final String uri = (String) URI_and_localNames.get(i);
+                    final String localName =
+                        (String) URI_and_localNames.get(i + 1);
+                    if (uri != null)
+                    {
+                        // If there is no URI don't put this in, just the localName then.
+                        sb.append('{');
+                        sb.append(uri);
+                        sb.append('}');
+                    }
+                    sb.append(localName);
+                }
+                m_StringOfCDATASections = sb.toString();
+            }
+        }
+        initCdataElems(m_StringOfCDATASections);
     }
 
     /**
@@ -3091,37 +3177,7 @@ abstract public class ToStream extends SerializerBase
       */
      public void setEncoding(String encoding)
      {
-         String old = getEncoding();
-         super.setEncoding(encoding);
-         if (old == null || !old.equals(encoding)) {
-            // If we have changed the setting of the
-            m_encodingInfo = Encodings.getEncodingInfo(encoding);
-
-            if (encoding != null && m_encodingInfo.name == null) {
-                // We tried to get an EncodingInfo for Object for the given
-                // encoding, but it came back with an internall null name
-                // so the encoding is not supported by the JDK, issue a message.
-                String msg = Utils.messages.createMessage(
-                                MsgKey.ER_ENCODING_NOT_SUPPORTED,new Object[]{ encoding });
-                try
-                {
-                        // Prepare to issue the warning message
-                        Transformer tran = super.getTransformer();
-                        if (tran != null) {
-                                ErrorListener errHandler = tran.getErrorListener();
-                                // Issue the warning message
-                                if (null != errHandler && m_sourceLocator != null)
-                                        errHandler.warning(new TransformerException(msg, m_sourceLocator));
-                                else
-                                        System.out.println(msg);
-                    }
-                        else
-                                System.out.println(msg);
-                }
-                catch (Exception e){}
-            }
-         }
-         return;
+         setOutputProperty(OutputKeys.ENCODING,encoding);
      }
 
     /**
@@ -3392,5 +3448,25 @@ abstract public class ToStream extends SerializerBase
      */
     public void setDTDEntityExpansion(boolean expand) {
         m_expandDTDEntities = expand;
+    }
+
+    /**
+     * Remembers the cdata sections specified in the cdata-section-elements by appending the given
+     * cdata section elements to the list. This method can be called multiple times, but once an
+     * element is put in the list of cdata section elements it can not be removed.
+     * This method should be used by both Xalan and XSLTC.
+     *
+     * @param URI_and_localNames a whitespace separated list of element names, each element
+     * is a URI in curly braces (optional) and a local name. An example of such a parameter is:
+     * "{http://company.com}price {myURI2}book chapter"
+     */
+    public void addCdataSectionElements(String URI_and_localNames)
+    {
+        if (URI_and_localNames != null)
+            initCdataElems(URI_and_localNames);
+        if (m_StringOfCDATASections == null)
+            m_StringOfCDATASections = URI_and_localNames;
+        else
+            m_StringOfCDATASections += (" " + URI_and_localNames);
     }
 }

--- a/jaxp/src/com/sun/org/apache/xml/internal/serializer/ToUnknownStream.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serializer/ToUnknownStream.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Writer;
 import java.util.Properties;
-import java.util.Vector;
+import java.util.ArrayList;
 
 import javax.xml.transform.SourceLocator;
 import javax.xml.transform.Transformer;
@@ -100,12 +100,12 @@ public final class ToUnknownStream extends SerializerBase
      * A collection of namespace URI's (only for first element).
      * _namespacePrefix has the matching prefix for these URI's
      */
-    private Vector m_namespaceURI = null;
+    private ArrayList<String> m_namespaceURI = null;
     /**
      * A collection of namespace Prefix (only for first element)
      * _namespaceURI has the matching URIs for these prefix'
      */
-    private Vector m_namespacePrefix = null;
+    private ArrayList<String> m_namespacePrefix = null;
 
     /**
      * true if startDocument() was called before the underlying handler
@@ -421,11 +421,11 @@ public final class ToUnknownStream extends SerializerBase
             {
                 if (m_namespacePrefix == null)
                 {
-                    m_namespacePrefix = new Vector();
-                    m_namespaceURI = new Vector();
+                    m_namespacePrefix = new ArrayList<>();
+                    m_namespaceURI = new ArrayList<>();
                 }
-                m_namespacePrefix.addElement(prefix);
-                m_namespaceURI.addElement(uri);
+                m_namespacePrefix.add(prefix);
+                m_namespaceURI.add(uri);
 
                 if (m_firstElementURI == null)
                 {
@@ -1092,8 +1092,8 @@ public final class ToUnknownStream extends SerializerBase
                 for (int i = 0; i < n; i++)
                 {
                     final String prefix =
-                        (String) m_namespacePrefix.elementAt(i);
-                    final String uri = (String) m_namespaceURI.elementAt(i);
+                        (String) m_namespacePrefix.get(i);
+                    final String uri = (String) m_namespaceURI.get(i);
                     m_handler.startPrefixMapping(prefix, uri, false);
                 }
                 m_namespacePrefix = null;
@@ -1165,8 +1165,8 @@ public final class ToUnknownStream extends SerializerBase
             final int max = m_namespacePrefix.size();
             for (int i = 0; i < max; i++)
             {
-                final String prefix = (String) m_namespacePrefix.elementAt(i);
-                final String uri = (String) m_namespaceURI.elementAt(i);
+                final String prefix = m_namespacePrefix.get(i);
+                final String uri = m_namespaceURI.get(i);
 
                 if (m_firstElementPrefix != null
                     && m_firstElementPrefix.equals(prefix)
@@ -1194,7 +1194,7 @@ public final class ToUnknownStream extends SerializerBase
      * specified in the cdata-section-elements attribute.
      * @see SerializationHandler#setCdataSectionElements(java.util.Vector)
      */
-    public void setCdataSectionElements(Vector URI_and_localNames)
+    public void setCdataSectionElements(ArrayList<String> URI_and_localNames)
     {
         m_handler.setCdataSectionElements(URI_and_localNames);
     }

--- a/jaxp/src/com/sun/org/apache/xml/internal/serializer/WriterToUTF8Buffered.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serializer/WriterToUTF8Buffered.java
@@ -3,9 +3,11 @@
  * DO NOT REMOVE OR ALTER!
  */
 /*
- * Copyright 1999-2005 The Apache Software Foundation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the  "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/jaxp/src/com/sun/org/apache/xml/internal/serializer/XSLOutputAttributes.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serializer/XSLOutputAttributes.java
@@ -3,9 +3,11 @@
  * DO NOT REMOVE OR ALTER!
  */
 /*
- * Copyright 2003-2004 The Apache Software Foundation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the  "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -22,7 +24,7 @@
  */
 package com.sun.org.apache.xml.internal.serializer;
 
-import java.util.Vector;
+import java.util.ArrayList;
 
 /**
  * This interface has methods associated with the XSLT xsl:output attribues
@@ -105,11 +107,6 @@ interface XSLOutputAttributes
      */
     public String getVersion();
 
-
-
-
-
-
     /**
      * Sets the value coming from the xsl:output cdata-section-elements
      * stylesheet property.
@@ -124,7 +121,7 @@ interface XSLOutputAttributes
      * relevant in specifying which elements have their text to be output as
      * CDATA sections.
      */
-    public void setCdataSectionElements(Vector URI_and_localNames);
+    public void setCdataSectionElements(ArrayList<String> URI_and_localNames);
 
     /** Set the value coming from the xsl:output doctype-public and doctype-system stylesheet properties
      * @param system the system identifier to be used in the DOCTYPE declaration
@@ -181,4 +178,58 @@ interface XSLOutputAttributes
      */
     public void setVersion(String version);
 
+    /**
+     * Get the value for a property that affects seraialization,
+     * if a property was set return that value, otherwise return
+     * the default value, otherwise return null.
+     * @param name The name of the property, which is just the local name
+     * if it is in no namespace, but is the URI in curly braces followed by
+     * the local name if it is in a namespace, for example:
+     * <ul>
+     * <li> "encoding"
+     * <li> "method"
+     * <li> "{http://xml.apache.org/xalan}indent-amount"
+     * <li> "{http://xml.apache.org/xalan}line-separator"
+     * </ul>
+     * @return The value of the parameter
+     */
+    public String getOutputProperty(String name);
+    /**
+     * Get the default value for a property that affects seraialization,
+     * or null if there is none. It is possible that a non-default value
+     * was set for the property, however the value returned by this method
+     * is unaffected by any non-default settings.
+     * @param name The name of the property.
+     * @return The default value of the parameter, or null if there is no default value.
+     */
+    public String getOutputPropertyDefault(String name);
+    /**
+     * Set the non-default value for a property that affects seraialization.
+     * @param name The name of the property, which is just the local name
+     * if it is in no namespace, but is the URI in curly braces followed by
+     * the local name if it is in a namespace, for example:
+     * <ul>
+     * <li> "encoding"
+     * <li> "method"
+     * <li> "{http://xml.apache.org/xalan}indent-amount"
+     * <li> "{http://xml.apache.org/xalan}line-separator"
+     * </ul>
+     * @val The non-default value of the parameter
+     */
+    public void   setOutputProperty(String name, String val);
+
+    /**
+     * Set the default value for a property that affects seraialization.
+     * @param name The name of the property, which is just the local name
+     * if it is in no namespace, but is the URI in curly braces followed by
+     * the local name if it is in a namespace, for example:
+     * <ul>
+     * <li> "encoding"
+     * <li> "method"
+     * <li> "{http://xml.apache.org/xalan}indent-amount"
+     * <li> "{http://xml.apache.org/xalan}line-separator"
+     * </ul>
+     * @val The default value of the parameter
+     */
+    public void   setOutputPropertyDefault(String name, String val);
 }


### PR DESCRIPTION
I'd like to backport JDK-8041523 to 8u.
This backport fixes jck8 api/xinclude test failures that occur after JDK-8037259 backport to 8u.
Аffected tests:
api/xinclude/Nist/Nist-include-38.html#Nist-include-38
api/xinclude/Nist/Nist-include-37.html#Nist-include-37
api/xinclude/Harold/harold-64.html#harold-64

Original patch from jdk9 [894ae6562453](http://hg.openjdk.java.net/jdk9/jdk9/jaxp/rev/894ae6562453) applies almost cleanly except for some copyright differences and imports reshuffling.

Tested with jdk_tier1, jdk_other (that includes javax/xml) and jck8 api/xinclude.