### PR TITLE
8194154: System property user.dir should not be changed

### DIFF
--- a/jdk/src/solaris/classes/java/io/UnixFileSystem.java
+++ b/jdk/src/solaris/classes/java/io/UnixFileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@ class UnixFileSystem extends FileSystem {
     private final char slash;
     private final char colon;
     private final String javaHome;
+    private final String userDir;
 
     public UnixFileSystem() {
         slash = AccessController.doPrivileged(
@@ -42,6 +43,8 @@ class UnixFileSystem extends FileSystem {
             new GetPropertyAction("path.separator")).charAt(0);
         javaHome = AccessController.doPrivileged(
             new GetPropertyAction("java.home"));
+        userDir = AccessController.doPrivileged(
+            new GetPropertyAction("user.dir"));
     }
 
 
@@ -130,7 +133,11 @@ class UnixFileSystem extends FileSystem {
 
     public String resolve(File f) {
         if (isAbsolute(f)) return f.getPath();
-        return resolve(System.getProperty("user.dir"), f.getPath());
+        SecurityManager sm = System.getSecurityManager();
+        if (sm != null) {
+            sm.checkPropertyAccess("user.dir");
+        }
+        return resolve(userDir, f.getPath());
     }
 
     // Caches for canonicalization results to improve startup performance.

--- a/jdk/src/windows/classes/java/io/WinNTFileSystem.java
+++ b/jdk/src/windows/classes/java/io/WinNTFileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,6 +40,7 @@ class WinNTFileSystem extends FileSystem {
     private final char slash;
     private final char altSlash;
     private final char semicolon;
+    private final String userDir;
 
     public WinNTFileSystem() {
         slash = AccessController.doPrivileged(
@@ -47,6 +48,8 @@ class WinNTFileSystem extends FileSystem {
         semicolon = AccessController.doPrivileged(
             new GetPropertyAction("path.separator")).charAt(0);
         altSlash = (this.slash == '\\') ? '/' : '\\';
+        userDir = AccessController.doPrivileged(
+            new GetPropertyAction("user.dir"));
     }
 
     private boolean isSlash(char c) {
@@ -343,7 +346,11 @@ class WinNTFileSystem extends FileSystem {
     private String getUserPath() {
         /* For both compatibility and security,
            we must look this up every time */
-        return normalize(System.getProperty("user.dir"));
+        SecurityManager sm = System.getSecurityManager();
+        if (sm != null) {
+            sm.checkPropertyAccess("user.dir");
+        }
+        return normalize(userDir);
     }
 
     private String getDrive(String path) {

--- a/jdk/test/java/io/File/UserDirChangedTest.java
+++ b/jdk/test/java/io/File/UserDirChangedTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+   @bug 8194154
+   @summary Test changing property user.dir on impacting getCanonicalPath
+   @run main/othervm UserDirChangedTest
+ */
+
+import java.io.File;
+
+public class UserDirChangedTest {
+    public static void main(String[] args) throws Exception {
+        String keyUserDir = "user.dir";
+        String userDirNew = "/home/a/b/c/";
+        String fileName = "./a";
+
+        String userDir = System.getProperty(keyUserDir);
+        File file = new File(fileName);
+        String canFilePath = file.getCanonicalPath();
+
+        // now reset user.dir, this will cause crash on linux without bug 8194154 fixed.
+        System.setProperty(keyUserDir,  userDirNew);
+        String newCanFilePath = file.getCanonicalPath();
+        System.out.format("%24s %48s%n", "Canonical Path = ", canFilePath);
+        System.out.format("%24s %48s%n", "new Canonical Path = ", newCanFilePath);
+        if (!canFilePath.equals(newCanFilePath)) {
+            throw new RuntimeException("Changing property user.dir should have no effect on getCanonicalPath");
+        }
+    }
+}


### PR DESCRIPTION
Hi,

Please review the backport of JDK-8194154 to 8u.
Bug: https://bugs.openjdk.java.net/browse/JDK-8194154
Original commit: [http://hg.openjdk.java.net/jdk/jdk/rev/847a988152b8](https://hg.openjdk.java.net/jdk/jdk/rev/847a988152b8)
8u webrev: https://cr.openjdk.java.net/~dongbohe/8194154/webrev.00/

Patch doesn't apply cleanly but is trivial, because JDK-8154231[1] and JDK-8155775[2] does not exist in 8,
and some copyright year conflicts.

Testing: checked that added test fails without the patch and passes with the patch, tested with tier1.

[1] https://bugs.openjdk.java.net/browse/JDK-8154231
[2] https://bugs.openjdk.java.net/browse/JDK-8155775

Original RFR email: https://mail.openjdk.java.net/pipermail/jdk8u-dev/2022-January/014497.html

Thanks,
hedongbo

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8194154](https://bugs.openjdk.java.net/browse/JDK-8194154): System property user.dir should not be changed


### Reviewers
 * [Severin Gehwolf](https://openjdk.java.net/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk8u-dev pull/8/head:pull/8` \
`$ git checkout pull/8`

Update a local copy of the PR: \
`$ git checkout pull/8` \
`$ git pull https://git.openjdk.java.net/jdk8u-dev pull/8/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8`

View PR using the GUI difftool: \
`$ git pr show -t 8`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk8u-dev/pull/8.diff">https://git.openjdk.java.net/jdk8u-dev/pull/8.diff</a>

</details>
