### PR TITLE
8260589: Crash in JfrTraceIdLoadBarrier::load(_jclass*)

### DIFF
--- a/hotspot/src/share/vm/jfr/recorder/checkpoint/types/traceid/jfrTraceId.cpp
+++ b/hotspot/src/share/vm/jfr/recorder/checkpoint/types/traceid/jfrTraceId.cpp
@@ -45,7 +45,7 @@ static traceid atomic_inc(traceid volatile* const dest) {
 }
 
 static traceid next_class_id() {
-  static volatile traceid class_id_counter = MaxJfrEventId + 100;
+  static volatile traceid class_id_counter = MaxJfrEventId + 101; // + 101 is for the void.class primitive;
   return atomic_inc(&class_id_counter) << TRACE_ID_SHIFT;
 }
 
@@ -107,6 +107,10 @@ void JfrTraceId::assign(const ClassLoaderData* cld) {
   cld->set_trace_id(next_class_loader_data_id());
 }
 
+traceid JfrTraceId::assign_primitive_klass_id() {
+  return next_class_id();
+}
+
 traceid JfrTraceId::assign_thread_id() {
   return next_thread_id();
 }
@@ -130,6 +134,28 @@ void JfrTraceId::restore(const Klass* k) {
   const traceid event_flags = k->trace_id();
   // get a fresh traceid and restore the original event flags
   k->set_trace_id(next_class_id() | event_flags);
+  if (k->oop_is_typeArray()) {
+    // the next id is reserved for the corresponding primitive class
+    next_class_id();
+  }
+}
+
+// A mirror representing a primitive class (e.g. int.class) has no reified Klass*,
+// instead it has an associated TypeArrayKlass* (e.g. int[].class).
+// We can use the TypeArrayKlass* as a proxy for deriving the id of the primitive class.
+// The exception is the void.class, which has neither a Klass* nor a TypeArrayKlass*.
+// It will use a reserved constant.
+static traceid load_primitive(const oop mirror) {
+  assert(java_lang_Class::is_primitive(mirror), "invariant");
+  const Klass* const tak = java_lang_Class::array_klass(mirror);
+  traceid id;
+  if (tak == NULL) {
+    // The first klass id is reserved for the void.class
+    id = MaxJfrEventId + 101;
+  } else {
+    id = JfrTraceId::get(tak) + 1;
+  }
+  return id;
 }
 
 traceid JfrTraceId::get(jclass jc) {
@@ -145,7 +171,8 @@ traceid JfrTraceId::use(jclass jc, bool leakp /* false */) {
   assert(((JavaThread*)Thread::current())->thread_state() == _thread_in_vm, "invariant");
   const oop my_oop = JNIHandles::resolve(jc);
   assert(my_oop != NULL, "invariant");
-  return use(java_lang_Class::as_Klass(my_oop), leakp);
+  const Klass* const k = java_lang_Class::as_Klass(my_oop);
+  return k != NULL ? use(k, leakp) : load_primitive(my_oop);
 }
 
 bool JfrTraceId::in_visible_set(const jclass jc) {

--- a/hotspot/src/share/vm/jfr/recorder/checkpoint/types/traceid/jfrTraceId.hpp
+++ b/hotspot/src/share/vm/jfr/recorder/checkpoint/types/traceid/jfrTraceId.hpp
@@ -77,6 +77,7 @@ class JfrTraceId : public AllStatic {
  public:
   static void assign(const Klass* klass);
   static void assign(const ClassLoaderData* cld);
+  static traceid assign_primitive_klass_id();
   static traceid assign_thread_id();
 
   static traceid get(const Klass* klass);

--- a/hotspot/src/share/vm/jfr/support/jfrTraceIdExtension.hpp
+++ b/hotspot/src/share/vm/jfr/support/jfrTraceIdExtension.hpp
@@ -38,6 +38,7 @@
   static size_t trace_id_size() { return sizeof(traceid); }
 
 #define INIT_ID(data) JfrTraceId::assign(data)
+#define ASSIGN_PRIMITIVE_CLASS_ID(data) JfrTraceId::assign_primitive_klass_id()
 #define REMOVE_ID(k) JfrTraceId::remove(k);
 #define RESTORE_ID(k) JfrTraceId::restore(k);
 

--- a/hotspot/src/share/vm/oops/typeArrayKlass.cpp
+++ b/hotspot/src/share/vm/oops/typeArrayKlass.cpp
@@ -68,6 +68,7 @@ TypeArrayKlass* TypeArrayKlass::create_klass(BasicType type,
   // including classes in the bootstrap (NULL) class loader.
   // GC walks these as strong roots.
   null_loader_data->add_class(ak);
+  JFR_ONLY(ASSIGN_PRIMITIVE_CLASS_ID(ak);)
 
   // Call complete_create_array_klass after all instance variables have been initialized.
   complete_create_array_klass(ak, ak->super(), CHECK_NULL);

--- a/jdk/test/jdk/jfr/jvm/TestPrimitiveClasses.java
+++ b/jdk/test/jdk/jfr/jvm/TestPrimitiveClasses.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2021, Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.jfr.jvm;
+
+import java.util.List;
+
+import jdk.jfr.Event;
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedClass;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.test.lib.Asserts;
+import jdk.test.lib.jfr.Events;
+
+/**
+ * @test TestPrimitiveClasses
+ * @key jfr
+ * @library /lib /
+ * @run main/othervm jdk.jfr.jvm.TestPrimitiveClasses
+ */
+public class TestPrimitiveClasses {
+
+    private static class MyEvent extends Event {
+        Class<?> booleanClass = boolean.class;
+        Class<?> charClass = char.class;
+        Class<?> floatClass = float.class;
+        Class<?> doubleClass = double.class;
+        Class<?> byteClass = byte.class;
+        Class<?> shortClass = short.class;
+        Class<?> intClass = int.class;
+        Class<?> longClass = long.class;
+        Class<?> voidClass = void.class;
+    }
+
+    public static void main(String[] args) throws Exception {
+        try (Recording r = new Recording()) {
+            r.enable(MyEvent.class);
+            r.start();
+            MyEvent myEvent = new MyEvent();
+            myEvent.commit();
+            r.stop();
+            List<RecordedEvent> events = Events.fromRecording(r);
+            Events.hasEvents(events);
+            RecordedEvent event = events.get(0);
+            System.out.println(event);
+            testField(event, "booleanClass", boolean.class);
+            testField(event, "charClass", char.class);
+            testField(event, "floatClass", float.class);
+            testField(event, "doubleClass", double.class);
+            testField(event, "byteClass", byte.class);
+            testField(event, "shortClass", short.class);
+            testField(event, "intClass", int.class);
+            testField(event, "longClass", long.class);
+            testField(event, "voidClass", void.class);
+        }
+    }
+
+    private static void testField(RecordedEvent event, String fieldName, Class<?> expected) {
+        Asserts.assertTrue(event.hasField(fieldName));
+        RecordedClass classField = event.getValue(fieldName);
+        Asserts.assertEquals(classField.getName(), expected.getName());
+        Asserts.assertEquals(classField.getClassLoader().getName(), "<bootloader>");
+        Asserts.assertEquals(classField.getModifiers(), expected.getModifiers());
+    }
+}


### PR DESCRIPTION
Hi!

Please review the backport of JDK-8260589 to 8u.
This crash problem is easy to reproduce, so I feel it is necessary to backport it to 8u.

3 months ago, I launched webrev and it has been reviewed by Zhengyu Gu ([the review mail link](https://mail.openjdk.java.net/pipermail/jdk8u-dev/2022-March/014715.html)), thanks a lot to Zhengyu and Mario.
Recently, I learned that the review method of 8u was changed to github, so I re-launched it in the new way.

Bug: https://bugs.openjdk.java.net/browse/JDK-8260589
11u commit: https://github.com/openjdk/jdk11u-dev/commit/1d204c554ffe969567161cc05992486ff47d346d
Test: jdk/test/jdk/jfr/jvm/TestPrimitiveClasses.java passed.

Due to the differences between JFR in 11u and 17, Denghui made some changes when backporting this fix to 11u. 
Denghui's changes also apply to 8u, so I directly quote Denghui's list here. (4 in total)
1. use MaxJfrEventId + 101 instead of LAST_TYPE_ID + 1 as the klass id of void.class
2. jdk 11 doesn't support jfr streaming, so I removed the call `JfrTraceIdEpoch::set_changed_tag_state()` in `load_primitive`
3. the Class in jdk 11 doesn't have the field 'hidden', so I removed `writer->write<bool>(false);` in `write_primitive`
4. there are many differences in the API of JfrTraceId between 11u and tip

In addition to the above differences, I also make supplementary explanations for the modifications I made.
1. The static global variable clear_artifacts in 11u was introduced by the bugfix https://bugs.openjdk.java.net/browse/JDK-8231081, but this fix has not been backported to 8u, so I removed the code related to clear_artifacts. In 8u, the metadata of the primitive types will be written into the previous chunk on every chunk rotation.
2. In 11u, _artifacts and _class_unload are static global variables, but in 8u, they are static member variables of JfrTypeSet, so I also made necessary changes to the functions that use these two variables.

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8260589](https://bugs.openjdk.org/browse/JDK-8260589): Crash in JfrTraceIdLoadBarrier::load(_jclass*)


### Reviewers
 * [Zhengyu Gu](https://openjdk.org/census#zgu) (@zhengyu123 - **Reviewer**) ⚠️ Review applies to [1ca0c4a5](https://git.openjdk.org/jdk8u-dev/pull/36/files/1ca0c4a5ec5d72c4a37c70565d19a4942c20df3b)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/36/head:pull/36` \
`$ git checkout pull/36`

Update a local copy of the PR: \
`$ git checkout pull/36` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/36/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 36`

View PR using the GUI difftool: \
`$ git pr show -t 36`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/36.diff">https://git.openjdk.org/jdk8u-dev/pull/36.diff</a>

</details>
