### PR TITLE
8186902: jcmd GC.run should not be blocked by DisableExplicitGC

### DIFF
--- a/hotspot/src/share/vm/services/diagnosticCommand.cpp
+++ b/hotspot/src/share/vm/services/diagnosticCommand.cpp
@@ -263,11 +263,7 @@ int VMUptimeDCmd::num_arguments() {
 }
 
 void SystemGCDCmd::execute(DCmdSource source, TRAPS) {
-  if (!DisableExplicitGC) {
-    Universe::heap()->collect(GCCause::_java_lang_system_gc);
-  } else {
-    output()->print_cr("Explicit GC is disabled, no GC has been performed.");
-  }
+  Universe::heap()->collect(GCCause::GCCause::_java_lang_system_gc);
 }
 
 void RunFinalizationDCmd::execute(DCmdSource source, TRAPS) {


### PR DESCRIPTION
I would like to backport this parity bug to openjdk8u.

Original bug: https://bugs.openjdk.java.net/browse/JDK-8186902
Original patch: 
[http://hg.openjdk.java.net/jdk10/jdk10/hotspot/rev/3d1150c7899c](https://hg.openjdk.java.net/jdk10/jdk10/hotspot/rev/3d1150c7899c)


The original patch does not apply cleanly. Besides line shifts, 8u does 
not define `GCCause::_dcmd_gc_run`, but `GCCause::_java_lang_system_gc` instead.

Original code review thread: https://mail.openjdk.java.net/pipermail/jdk8u-dev/2021-September/014288.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8186902](https://bugs.openjdk.java.net/browse/JDK-8186902): jcmd GC.run should not be blocked by DisableExplicitGC ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk8u-dev pull/40/head:pull/40` \
`$ git checkout pull/40`

Update a local copy of the PR: \
`$ git checkout pull/40` \
`$ git pull https://git.openjdk.java.net/jdk8u-dev pull/40/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 40`

View PR using the GUI difftool: \
`$ git pr show -t 40`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk8u-dev/pull/40.diff">https://git.openjdk.java.net/jdk8u-dev/pull/40.diff</a>

</details>
