### PR TITLE
8223396: [TESTBUG] several jfr tests do not clean up files created in /tmp

### DIFF
--- a/jdk/test/jdk/jfr/event/io/EvilInstrument.java
+++ b/jdk/test/jdk/jfr/event/io/EvilInstrument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.security.ProtectionDomain;
 import java.util.concurrent.CountDownLatch;
+import jdk.test.lib.Utils;
 
 
 /**
@@ -87,7 +88,7 @@ public class EvilInstrument {
     }
 
     public static File createScratchFile() throws IOException {
-        return File.createTempFile("EvilTransformer", null, new File(".")).getAbsoluteFile();
+        return Utils.createTempFile("EvilTransformer", null).toFile();
     }
 
     class EvilTransformer implements ClassFileTransformer {

--- a/jdk/test/jdk/jfr/event/io/TestDisabledEvents.java
+++ b/jdk/test/jdk/jfr/event/io/TestDisabledEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@ import java.nio.channels.FileChannel;
 
 import jdk.jfr.Recording;
 import jdk.jfr.consumer.RecordedEvent;
+import jdk.test.lib.Utils;
 import jdk.test.lib.jfr.Events;
 
 /**
@@ -55,8 +56,7 @@ public class TestDisabledEvents {
     private static final byte[] writeBuf = { 'B', 'C', 'D' };
 
     public static void main(String[] args) throws Throwable {
-        File tmp = File.createTempFile("TestDisabledEvents", ".tmp", new File("."));
-        tmp.deleteOnExit();
+        File tmp = Utils.createTempFile("TestDisabledEvents", ".tmp").toFile();
         Recording recording = new Recording();
         recording.disable(IOEvent.EVENT_FILE_READ);
         recording.disable(IOEvent.EVENT_FILE_WRITE);

--- a/jdk/test/jdk/jfr/event/io/TestFileChannelEvents.java
+++ b/jdk/test/jdk/jfr/event/io/TestFileChannelEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@ import java.util.List;
 
 import jdk.jfr.Recording;
 import jdk.jfr.consumer.RecordedEvent;
+import jdk.test.lib.Utils;
 import jdk.test.lib.jfr.Events;
 
 /**
@@ -48,8 +49,7 @@ import jdk.test.lib.jfr.Events;
  */
 public class TestFileChannelEvents {
     public static void main(String[] args) throws Throwable {
-        File tmp = File.createTempFile("TestFileChannelEvents", ".tmp", new File("."));
-        tmp.deleteOnExit();
+        File tmp = Utils.createTempFile("TestFileChannelEvents", ".tmp").toFile();
         Recording recording = new Recording();
         List<IOEvent> expectedEvents = new ArrayList<>();
 

--- a/jdk/test/jdk/jfr/event/io/TestFileReadOnly.java
+++ b/jdk/test/jdk/jfr/event/io/TestFileReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@ import java.util.List;
 
 import jdk.jfr.Recording;
 import jdk.jfr.consumer.RecordedEvent;
+import jdk.test.lib.Utils;
 import jdk.test.lib.jfr.Events;
 
 /**
@@ -50,8 +51,7 @@ import jdk.test.lib.jfr.Events;
 public class TestFileReadOnly {
 
     public static void main(String[] args) throws Throwable {
-        File tmp = File.createTempFile("TestFileReadOnly", ".tmp", new File("."));
-        tmp.deleteOnExit();
+        File tmp = Utils.createTempFile("TestFileReadOnly", ".tmp").toFile();
         Recording recording = new Recording();
         List<IOEvent> expectedEvents = new ArrayList<>();
 

--- a/jdk/test/jdk/jfr/event/io/TestFileStreamEvents.java
+++ b/jdk/test/jdk/jfr/event/io/TestFileStreamEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@ import java.util.List;
 
 import jdk.jfr.Recording;
 import jdk.jfr.consumer.RecordedEvent;
+import jdk.test.lib.Utils;
 import jdk.test.lib.jfr.Events;
 
 /**
@@ -48,8 +49,7 @@ import jdk.test.lib.jfr.Events;
 
 public class TestFileStreamEvents {
     public static void main(String[] args) throws Throwable {
-        File tmp = File.createTempFile("TestFileStreamEvents", ".tmp", new File("."));
-        tmp.deleteOnExit();
+        File tmp = Utils.createTempFile("TestFileStreamEvents", ".tmp").toFile();
         Recording recording = new Recording();
         List<IOEvent> expectedEvents = new ArrayList<>();
 

--- a/jdk/test/jdk/jfr/event/io/TestRandomAccessFileEvents.java
+++ b/jdk/test/jdk/jfr/event/io/TestRandomAccessFileEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import java.util.List;
 
 import jdk.jfr.Recording;
 import jdk.jfr.consumer.RecordedEvent;
+import jdk.test.lib.Utils;
 import jdk.test.lib.jfr.Events;
 
 /**
@@ -47,8 +48,7 @@ import jdk.test.lib.jfr.Events;
 public class TestRandomAccessFileEvents {
 
     public static void main(String[] args) throws Throwable {
-        File tmp = File.createTempFile("TestRandomAccessFileEvents", ".tmp", new File("."));
-        tmp.deleteOnExit();
+        File tmp = Utils.createTempFile("TestRandomAccessFileEvents", ".tmp").toFile();
         Recording recording = new Recording();
         List<IOEvent> expectedEvents = new ArrayList<>();
 

--- a/jdk/test/jdk/jfr/event/io/TestRandomAccessFileThread.java
+++ b/jdk/test/jdk/jfr/event/io/TestRandomAccessFileThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@ import java.util.List;
 import jdk.jfr.Recording;
 import jdk.jfr.consumer.RecordedEvent;
 import jdk.test.lib.Asserts;
+import jdk.test.lib.Utils;
 import jdk.test.lib.jfr.Events;
 import jdk.test.lib.thread.TestThread;
 import jdk.test.lib.thread.XRun;
@@ -62,8 +63,7 @@ public class TestRandomAccessFileThread {
     private static volatile int writeCount = 0; // Number of writes executed.
 
     public static void main(String[] args) throws Throwable {
-        File tmp = File.createTempFile("TestRandomAccessFileThread", ".tmp", new File("."));
-        tmp.deleteOnExit();
+        File tmp = Utils.createTempFile("TestRandomAccessFileThread", ".tmp").toFile();
 
         Recording recording = new Recording();
         recording.enable(IOEvent.EVENT_FILE_READ).withThreshold(Duration.ofMillis(0));

--- a/jdk/test/jdk/jfr/jcmd/TestJcmdConfigure.java
+++ b/jdk/test/jdk/jfr/jcmd/TestJcmdConfigure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import java.util.List;
 
 import jdk.jfr.internal.Options;
 import jdk.test.lib.Asserts;
+import jdk.test.lib.Utils;
 
 /**
  * @test
@@ -62,7 +63,7 @@ public class TestJcmdConfigure {
         // - where feasible, check if they are respected
         //
 
-        String dumpPath = Files.createTempDirectory("dump-path").toAbsolutePath().toString();
+        String dumpPath = Utils.createTempDirectory("dump-path-").toAbsolutePath().toString();
 
         test(DUMPPATH, dumpPath);
         test(STACK_DEPTH, 15);

--- a/jdk/test/jdk/jfr/jmx/JmxHelper.java
+++ b/jdk/test/jdk/jfr/jmx/JmxHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,6 +48,7 @@ import jdk.management.jfr.FlightRecorderMXBean;
 import jdk.management.jfr.RecordingInfo;
 import jdk.management.jfr.SettingDescriptorInfo;
 import jdk.test.lib.Asserts;
+import jdk.test.lib.Utils;
 import jdk.test.lib.jfr.CommonHelper;
 import jdk.test.lib.jfr.Events;
 
@@ -127,7 +128,7 @@ public class JmxHelper {
     }
 
     static File dump(long streamId, FlightRecorderMXBean bean) throws IOException {
-        File f = File.createTempFile("stream_" + streamId + "_", ".jfr", new File("."));
+        File f = Utils.createTempFile("stream_" + streamId + "_", ".jfr").toFile();
         try (FileOutputStream fos = new FileOutputStream(f); BufferedOutputStream bos = new BufferedOutputStream(fos)) {
             while (true) {
                 byte[] data = bean.readStream(streamId);

--- a/jdk/test/jdk/jfr/jvm/TestJavaEvent.java
+++ b/jdk/test/jdk/jfr/jvm/TestJavaEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,7 @@ import jdk.jfr.Recording;
 import jdk.jfr.ValueDescriptor;
 import jdk.jfr.consumer.RecordedEvent;
 import jdk.jfr.consumer.RecordingFile;
+import jdk.test.lib.Utils;
 
 /**
  * @test TestGetThreadId
@@ -117,7 +118,7 @@ public class TestJavaEvent {
 
         r.stop();
         // prettyPrint();
-        File file = File.createTempFile("test", ".jfr");
+        File file = Utils.createTempFile("test", ".jfr").toFile();
         r.dump(file.toPath());
         int eventCount = 0;
         for (RecordedEvent e : RecordingFile.readAllEvents(file.toPath())) {

--- a/jdk/test/lib/jdk/test/lib/Utils.java
+++ b/jdk/test/lib/jdk/test/lib/Utils.java
@@ -808,4 +808,24 @@ public final class Utils {
         Path dir = Paths.get(System.getProperty("user.dir", "."));
         return Files.createTempFile(dir, prefix, suffix);
     }
+
+    /**
+     * Creates an empty directory in "user.dir" or "."
+     * <p>
+     * This method is meant as a replacement for {@code Files#createTempDirectory(String, String, FileAttribute...)}
+     * that doesn't leave files behind in /tmp directory of the test machine
+     * <p>
+     * If the property "user.dir" is not set, "." will be used.
+     *
+     * @param prefix
+     * @param attrs
+     * @return the path to the newly created directory
+     * @throws IOException
+     *
+     * @see {@link Files#createTempDirectory(String, String, FileAttribute...)}
+     */
+    public static Path createTempDirectory(String prefix, FileAttribute<?>... attrs) throws IOException {
+        Path dir = Paths.get(System.getProperty("user.dir", "."));
+        return Files.createTempDirectory(dir, prefix);
+    }
 }


### PR DESCRIPTION
Hi,

This is a clean backport of [JDK-8223396](https://bugs.openjdk.java.net/browse/JDK-8223396). I'm backporting this as a predecessor of PR #10.

Test:
- [x] jdk_jfr
  EvilInstrument.java test fails. Followup JDK-8230865 backport to fix it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8223396](https://bugs.openjdk.java.net/browse/JDK-8223396): [TESTBUG] several jfr tests do not clean up files created in /tmp


### Reviewers
 * [Andrew John Hughes](https://openjdk.java.net/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk8u-dev pull/14/head:pull/14` \
`$ git checkout pull/14`

Update a local copy of the PR: \
`$ git checkout pull/14` \
`$ git pull https://git.openjdk.java.net/jdk8u-dev pull/14/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14`

View PR using the GUI difftool: \
`$ git pr show -t 14`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk8u-dev/pull/14.diff">https://git.openjdk.java.net/jdk8u-dev/pull/14.diff</a>

</details>
