### PR TITLE
8275811: Incorrect instance to dispose

### DIFF
--- a/jdk/src/share/classes/sun/security/ssl/InputRecord.java
+++ b/jdk/src/share/classes/sun/security/ssl/InputRecord.java
@@ -100,7 +100,7 @@ abstract class InputRecord implements Record, Closeable {
          * Since MAC's doFinal() is called for every SSL/TLS packet, it's
          * not necessary to do the same with MAC's.
          */
-        readCipher.dispose();
+        this.readCipher.dispose();
 
         this.readCipher = readCipher;
     }

--- a/jdk/src/share/classes/sun/security/ssl/OutputRecord.java
+++ b/jdk/src/share/classes/sun/security/ssl/OutputRecord.java
@@ -123,6 +123,11 @@ abstract class OutputRecord
     // SSLEngine and SSLSocket
     abstract void encodeChangeCipherSpec() throws IOException;
 
+    // SSLEngine and SSLSocket
+    void disposeWriteCipher() {
+        throw new UnsupportedOperationException();
+    }
+
     // apply to SSLEngine only
     Ciphertext encode(
         ByteBuffer[] srcs, int srcsOffset, int srcsLength,
@@ -170,7 +175,7 @@ abstract class OutputRecord
          * Since MAC's doFinal() is called for every SSL/TLS packet, it's
          * not necessary to do the same with MAC's.
          */
-        writeCipher.dispose();
+        disposeWriteCipher();
 
         this.writeCipher = writeCipher;
         this.isFirstAppOutputRecord = true;
@@ -194,7 +199,7 @@ abstract class OutputRecord
         flush();
 
         // Dispose of any intermediate state in the underlying cipher.
-        writeCipher.dispose();
+        disposeWriteCipher();
 
         this.writeCipher = writeCipher;
         this.isFirstAppOutputRecord = true;

--- a/jdk/src/share/classes/sun/security/ssl/SSLSocketOutputRecord.java
+++ b/jdk/src/share/classes/sun/security/ssl/SSLSocketOutputRecord.java
@@ -231,6 +231,11 @@ final class SSLSocketOutputRecord extends OutputRecord implements SSLRecord {
     }
 
     @Override
+    void disposeWriteCipher() {
+        writeCipher.dispose();
+    }
+
+    @Override
     public synchronized void flush() throws IOException {
         int position = headerSize + writeCipher.getExplicitNonceSize();
         if (count <= position) {


### PR DESCRIPTION
I would like to backport this patch for parity with Oracle 8u331.

Bug: https://bugs.openjdk.java.net/browse/JDK-8275811
Patch: https://github.com/openjdk/jdk/commit/cddc6ce44695cba4614c3405eb2b194d7c76489b

The original patch does not apply cleanly to 8u. The only conflicts are 
in `OutputRecord.java`, due to line shifts. Resolved manually.

Origin code review thread: https://mail.openjdk.java.net/pipermail/jdk8u-dev/2021-December/014478.html

Test:

- [x] jdk_security, no new failure

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8275811](https://bugs.openjdk.java.net/browse/JDK-8275811): Incorrect instance to dispose ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk8u-dev pull/38/head:pull/38` \
`$ git checkout pull/38`

Update a local copy of the PR: \
`$ git checkout pull/38` \
`$ git pull https://git.openjdk.java.net/jdk8u-dev pull/38/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 38`

View PR using the GUI difftool: \
`$ git pr show -t 38`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk8u-dev/pull/38.diff">https://git.openjdk.java.net/jdk8u-dev/pull/38.diff</a>

</details>
