### PR TITLE
JDK-8284772: 8u GHA: Use GCC Major Version Dependencies Only

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install openjdk-8-jdk gcc-9=9.3.0-17ubuntu1~20.04 g++-9=9.3.0-17ubuntu1~20.04 libxrandr-dev libxtst-dev libcups2-dev libasound2-dev
+          sudo apt-get install openjdk-8-jdk gcc-9 g++-9 libxrandr-dev libxtst-dev libcups2-dev libasound2-dev
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 100 --slave /usr/bin/g++ g++ /usr/bin/g++-9
 
       - name: Configure
@@ -439,12 +439,12 @@ jobs:
 
       - name: Install native host dependencies
         run: |
-          sudo apt-get install openjdk-8-jdk gcc-9=9.3.0-17ubuntu1~20.04 g++-9=9.3.0-17ubuntu1~20.04 libxrandr-dev libxtst-dev libcups2-dev libasound2-dev
+          sudo apt-get install openjdk-8-jdk gcc-9 g++-9 libxrandr-dev libxtst-dev libcups2-dev libasound2-dev
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 100 --slave /usr/bin/g++ g++ /usr/bin/g++-9
         if: matrix.debian-arch == ''
 
       - name: Install cross-compilation host dependencies
-        run: sudo apt-get install gcc-9-${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-flavor}}=9.3.0-17ubuntu1~20.04cross2 g++-9-${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-flavor}}=9.3.0-17ubuntu1~20.04cross2
+        run: sudo apt-get install gcc-9-${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-flavor}} g++-9-${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-flavor}}
         if: matrix.debian-arch != ''
 
       - name: Cache sysroot


### PR DESCRIPTION
Major versions of GCC often cause problems with OpenJDK. Fedora's eager adoption of them means we often encounter these early. [JDK-8282231](https://bugs.openjdk.java.net/browse/JDK-8282231) is just the latest example from the introduction of GCC 12.

However, the GHA workflow in OpenJDK doesn't just depend on a major version of GCC - which is actually contained in the Ubuntu package name of `gcc-9` itself - but the full revision number, even down to local packaging changes.

I believe this is overkill and leads to valuable time being wasted on issues like [JDK-8283778](https://bugs.openjdk.java.net/browse/JDK-8283778) where the GCC version itself didn't change at all, just the Ubuntu version suffix.

Rather than maintain this for 8u, I suggest we just depend on `gcc-9` which is already a pretty modern version for 8u. I have yet to see an issue be specific to a minor GCC version bump, whereas the current setup is pretty much guaranteed to mean further fixes to the GitHub workflow every time the Ubuntu packager produces a new build.

Note that the x86-32 Linux build already uses just `gcc-9-multilib` which is why it hasn't been broken by the latest GCC update.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284772](https://bugs.openjdk.java.net/browse/JDK-8284772): 8u GHA: Use GCC Major Version Dependencies Only


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk8u-dev pull/35/head:pull/35` \
`$ git checkout pull/35`

Update a local copy of the PR: \
`$ git checkout pull/35` \
`$ git pull https://git.openjdk.java.net/jdk8u-dev pull/35/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 35`

View PR using the GUI difftool: \
`$ git pr show -t 35`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk8u-dev/pull/35.diff">https://git.openjdk.java.net/jdk8u-dev/pull/35.diff</a>

</details>
