### PR TITLE
8255239: The timezone of the hs_err_pid log file is corrupted in Japanese locale

### DIFF
--- a/hotspot/src/share/vm/runtime/os.cpp
+++ b/hotspot/src/share/vm/runtime/os.cpp
@@ -887,8 +887,12 @@ void os::print_date_and_time(outputStream *st, char* buf, size_t buflen) {
 
   struct tm tz;
   if (localtime_pd(&tloc, &tz) != NULL) {
-    ::strftime(buf, buflen, "%Z", &tz);
-    st->print_cr("timezone: %s", buf);
+    wchar_t w_buf[80];
+    size_t n = ::wcsftime(w_buf, 80, L"%Z", &tz);
+    if (n > 0) {
+      ::wcstombs(buf, w_buf, buflen);
+      st->print_cr("timezone: %s", buf);
+    }
   }
 
   double t = os::elapsedTime();


### PR DESCRIPTION
This is a backport of JDK-8282051: The timezone of the hs_err_pid log file is corrupted in Japanese locale.

I would like to backport the patch to openjdk8u. 
Original patch does not apply cleanly to 8u.
Because the format of time zone in hs_err_pid log is different from 11u and later.
The following is the example of time zone info:
  jdk11:
     Time: Sat Mar 12 00:14:03 2022 Tokyo Standard Time elapsed time: 0 seconds (0d 0h 0m 0s)
  jdk8:
     time: Sat Mar 12 00:09:26 2022
     timezone: Tokyo Standard Time
     elapsed time: 2.736524 seconds (0d 0h 0m 2s)

Testing:
 build on Windows x86_64
 hotspot/runtime on Windows x86_64
 a specific test to confirm the fix in Japanese locale

Could you please review this PR?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255239](https://bugs.openjdk.java.net/browse/JDK-8255239): The timezone of the hs_err_pid log file is corrupted in Japanese locale


### Reviewers
 * [Andrew John Hughes](https://openjdk.java.net/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk8u-dev pull/20/head:pull/20` \
`$ git checkout pull/20`

Update a local copy of the PR: \
`$ git checkout pull/20` \
`$ git pull https://git.openjdk.java.net/jdk8u-dev pull/20/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20`

View PR using the GUI difftool: \
`$ git pr show -t 20`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk8u-dev/pull/20.diff">https://git.openjdk.java.net/jdk8u-dev/pull/20.diff</a>

</details>
