### PR TITLE
8221988: add possibility to build with Visual Studio 2019

### DIFF
--- a/common/autoconf/toolchain_windows.m4
+++ b/common/autoconf/toolchain_windows.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
 
 ################################################################################
 # The order of these defines the priority by which we try to find them.
-VALID_VS_VERSIONS="2010 2012 2013 2015 2017"
+VALID_VS_VERSIONS="2017 2019 2013 2015 2012 2010"
 
 VS_DESCRIPTION_2010="Microsoft Visual Studio 2010"
 VS_VERSION_INTERNAL_2010=100
@@ -83,6 +83,20 @@ VS_SDK_INSTALLDIR_2017=
 VS_VS_PLATFORM_NAME_2017="v141"
 VS_SDK_PLATFORM_NAME_2017=
 
+VS_DESCRIPTION_2019="Microsoft Visual Studio 2019"
+VS_VERSION_INTERNAL_2019=141
+VS_MSVCR_2019=vcruntime140.dll
+VS_MSVCP_2019=msvcp140.dll
+VS_ENVVAR_2019="VS160COMNTOOLS"
+VS_USE_UCRT_2019="true"
+VS_VS_INSTALLDIR_2019="Microsoft Visual Studio/2019"
+VS_EDITIONS_2019="BuildTools Community Professional Enterprise"
+VS_SDK_INSTALLDIR_2019=
+VS_VS_PLATFORM_NAME_2019="v142"
+VS_SDK_PLATFORM_NAME_2019=
+VS_SUPPORTED_2019=false
+VS_TOOLSET_SUPPORTED_2019=false
+
 ################################################################################
 
 AC_DEFUN([TOOLCHAIN_CHECK_POSSIBLE_VISUAL_STUDIO_ROOT],
@@ -93,7 +107,7 @@ AC_DEFUN([TOOLCHAIN_CHECK_POSSIBLE_VISUAL_STUDIO_ROOT],
     METHOD="$3"
 
     BASIC_WINDOWS_REWRITE_AS_UNIX_PATH(VS_BASE)
-    # In VS 2017, the default installation is in a subdir named after the edition.
+    # In VS 2017 and VS 2019, the default installation is in a subdir named after the edition.
     # Find the first one present and use that.
     if test "x$VS_EDITIONS" != x; then
       for edition in $VS_EDITIONS; do
@@ -520,7 +534,7 @@ AC_DEFUN([TOOLCHAIN_SETUP_MSVC_DLL],
           POSSIBLE_MSVC_DLL="$CYGWIN_VC_INSTALL_DIR/redist/x86/Microsoft.VC${VS_VERSION_INTERNAL}.CRT/$DLL_NAME"
         fi
       else
-        # Probe: Using well-known location from VS 2017
+        # Probe: Using well-known location from VS 2017 and VS 2019
         if test "x$OPENJDK_TARGET_CPU_BITS" = x64; then
           POSSIBLE_MSVC_DLL="`ls $CYGWIN_VC_INSTALL_DIR/Redist/MSVC/*/x64/Microsoft.VC${VS_VERSION_INTERNAL}.CRT/$DLL_NAME`"
         else

--- a/common/autoconf/toolchain_windows.m4
+++ b/common/autoconf/toolchain_windows.m4
@@ -25,7 +25,7 @@
 
 ################################################################################
 # The order of these defines the priority by which we try to find them.
-VALID_VS_VERSIONS="2017 2019 2013 2015 2012 2010"
+VALID_VS_VERSIONS="2013 2015 2012 2010 2017 2019"
 
 VS_DESCRIPTION_2010="Microsoft Visual Studio 2010"
 VS_VERSION_INTERNAL_2010=100

--- a/common/autoconf/toolchain_windows.m4
+++ b/common/autoconf/toolchain_windows.m4
@@ -25,7 +25,7 @@
 
 ################################################################################
 # The order of these defines the priority by which we try to find them.
-VALID_VS_VERSIONS="2013 2015 2012 2010 2017 2019"
+VALID_VS_VERSIONS="2010 2012 2013 2015 2017 2019"
 
 VS_DESCRIPTION_2010="Microsoft Visual Studio 2010"
 VS_VERSION_INTERNAL_2010=100

--- a/make/devkit/createWindowsDevkit2019.sh
+++ b/make/devkit/createWindowsDevkit2019.sh
@@ -1,0 +1,209 @@
+#!/bin/bash
+#
+# Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+# This script copies parts of a Visual Studio installation into a devkit
+# suitable for building OpenJDK and OracleJDK. Needs to run in Cygwin or WSL.
+# erik.joelsson@oracle.com
+
+VS_VERSION="2019"
+VS_VERSION_NUM_NODOT="160"
+VS_DLL_VERSION="140"
+SDK_VERSION="10"
+SDK_FULL_VERSION="10.0.17763.0"
+MSVC_DIR="Microsoft.VC141.CRT"
+MSVC_FULL_VERSION="14.12.27508"
+REDIST_FULL_VERSION="14.20.27508"
+
+SCRIPT_DIR="$(cd "$(dirname $0)" > /dev/null && pwd)"
+BUILD_DIR="${SCRIPT_DIR}/../../build/devkit"
+
+################################################################################
+# Prepare settings
+
+UNAME_SYSTEM=`uname -s`
+UNAME_RELEASE=`uname -r`
+
+# Detect cygwin or WSL
+IS_CYGWIN=`echo $UNAME_SYSTEM | grep -i CYGWIN`
+IS_WSL=`echo $UNAME_RELEASE | grep Microsoft`
+if test "x$IS_CYGWIN" != "x"; then
+    BUILD_ENV="cygwin"
+elif test "x$IS_WSL" != "x"; then
+    BUILD_ENV="wsl"
+else
+    echo "Unknown environment; only Cygwin and WSL are supported."
+    exit 1
+fi
+
+if test "x$BUILD_ENV" = "xcygwin"; then
+    WINDOWS_PATH_TO_UNIX_PATH="cygpath -u"
+elif test "x$BUILD_ENV" = "xwsl"; then
+    WINDOWS_PATH_TO_UNIX_PATH="wslpath -u"
+fi
+
+# Work around the insanely named ProgramFiles(x86) env variable
+PROGRAMFILES_X86="$($WINDOWS_PATH_TO_UNIX_PATH "$(cmd.exe /c set | sed -n 's/^ProgramFiles(x86)=//p' | tr -d '\r')")"
+
+# Find Visual Studio installation dir
+VSNNNCOMNTOOLS=`cmd.exe /c echo %VS${VS_VERSION_NUM_NODOT}COMNTOOLS% | tr -d '\r'`
+if [ -d "$VSNNNCOMNTOOLS" ]; then
+    VS_INSTALL_DIR="$($WINDOWS_PATH_TO_UNIX_PATH "$VSNNNCOMNTOOLS/../..")"
+else
+    VS_INSTALL_DIR="${PROGRAMFILES_X86}/Microsoft Visual Studio/2019"
+    VS_INSTALL_DIR="$(ls -d "${VS_INSTALL_DIR}/"{Community,Professional,Enterprise} 2>/dev/null | head -n1)"
+fi
+echo "VS_INSTALL_DIR: $VS_INSTALL_DIR"
+
+# Extract semantic version
+POTENTIAL_INI_FILES="Common7/IDE/wdexpress.isolation.ini Common7/IDE/devenv.isolation.ini"
+for f in $POTENTIAL_INI_FILES; do
+    if [ -f "$VS_INSTALL_DIR/$f" ]; then
+        VS_VERSION_SP="$(grep ^SemanticVersion= "$VS_INSTALL_DIR/$f")"
+        # Remove SemnaticVersion=
+        VS_VERSION_SP="${VS_VERSION_SP#*=}"
+        # Remove suffix of too detailed numbering starting with +
+        VS_VERSION_SP="${VS_VERSION_SP%+*}"
+        break
+    fi
+done
+if [ -z "$VS_VERSION_SP" ]; then
+    echo "Failed to find SP version"
+    exit 1
+fi
+echo "Found Version SP: $VS_VERSION_SP"
+
+# Setup output dirs
+DEVKIT_ROOT="${BUILD_DIR}/VS${VS_VERSION}-${VS_VERSION_SP}-devkit"
+DEVKIT_BUNDLE="${DEVKIT_ROOT}.tar.gz"
+
+echo "Creating devkit in $DEVKIT_ROOT"
+
+MSVCR_DLL=${MSVC_DIR}/vcruntime${VS_DLL_VERSION}.dll
+MSVCP_DLL=${MSVC_DIR}/msvcp${VS_DLL_VERSION}.dll
+
+################################################################################
+# Copy Visual Studio files
+
+TOOLS_VERSION="$(ls "$VS_INSTALL_DIR/VC/Tools/MSVC" | sort -r -n | head -n1)"
+echo "Found Tools version: $TOOLS_VERSION"
+VC_SUBDIR="VC/Tools/MSVC/$TOOLS_VERSION"
+REDIST_VERSION="$(ls "$VS_INSTALL_DIR/VC/Redist/MSVC" | sort -r -n | head -n1)"
+echo "Found Redist version: $REDIST_VERSION"
+REDIST_SUBDIR="VC/Redist/MSVC/$REDIST_VERSION"
+echo "Copying VC..."
+rm -rf $DEVKIT_ROOT/VC
+mkdir -p $DEVKIT_ROOT/VC/bin
+cp -r "$VS_INSTALL_DIR/${VC_SUBDIR}/bin/Hostx64/x64" $DEVKIT_ROOT/VC/bin/
+cp -r "$VS_INSTALL_DIR/${VC_SUBDIR}/bin/Hostx86/x86" $DEVKIT_ROOT/VC/bin/
+mkdir -p $DEVKIT_ROOT/VC/lib
+cp -r "$VS_INSTALL_DIR/${VC_SUBDIR}/lib/x64" $DEVKIT_ROOT/VC/lib/
+cp -r "$VS_INSTALL_DIR/${VC_SUBDIR}/lib/x86" $DEVKIT_ROOT/VC/lib/
+cp -r "$VS_INSTALL_DIR/${VC_SUBDIR}/include" $DEVKIT_ROOT/VC/
+mkdir -p $DEVKIT_ROOT/VC/atlmfc/lib
+cp -r "$VS_INSTALL_DIR/${VC_SUBDIR}/atlmfc/lib/x64" $DEVKIT_ROOT/VC/atlmfc/lib/
+cp -r "$VS_INSTALL_DIR/${VC_SUBDIR}/atlmfc/lib/x86" $DEVKIT_ROOT/VC/atlmfc/lib/
+cp -r "$VS_INSTALL_DIR/${VC_SUBDIR}/atlmfc/include" $DEVKIT_ROOT/VC/atlmfc/
+mkdir -p $DEVKIT_ROOT/VC/Auxiliary
+cp -r "$VS_INSTALL_DIR/VC/Auxiliary/Build" $DEVKIT_ROOT/VC/Auxiliary/
+mkdir -p $DEVKIT_ROOT/VC/redist
+cp -r "$VS_INSTALL_DIR/$REDIST_SUBDIR/x64" $DEVKIT_ROOT/VC/redist/
+cp -r "$VS_INSTALL_DIR/$REDIST_SUBDIR/x86" $DEVKIT_ROOT/VC/redist/
+
+# The redist runtime libs are needed to run the compiler but may not be
+# installed on the machine where the devkit will be used.
+cp $DEVKIT_ROOT/VC/redist/x86/$MSVCR_DLL $DEVKIT_ROOT/VC/bin/x86
+cp $DEVKIT_ROOT/VC/redist/x86/$MSVCP_DLL $DEVKIT_ROOT/VC/bin/x86
+cp $DEVKIT_ROOT/VC/redist/x64/$MSVCR_DLL $DEVKIT_ROOT/VC/bin/x64
+cp $DEVKIT_ROOT/VC/redist/x64/$MSVCP_DLL $DEVKIT_ROOT/VC/bin/x64
+
+################################################################################
+# Copy SDK files
+
+SDK_INSTALL_DIR="$PROGRAMFILES_X86/Windows Kits/$SDK_VERSION"
+echo "SDK_INSTALL_DIR: $SDK_INSTALL_DIR"
+
+SDK_FULL_VERSION="$(ls "$SDK_INSTALL_DIR/bin" | sort -r -n | head -n1)"
+echo "Found SDK version: $SDK_FULL_VERSION"
+UCRT_VERSION="$(ls "$SDK_INSTALL_DIR/Redist" | grep $SDK_VERSION | sort -r -n | head -n1)"
+echo "Found UCRT version: $UCRT_VERSION"
+echo "Copying SDK..."
+rm -rf $DEVKIT_ROOT/$SDK_VERSION
+mkdir -p $DEVKIT_ROOT/$SDK_VERSION/bin
+cp -r "$SDK_INSTALL_DIR/bin/$SDK_FULL_VERSION/x64" $DEVKIT_ROOT/$SDK_VERSION/bin/
+cp -r "$SDK_INSTALL_DIR/bin/$SDK_FULL_VERSION/x86" $DEVKIT_ROOT/$SDK_VERSION/bin/
+mkdir -p $DEVKIT_ROOT/$SDK_VERSION/lib
+cp -r "$SDK_INSTALL_DIR/lib/$SDK_FULL_VERSION/um/x64" $DEVKIT_ROOT/$SDK_VERSION/lib/
+cp -r "$SDK_INSTALL_DIR/lib/$SDK_FULL_VERSION/um/x86" $DEVKIT_ROOT/$SDK_VERSION/lib/
+cp -r "$SDK_INSTALL_DIR/lib/$SDK_FULL_VERSION/ucrt/x64" $DEVKIT_ROOT/$SDK_VERSION/lib/
+cp -r "$SDK_INSTALL_DIR/lib/$SDK_FULL_VERSION/ucrt/x86" $DEVKIT_ROOT/$SDK_VERSION/lib/
+mkdir -p $DEVKIT_ROOT/$SDK_VERSION/Redist
+cp -r "$SDK_INSTALL_DIR/Redist/$UCRT_VERSION/ucrt" $DEVKIT_ROOT/$SDK_VERSION/Redist/
+mkdir -p $DEVKIT_ROOT/$SDK_VERSION/include
+cp -r "$SDK_INSTALL_DIR/include/$SDK_FULL_VERSION/"* $DEVKIT_ROOT/$SDK_VERSION/include/
+
+################################################################################
+# Generate devkit.info
+
+echo-info() {
+    echo "$1" >> $DEVKIT_ROOT/devkit.info
+}
+
+echo "Generating devkit.info..."
+rm -f $DEVKIT_ROOT/devkit.info
+echo-info "# This file describes to configure how to interpret the contents of this devkit"
+echo-info "DEVKIT_NAME=\"Microsoft Visual Studio $VS_VERSION $VS_VERSION_SP (devkit)\""
+echo-info "DEVKIT_VS_VERSION=\"$VS_VERSION\""
+echo-info ""
+echo-info "DEVKIT_TOOLCHAIN_PATH_x86=\"\$DEVKIT_ROOT/VC/bin/x86:\$DEVKIT_ROOT/$SDK_VERSION/bin/x86\""
+echo-info "DEVKIT_VS_INCLUDE_x86=\"\$DEVKIT_ROOT/VC/include;\$DEVKIT_ROOT/VC/atlmfc/include;\$DEVKIT_ROOT/$SDK_VERSION/include/shared;\$DEVKIT_ROOT/$SDK_VERSION/include/ucrt;\$DEVKIT_ROOT/$SDK_VERSION/include/um;\$DEVKIT_ROOT/$SDK_VERSION/include/winrt\""
+echo-info "DEVKIT_VS_LIB_x86=\"\$DEVKIT_ROOT/VC/lib/x86;\$DEVKIT_ROOT/VC/atlmfc/lib/x86;\$DEVKIT_ROOT/$SDK_VERSION/lib/x86\""
+echo-info "DEVKIT_MSVCR_DLL_x86=\"\$DEVKIT_ROOT/VC/redist/x86/$MSVCR_DLL\""
+echo-info "DEVKIT_MSVCP_DLL_x86=\"\$DEVKIT_ROOT/VC/redist/x86/$MSVCP_DLL\""
+echo-info "DEVKIT_UCRT_DLL_DIR_x86=\"\$DEVKIT_ROOT/10/Redist/ucrt/DLLs/x86\""
+echo-info ""
+echo-info "DEVKIT_TOOLCHAIN_PATH_x86_64=\"\$DEVKIT_ROOT/VC/bin/x64:\$DEVKIT_ROOT/$SDK_VERSION/bin/x64:\$DEVKIT_ROOT/$SDK_VERSION/bin/x86\""
+echo-info "DEVKIT_VS_INCLUDE_x86_64=\"\$DEVKIT_ROOT/VC/include;\$DEVKIT_ROOT/VC/atlmfc/include;\$DEVKIT_ROOT/$SDK_VERSION/include/shared;\$DEVKIT_ROOT/$SDK_VERSION/include/ucrt;\$DEVKIT_ROOT/$SDK_VERSION/include/um;\$DEVKIT_ROOT/$SDK_VERSION/include/winrt\""
+echo-info "DEVKIT_VS_LIB_x86_64=\"\$DEVKIT_ROOT/VC/lib/x64;\$DEVKIT_ROOT/VC/atlmfc/lib/x64;\$DEVKIT_ROOT/$SDK_VERSION/lib/x64\""
+echo-info "DEVKIT_MSVCR_DLL_x86_64=\"\$DEVKIT_ROOT/VC/redist/x64/$MSVCR_DLL\""
+echo-info "DEVKIT_MSVCP_DLL_x86_64=\"\$DEVKIT_ROOT/VC/redist/x64/$MSVCP_DLL\""
+echo-info "DEVKIT_UCRT_DLL_DIR_x86_64=\"\$DEVKIT_ROOT/10/Redist/ucrt/DLLs/x64\""
+echo-info ""
+echo-info "DEVKIT_TOOLS_VERSION=\"$TOOLS_VERSION\""
+echo-info "DEVKIT_REDIST_VERSION=\"$REDIST_VERSION\""
+echo-info "DEVKIT_SDK_VERSION=\"$SDK_FULL_VERSION\""
+echo-info "DEVKIT_UCRT_VERSION=\"$UCRT_VERSION\""
+
+################################################################################
+# Copy this script
+
+echo "Copying this script..."
+cp $0 $DEVKIT_ROOT/
+
+################################################################################
+# Create bundle
+
+echo "Creating bundle: $DEVKIT_BUNDLE"
+(cd "$DEVKIT_ROOT" && tar zcf "$DEVKIT_BUNDLE" .)


### PR DESCRIPTION
Hi!

Please review backport of 8221988. This one opens a bunch of backports enabling support of VS2019. **WARNING**: the patch DOES NOT enable the building with MSVS2019 toolkit, that requires 5-6 more backports. The patch ONLY adds recognition of MSVS2019 to the build system.

The 11u patch applied with the following changes:

- changes to absent documentation files skipped
- resolved baseline conflicts toolchain_windows.m4
- valid MSVS versions were ascending sorted

Verification: `bash configure` under VS2019 prompt.

Regression:

- VS2017 full build (both 64/32-bit): ok
- VS2015 full build: ok (requires --with-extra-cflags='/EHsc /wd4091' --with-extra-cxxflags='/EHsc /wd4091')
- VS2013 full build: ok
- VS2012 full build: ok
- VS2010 full build: ok

@RealCLanger @mdoerr if you take a look at this I will be very grateful

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8221988](https://bugs.openjdk.java.net/browse/JDK-8221988): add possibility to build with Visual Studio 2019


### Reviewers
 * [Severin Gehwolf](https://openjdk.java.net/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.java.net/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk8u-dev pull/33/head:pull/33` \
`$ git checkout pull/33`

Update a local copy of the PR: \
`$ git checkout pull/33` \
`$ git pull https://git.openjdk.java.net/jdk8u-dev pull/33/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 33`

View PR using the GUI difftool: \
`$ git pr show -t 33`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk8u-dev/pull/33.diff">https://git.openjdk.java.net/jdk8u-dev/pull/33.diff</a>

</details>
