### PR TITLE
8281814: Debuginfo.diz contains redundant build path after backport JDK-8025936

### DIFF
--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -530,7 +530,7 @@ define SetupNativeCompilation
             # to be rebuilt properly.
             $$($1_DEBUGINFO_ZIP): $$($1_DEBUGINFO_FILES) $$($1_TARGET)
 		$(CD) $$($1_OBJECT_DIR) \
-		&& $(ZIP) -q $$@ $$($1_DEBUGINFO_FILES)
+		&& $(ZIP) -q $$@ $$(notdir $$($1_DEBUGINFO_FILES))
           endif
         else
           ifneq ($$($1_STRIP_POLICY), no_strip)


### PR DESCRIPTION
Hi,

I would like to backport 8035134 to fix debuginfo regression, introduced by [JDK-8025936](https://bugs.openjdk.java.net/browse/JDK-8025936).
As discussed on [JDK-8281814](https://bugs.openjdk.java.net/browse/JDK-8281814), we cannot see the details of the original patch.
It is only a different context, no risk.

Testing: worked correctly after patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281814](https://bugs.openjdk.java.net/browse/JDK-8281814): Debuginfo.diz contains redundant build path after backport JDK-8025936


### Reviewers
 * [Severin Gehwolf](https://openjdk.java.net/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk8u-dev pull/26/head:pull/26` \
`$ git checkout pull/26`

Update a local copy of the PR: \
`$ git checkout pull/26` \
`$ git pull https://git.openjdk.java.net/jdk8u-dev pull/26/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26`

View PR using the GUI difftool: \
`$ git pr show -t 26`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk8u-dev/pull/26.diff">https://git.openjdk.java.net/jdk8u-dev/pull/26.diff</a>

</details>
