### PR TITLE
8129940: JRadioButton does not honor non-standard FocusTraversalKeys

### DIFF
--- a/jdk/src/share/classes/javax/swing/plaf/basic/BasicRadioButtonUI.java
+++ b/jdk/src/share/classes/javax/swing/plaf/basic/BasicRadioButtonUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import sun.swing.SwingUtilities2;
 import sun.awt.AppContext;
 import java.util.Enumeration;
 import java.util.HashSet;
+import java.util.Set;
 
 /**
  * RadioButtonUI implementation for BasicRadioButtonUI
@@ -587,21 +588,30 @@ public class BasicRadioButtonUI extends BasicToggleButtonUI
      */
     private class KeyHandler implements KeyListener {
 
-        // This listener checks if the key event is a KeyEvent.VK_TAB
-        // or shift + KeyEvent.VK_TAB event on a radio button, consume the event
-        // if so and move the focus to next/previous component
+        // This listener checks if the key event is a focus traversal key event
+        // on a radio button, consume the event if so and move the focus
+        // to next/previous component
         public void keyPressed(KeyEvent e) {
-            if (e.getKeyCode() == KeyEvent.VK_TAB) {
-                 // Get the source of the event.
-                Object eventSrc = e.getSource();
-
-                // Check whether the source is a visible and enabled JRadioButton
-                if (isValidRadioButtonObj(eventSrc)) {
+            AWTKeyStroke stroke = AWTKeyStroke.getAWTKeyStrokeForEvent(e);
+            if (stroke != null && e.getSource() instanceof JRadioButton) {
+                JRadioButton source = (JRadioButton) e.getSource();
+                boolean next = isFocusTraversalKey(source,
+                        KeyboardFocusManager.FORWARD_TRAVERSAL_KEYS,
+                        stroke);
+                if (next || isFocusTraversalKey(source,
+                        KeyboardFocusManager.BACKWARD_TRAVERSAL_KEYS,
+                        stroke)) {
                     e.consume();
-                    ButtonGroupInfo btnGroupInfo = new ButtonGroupInfo((JRadioButton)eventSrc);
-                    btnGroupInfo.jumpToNextComponent(!e.isShiftDown());
+                    ButtonGroupInfo btnGroupInfo = new ButtonGroupInfo(source);
+                    btnGroupInfo.jumpToNextComponent(next);
                 }
             }
+        }
+
+        private boolean isFocusTraversalKey(JComponent c, int id,
+                                            AWTKeyStroke stroke) {
+            Set<AWTKeyStroke> keys = c.getFocusTraversalKeys(id);
+            return keys != null && keys.contains(stroke);
         }
 
         public void keyReleased(KeyEvent e) {

--- a/jdk/test/javax/swing/JRadioButton/FocusTraversal/FocusTraversal.java
+++ b/jdk/test/javax/swing/JRadioButton/FocusTraversal/FocusTraversal.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+   @bug 8129940
+   @summary JRadioButton does not honor non-standard FocusTraversalKeys
+   @author Semyon Sadetsky
+  */
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.KeyEvent;
+import java.util.HashSet;
+import java.util.Set;
+
+public class FocusTraversal {
+
+    private static JFrame frame;
+    private static JRadioButton a;
+    private static JRadioButton d;
+    private static JTextField next;
+    private static JTextField prev;
+
+    public static void main(String[] args) throws Exception {
+        SwingUtilities.invokeAndWait(new Runnable() {
+            @Override
+            public void run() {
+                frame = new JFrame("FocusTraversalTest");
+                frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+                frame.setUndecorated(true);
+
+                Set<KeyStroke> keystrokes = new HashSet<KeyStroke>();
+                keystrokes.add(KeyStroke.getKeyStroke("TAB"));
+                keystrokes.add(KeyStroke.getKeyStroke("ENTER"));
+                frame.setFocusTraversalKeys(
+                        KeyboardFocusManager.FORWARD_TRAVERSAL_KEYS,
+                        keystrokes);
+
+                a = new JRadioButton("a");
+                JRadioButton b = new JRadioButton("b");
+                JRadioButton c = new JRadioButton("c");
+                d = new JRadioButton("d");
+
+                ButtonGroup radioButtonGroup = new ButtonGroup();
+                radioButtonGroup.add(a);
+                radioButtonGroup.add(b);
+                radioButtonGroup.add(c);
+                radioButtonGroup.add(d);
+
+                JPanel panel = new JPanel();
+                prev = new JTextField("text");
+                panel.add(prev);
+                panel.add(a);
+                panel.add(b);
+                panel.add(c);
+                panel.add(d);
+                next = new JTextField("text");
+                panel.add(next);
+
+                JPanel root = new JPanel();
+                root.setLayout(new BorderLayout());
+                root.add(panel, BorderLayout.CENTER);
+                root.add(new JButton("OK"), BorderLayout.SOUTH);
+
+                frame.add(root);
+                frame.pack();
+                frame.setVisible(true);
+            }
+        });
+
+        SwingUtilities.invokeAndWait(new Runnable() {
+            @Override
+            public void run() {
+                a.requestFocus();
+            }
+        });
+
+        Robot robot = new Robot();
+        robot.waitForIdle();
+
+        robot.setAutoDelay(200);
+
+        robot.keyPress(KeyEvent.VK_ENTER);
+        robot.keyRelease(KeyEvent.VK_ENTER);
+        robot.waitForIdle();
+
+        SwingUtilities.invokeAndWait(new Runnable() {
+            @Override
+            public void run() {
+                Component focusOwner =
+                        FocusManager.getCurrentManager().getFocusOwner();
+                if (focusOwner != next) {
+                    throw new RuntimeException(
+                            "Focus component is wrong after forward key " + focusOwner);
+                }
+            }
+        });
+
+        robot.keyPress(KeyEvent.VK_SHIFT);
+        robot.keyPress(KeyEvent.VK_TAB);
+        robot.keyRelease(KeyEvent.VK_TAB);
+        robot.keyRelease(KeyEvent.VK_SHIFT);
+        robot.waitForIdle();
+        SwingUtilities.invokeAndWait(new Runnable() {
+            @Override
+            public void run() {
+                Component focusOwner =
+                        FocusManager.getCurrentManager().getFocusOwner();
+                if (focusOwner != d) {
+                    throw new RuntimeException(
+                            "Focus component is wrong after backward key " + focusOwner);
+                }
+            }
+        });
+        SwingUtilities.invokeLater(new Runnable() {
+            @Override
+            public void run() {
+                frame.dispose();
+            }
+        });
+        System.out.println("ok");
+
+    }
+}


### PR DESCRIPTION
I would like to backport this patch to openjdk8u for parity with Oracle 
8u311.

The original bug: https://bugs.openjdk.java.net/browse/JDK-8129940
The original patch: 
[http://hg.openjdk.java.net/jdk9/jdk9/jdk/rev/fbf897c33625](https://hg.openjdk.java.net/jdk9/jdk9/jdk/rev/fbf897c33625)

The jdk9 patch does not apply cleanly, but only conflict is copyright 
year of `BasicRadioButtonUI.java` file.

Test:
- [x] Included `FocusTraversal/FocusTraversal.java` test fails without patch and passes with it on Linux x86_64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8129940](https://bugs.openjdk.java.net/browse/JDK-8129940): JRadioButton does not honor non-standard FocusTraversalKeys ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk8u-dev pull/41/head:pull/41` \
`$ git checkout pull/41`

Update a local copy of the PR: \
`$ git checkout pull/41` \
`$ git pull https://git.openjdk.java.net/jdk8u-dev pull/41/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 41`

View PR using the GUI difftool: \
`$ git pr show -t 41`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk8u-dev/pull/41.diff">https://git.openjdk.java.net/jdk8u-dev/pull/41.diff</a>

</details>
