### PR TITLE
8146215: (fs) java/nio/file/Files/probeContentType/Basic.java failed frequently on Solaris-sparc with Unexpected type: text/plain

### DIFF
--- a/jdk/src/share/classes/java/net/URLConnection.java
+++ b/jdk/src/share/classes/java/net/URLConnection.java
@@ -285,12 +285,7 @@ public abstract class URLConnection {
    /**
     * @since   JDK1.1
     */
-    private static FileNameMap fileNameMap;
-
-    /**
-     * @since 1.2.2
-     */
-    private static boolean fileNameMapLoaded = false;
+    private static volatile FileNameMap fileNameMap;
 
     /**
      * Loads filename map (a mimetable) from a data file. It will
@@ -302,18 +297,21 @@ public abstract class URLConnection {
      * @since 1.2
      * @see #setFileNameMap(java.net.FileNameMap)
      */
-    public static synchronized FileNameMap getFileNameMap() {
-        if ((fileNameMap == null) && !fileNameMapLoaded) {
-            fileNameMap = sun.net.www.MimeTable.loadTable();
-            fileNameMapLoaded = true;
+    public static FileNameMap getFileNameMap() {
+        FileNameMap map = fileNameMap;
+
+        if (map == null) {
+            fileNameMap = map = new FileNameMap() {
+                private FileNameMap internalMap =
+                    sun.net.www.MimeTable.loadTable();
+
+                public String getContentTypeFor(String fileName) {
+                    return internalMap.getContentTypeFor(fileName);
+                }
+            };
         }
 
-        return new FileNameMap() {
-            private FileNameMap map = fileNameMap;
-            public String getContentTypeFor(String fileName) {
-                return map.getContentTypeFor(fileName);
-            }
-        };
+        return map;
     }
 
     /**

--- a/jdk/src/share/classes/sun/nio/fs/AbstractFileTypeDetector.java
+++ b/jdk/src/share/classes/sun/nio/fs/AbstractFileTypeDetector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package sun.nio.fs;
 
+import java.net.FileNameMap;
+import java.net.URLConnection;
 import java.nio.file.Path;
 import java.nio.file.spi.FileTypeDetector;
 import java.util.Locale;
@@ -50,6 +52,16 @@ public abstract class AbstractFileTypeDetector
         if (file == null)
             throw new NullPointerException("'file' is null");
         String result = implProbeContentType(file);
+
+        // Fall back to content types property.
+        if (result == null) {
+            Path fileName = file.getFileName();
+            if (fileName != null) {
+                FileNameMap fileNameMap = URLConnection.getFileNameMap();
+                result = fileNameMap.getContentTypeFor(fileName.toString());
+            }
+        }
+
         return (result == null) ? null : parse(result);
     }
 

--- a/jdk/test/java/nio/file/Files/probeContentType/Basic.java
+++ b/jdk/test/java/nio/file/Files/probeContentType/Basic.java
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 4313887
+ * @bug 4313887 8129632 8129633 8162624 8146215
  * @summary Unit test for probeContentType method
  * @library ../..
  * @build Basic SimpleFileTypeDetector
@@ -38,7 +38,6 @@ import java.util.stream.Stream;
  * set of file extension to content type mappings.
  */
 public class Basic {
-
     private static final boolean IS_UNIX =
         ! System.getProperty("os.name").startsWith("Windows");
 
@@ -55,6 +54,23 @@ public class Basic {
         return Files.createTempFile("red", ".grape");
     }
 
+    private static void checkMimeTypesFile(Path mimeTypes) {
+        if (!Files.exists(mimeTypes)) {
+            System.out.println(mimeTypes + " does not exist");
+        } else if (!Files.isReadable(mimeTypes)) {
+            System.out.println(mimeTypes + " is not readable");
+        } else {
+            System.out.println(mimeTypes + " contents:");
+            try (Stream<String> lines = Files.lines(mimeTypes)) {
+                lines.forEach(System.out::println);
+                System.out.println("");
+            } catch (IOException ioe) {
+                System.err.printf("Problem reading %s: %s%n",
+                                  mimeTypes, ioe.getMessage());
+            }
+        }
+    }
+
     private static int checkContentTypes(String expected, String actual) {
         assert expected != null;
         assert actual != null;
@@ -63,36 +79,10 @@ public class Basic {
             if (IS_UNIX) {
                 Path userMimeTypes =
                     Paths.get(System.getProperty("user.home"), ".mime.types");
-                if (!Files.exists(userMimeTypes)) {
-                    System.out.println(userMimeTypes + " does not exist");
-                } else if (!Files.isReadable(userMimeTypes)) {
-                    System.out.println(userMimeTypes + " is not readable");
-                } else {
-                    System.out.println(userMimeTypes + " contents:");
-                    try (Stream<String> lines = Files.lines(userMimeTypes)) {
-                        lines.forEach(System.out::println);
-                        System.out.println("");
-                    } catch (IOException ioe) {
-                        System.err.println("Problem reading "
-                                           + userMimeTypes);
-                    }
-                }
+                checkMimeTypesFile(userMimeTypes);
 
                 Path etcMimeTypes = Paths.get("/etc/mime.types");
-                if (!Files.exists(etcMimeTypes)) {
-                    System.out.println(etcMimeTypes + " does not exist");
-                } else if (!Files.isReadable(etcMimeTypes)) {
-                    System.out.println(etcMimeTypes + " is not readable");
-                } else {
-                    System.out.println(etcMimeTypes + " contents:");
-                    try (Stream<String> lines = Files.lines(etcMimeTypes)) {
-                        lines.forEach(System.out::println);
-                        System.out.println("");
-                    } catch (IOException ioe) {
-                        System.err.println("Problem reading "
-                                           + etcMimeTypes);
-                    }
-                }
+                checkMimeTypesFile(etcMimeTypes);
             }
 
             System.err.println("Expected \"" + expected
@@ -125,9 +115,12 @@ public class Basic {
         file = createGrapeFile();
         try {
             String type = Files.probeContentType(file);
-            if (type == null)
-                throw new RuntimeException("Custom file type detector not installed?");
-            failures += checkContentTypes("grape/unknown", type);
+            if (type == null) {
+                System.err.println("Custom file type detector not installed?");
+                failures++;
+            } else {
+                failures += checkContentTypes("grape/unknown", type);
+            }
         } finally {
             Files.delete(file);
         }


### PR DESCRIPTION
Backport of a NIO fix.

Original commit on jdk9: https://hg.openjdk.java.net/jdk9/jdk9/jdk/rev/44bb7c7997ca

Patch does not apply cleanly, differences from original commit: paths reshuffling, copyright year in
AbstractFileTypeDetector.java, list of issues numbers changed and checkOSXContentTypes() function removed in Basic.java test.

Related mailing list threads:

https://mail.openjdk.java.net/pipermail/jdk8u-dev/2020-June/012050.html
https://mail.openjdk.java.net/pipermail/jdk8u-dev/2021-October/014321.html

Testing:

 - [x] jtreg:java/nio/file/Files/
 - [x] jtreg:java/net/URLConnection/

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8146215](https://bugs.openjdk.java.net/browse/JDK-8146215): (fs) java/nio/file/Files/probeContentType/Basic.java failed frequently on Solaris-sparc with Unexpected type: text/plain


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk8u-dev pull/44/head:pull/44` \
`$ git checkout pull/44`

Update a local copy of the PR: \
`$ git checkout pull/44` \
`$ git pull https://git.openjdk.java.net/jdk8u-dev pull/44/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 44`

View PR using the GUI difftool: \
`$ git pr show -t 44`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk8u-dev/pull/44.diff">https://git.openjdk.java.net/jdk8u-dev/pull/44.diff</a>

</details>
