### PR TITLE
8280963: Incorrect PrintFlags formatting on Windows

### DIFF
--- a/hotspot/src/share/vm/runtime/globals.cpp
+++ b/hotspot/src/share/vm/runtime/globals.cpp
@@ -303,13 +303,13 @@ void Flag::print_on(outputStream* st, bool withComments) {
     st->print("%-16s", get_bool() ? "true" : "false");
   }
   if (is_intx()) {
-    st->print("%-16ld", get_intx());
+    st->print(INTX_FORMAT_W(-16), get_intx());
   }
   if (is_uintx()) {
-    st->print("%-16lu", get_uintx());
+    st->print(UINTX_FORMAT_W(-16), get_uintx());
   }
   if (is_uint64_t()) {
-    st->print("%-16lu", get_uint64_t());
+    st->print(UINT64_FORMAT_W(-16), get_uint64_t());
   }
   if (is_double()) {
     st->print("%-16f", get_double());

--- a/hotspot/test/runtime/CommandLine/PrintFlagsUintxTest.java
+++ b/hotspot/test/runtime/CommandLine/PrintFlagsUintxTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8280963
+ * @summary "%-16lu" formatting string is used to format uintx (uintptr_t)
+ *          flag values for output. uintx is 64-bit on win64, and "lu" format
+ *          is intended to be used with unsigned long that is 32-bit on win64.
+ *          Thus flag values that are exact multiple of 4 GiB will be formatted
+ *          into 0 in PrintFlags output.
+ * @library /testlibrary
+ */
+
+import com.oracle.java.testlibrary.*;
+
+public class PrintFlagsUintxTest {
+    public static void main(String[] args) throws Exception {
+        if (!Platform.is64bit()) {
+            System.out.println("Test needs a 4GB heap and can only be run as a 64bit process, skipping.");
+            return;
+        }
+
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                "-Xmx4g", "-XX:+PrintFlagsFinal", "-version");
+
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.stdoutShouldMatch(".*MaxHeapSize\\s+:= 4294967296\\s+.*");
+    }
+}


### PR DESCRIPTION
A fix to 8u-only Windows-specific problem with -XX:+PrintFlags* output.

Problem description on Stack Overflow by Andrei Pangin: https://stackoverflow.com/a/63309395

The problem was fixed in jdk9 as part of [JDK-8042893](https://bugs.openjdk.java.net/browse/JDK-8042893), but this [jdk9 change](https://hg.openjdk.java.net/jdk9/jdk9/hotspot/rev/115188e14c15) doesn't look like a good candidate for the 8u backport according to [8u Best Practices](https://mail.openjdk.java.net/pipermail/jdk8u-dev/2020-June/012002.html). Still the problem manifests itself as a customer-visible bug on Windows because people do use -XX:+PrintFlagsFinal to find out the actual flags picked up by JVM and can be confused by unexpected zeros in the output. Proposed patch cherry-picks the minimal change from [JDK-8042893 commit](https://hg.openjdk.java.net/jdk9/jdk9/hotspot/rev/115188e14c15#l53.1).

Mailing list review: https://mail.openjdk.java.net/pipermail/jdk8u-dev/2022-February/014532.html

Testing:

 - [x] regression test is included with the proposed patch
 - [x] checked that it builds on Windows 64-bit and 32-bit on VS2017 and VS2010
 - [x] ran jtreg:hotspot/test/runtime on Windows and Linux

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280963](https://bugs.openjdk.org/browse/JDK-8280963): Incorrect PrintFlags formatting on Windows


### Reviewers
 * [Andrew John Hughes](https://openjdk.java.net/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/45/head:pull/45` \
`$ git checkout pull/45`

Update a local copy of the PR: \
`$ git checkout pull/45` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/45/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 45`

View PR using the GUI difftool: \
`$ git pr show -t 45`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/45.diff">https://git.openjdk.org/jdk8u-dev/pull/45.diff</a>

</details>
