### PR TITLE
8266187: Memory leak in appendBootClassPath()

### DIFF
--- a/jdk/src/share/instrument/InvocationAdapter.c
+++ b/jdk/src/share/instrument/InvocationAdapter.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -829,6 +829,7 @@ appendBootClassPath( JPLISAgent* agent,
 
             resolved = resolve(parent, path);
             jvmtierr = (*jvmtienv)->AddToBootstrapClassLoaderSearch(jvmtienv, resolved);
+            free(resolved);
         }
 
         /* print warning if boot class path not updated */


### PR DESCRIPTION
Backport this patch for parity with Oracle 8u331. It fixes a memory leak 
and risk is low,

Bug: https://bugs.openjdk.java.net/browse/JDK-8266187
Patch: https://github.com/openjdk/jdk/commit/aa90df6f51940a73f9aa078a32768855c8568034

The original patch does not apply cleanly. The conflict is copyright year line. Resolved manually.

The original code review thread: https://mail.openjdk.java.net/pipermail/jdk8u-dev/2021-December/014484.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8266187](https://bugs.openjdk.java.net/browse/JDK-8266187): Memory leak in appendBootClassPath()


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk8u-dev pull/42/head:pull/42` \
`$ git checkout pull/42`

Update a local copy of the PR: \
`$ git checkout pull/42` \
`$ git pull https://git.openjdk.java.net/jdk8u-dev pull/42/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 42`

View PR using the GUI difftool: \
`$ git pr show -t 42`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk8u-dev/pull/42.diff">https://git.openjdk.java.net/jdk8u-dev/pull/42.diff</a>

</details>
