### PR TITLE
8278138: OpenJDK8 fails to start on Windows 8.1 after upgrading compiler to VS2017

### DIFF
--- a/jdk/make/Images.gmk
+++ b/jdk/make/Images.gmk
@@ -145,7 +145,8 @@ endif
 WINDOWS_JDK_BIN_FILES = \
     $(EXE_SUFFIX) \
     $(LIBRARY_PREFIX)jli$(SHARED_LIBRARY_SUFFIX) \
-    $(notdir $(MSVCR_DLL))
+    $(notdir $(MSVCR_DLL)) \
+    $(wildcard $(JDK_OUTPUTDIR)/bin/api-ms-win-*.dll)
 
 WINDOWS_JDKJRE_BIN_FILES := \
     $(LIBRARY_PREFIX)attach$(SHARED_LIBRARY_SUFFIX) \


### PR DESCRIPTION
Could you please review the 8278138 bug fixes?

This problem is caused by missing DLL's which vcruntime140.dll depends on.
I think it is needed to copy the missing DLL's into jdk/bin as like jdk/jre/bin.
I fix to copy api-ms-win-*.dll files to jdk/bin when images directory is created.