### PR TITLE
8261107: ArrayIndexOutOfBoundsException in the ICC_Profile.getInstance(InputStream)

### DIFF
--- a/jdk/src/share/classes/java/awt/color/ICC_Profile.java
+++ b/jdk/src/share/classes/java/awt/color/ICC_Profile.java
@@ -1023,10 +1023,10 @@ public class ICC_Profile implements Serializable {
     static byte[] getProfileDataFromStream(InputStream s) throws IOException {
 
         BufferedInputStream bis = new BufferedInputStream(s);
-        bis.mark(128);
+        bis.mark(128); // 128 is the length of the ICC profile header
 
         byte[] header = IOUtils.readNBytes(bis, 128);
-        if (header[36] != 0x61 || header[37] != 0x63 ||
+        if (header.length < 128 || header[36] != 0x61 || header[37] != 0x63 ||
             header[38] != 0x73 || header[39] != 0x70) {
             return null;   /* not a valid profile */
         }

--- a/jdk/test/java/awt/Color/ICC_Profile/GetInstanceBrokenStream.java
+++ b/jdk/test/java/awt/Color/ICC_Profile/GetInstanceBrokenStream.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.color.ICC_Profile;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+/**
+ * @test
+ * @bug 8261107
+ * @summary Short and broken streams should be reported as unsupported
+ */
+public final class GetInstanceBrokenStream {
+
+    public static void main(String[] args) throws IOException {
+        // Empty header
+        testHeader(new byte[]{});
+        // Short header
+        testHeader(new byte[]{-12, 3, 45});
+        // Broken header
+        testHeader(new byte[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+                15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
+                31, 32, 33, 34, 35, 0x61, 0x63, 0x73, 0x70});
+    }
+
+    private static void testHeader(byte[] data) throws IOException {
+        ByteArrayInputStream bais = new ByteArrayInputStream(data);
+        try {
+            ICC_Profile.getInstance(bais);
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+}


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [06b33a0a](https://github.com/openjdk/jdk/commit/06b33a0ad78d1577711af22020cf5fdf25112523) from the [openjdk/jdk](https://git.openjdk.java.net/jdk) repository.
The commit being backported was authored by Sergey Bylokhov on 4 Feb 2021 and was reviewed by Alexander Zvegintsev and Prasanta Sadhukhan.

The new test failed before and works fine after the fix. No new issues were found by the java_desktop tests.
To apply the patch I had to change the paths and some patch context. The changed lines are the same.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261107](https://bugs.openjdk.java.net/browse/JDK-8261107): ArrayIndexOutOfBoundsException in the ICC_Profile.getInstance(InputStream)


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk8u-dev pull/21/head:pull/21` \
`$ git checkout pull/21`

Update a local copy of the PR: \
`$ git checkout pull/21` \
`$ git pull https://git.openjdk.java.net/jdk8u-dev pull/21/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21`

View PR using the GUI difftool: \
`$ git pr show -t 21`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk8u-dev/pull/21.diff">https://git.openjdk.java.net/jdk8u-dev/pull/21.diff</a>

</details>
