### PR TITLE
8146523: VirtualMemoryTracker::remove_released_region double count unmapped CDS shared memory

### DIFF
--- a/hotspot/src/share/vm/services/virtualMemoryTracker.cpp
+++ b/hotspot/src/share/vm/services/virtualMemoryTracker.cpp
@@ -409,6 +409,14 @@ bool VirtualMemoryTracker::remove_released_region(address addr, size_t size) {
     return false;
   }
 
+  if (reserved_rgn->flag() == mtClassShared &&
+      reserved_rgn->contain_region(addr, size) &&
+      !reserved_rgn->same_region(addr, size)) {
+    // This is an unmapped CDS region, which is part of the reserved shared
+    // memory region.
+    // See special handling in VirtualMemoryTracker::add_reserved_region also.
+    return true;
+  }
 
   VirtualMemorySummary::record_released_memory(size, reserved_rgn->flag());
 


### PR DESCRIPTION
8146523: VirtualMemoryTracker::remove_released_region double count unmapped CDS shared memory
Skip tracking release for unmapped CDS shared space.

JDK8u can reproduce this prolbem in some special case, for example the timestamp of jar file in jdk build is changed. 

To reproduce the issue with JDK8: 
1. Dump class list： java -XX:DumpLoadedClassList=my.list -version 
2. Generate jsa：java -XX:+UnlockDiagnosticVMOptions -Xshare:dump -XX:SharedClassListFile=my.list -XX:SharedArchiveFile=my.jsa 
3. Touch some jar files in JDK build： touch jre/lib/resources.jar eg 
4. Run with the jsa:java -XX:+UnlockDiagnosticVMOptions -Xshare:on -XX:SharedArchiveFile=nmt_version.jsa -XX:NativeMemoryTracking=summary -XX:-RequireSharedSpaces -version 

Then crash as below: 
```
# 
# A fatal error has been detected by the Java Runtime Environment: 
# 
# SIGSEGV (0xb) at pc=0x00007fc08dee0195, pid=21887, tid=0x00007fc08f024700 
# 
# JRE version: (8.0_322-b06) (build ) 
# Java VM: OpenJDK 64-Bit Server VM (25.322-b06 mixed mode linux-amd64 compressed oops) 
# Problematic frame: 
# V [libjvm.so+0xb32195] VirtualMemoryTracker::add_committed_region(unsigned char*, unsigned long, NativeCallStack const&)+0x1a5 
# 
# Failed to write core dump. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again 
# 
# An error report file with more information is saved as: 
# /data/work/test/nmtissue/hs_err_pid21887.log 
# 
# If you would like to submit a bug report, please visit: 
# https://github.com/adoptium/adoptium-support/issues 
# 
```
To solve the issue, we’d like to back port this fix to jdk8u

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8146523](https://bugs.openjdk.java.net/browse/JDK-8146523): VirtualMemoryTracker::remove_released_region double count unmapped CDS shared memory


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk8u-dev pull/27/head:pull/27` \
`$ git checkout pull/27`

Update a local copy of the PR: \
`$ git checkout pull/27` \
`$ git pull https://git.openjdk.java.net/jdk8u-dev pull/27/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27`

View PR using the GUI difftool: \
`$ git pr show -t 27`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk8u-dev/pull/27.diff">https://git.openjdk.java.net/jdk8u-dev/pull/27.diff</a>

</details>
