### PR TITLE
8230865: [TESTBUG] jdk/jfr/event/io/EvilInstrument.java fails at-run shell MakeJAR.sh target

### DIFF
--- a/jdk/test/jdk/jfr/event/io/EvilInstrument.java
+++ b/jdk/test/jdk/jfr/event/io/EvilInstrument.java
@@ -51,6 +51,7 @@ import java.util.concurrent.CountDownLatch;
  * @library /lib /
  *
  *
+ * @build jdk.jfr.event.io.EvilInstrument
  * @run shell MakeJAR.sh EvilInstrument 'Can-Redefine-Classes: true'
  * @run main/othervm -javaagent:EvilInstrument.jar jdk.jfr.event.io.EvilInstrument
  */


### PR DESCRIPTION
Hi,

I would like to backport this patch to fix test failure, introduced by JDK-8223396.

This is a clean backport on top of JDK-8223396 backport.

Test:
- [x] jdk_jfr

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8230865](https://bugs.openjdk.java.net/browse/JDK-8230865): [TESTBUG] jdk/jfr/event/io/EvilInstrument.java fails at-run shell MakeJAR.sh target


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk8u-dev pull/16/head:pull/16` \
`$ git checkout pull/16`

Update a local copy of the PR: \
`$ git checkout pull/16` \
`$ git pull https://git.openjdk.java.net/jdk8u-dev pull/16/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16`

View PR using the GUI difftool: \
`$ git pr show -t 16`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk8u-dev/pull/16.diff">https://git.openjdk.java.net/jdk8u-dev/pull/16.diff</a>

</details>
