### PR TITLE
8166140: C1: Possible integer overflow in LIRGenerator::generate_address on several platforms

### DIFF
--- a/hotspot/src/cpu/aarch64/vm/c1_LIRGenerator_aarch64.cpp
+++ b/hotspot/src/cpu/aarch64/vm/c1_LIRGenerator_aarch64.cpp
@@ -140,10 +140,11 @@ LIR_Opr LIRGenerator::safepoint_poll_register() {
 LIR_Address* LIRGenerator::generate_address(LIR_Opr base, LIR_Opr index,
                                             int shift, int disp, BasicType type) {
   assert(base->is_register(), "must be");
+  intx large_disp = disp;
 
   // accumulate fixed displacements
   if (index->is_constant()) {
-    disp += index->as_constant_ptr()->as_jint() << shift;
+    large_disp += (intx)(index->as_constant_ptr()->as_jint()) << shift;
     index = LIR_OprFact::illegalOpr;
   }
 
@@ -154,31 +155,31 @@ LIR_Address* LIRGenerator::generate_address(LIR_Opr base, LIR_Opr index,
       __ shift_left(index, shift, tmp);
       index = tmp;
     }
-    if (disp != 0) {
+    if (large_disp != 0) {
       LIR_Opr tmp = new_pointer_register();
-      if (Assembler::operand_valid_for_add_sub_immediate(disp)) {
-        __ add(tmp, tmp, LIR_OprFact::intptrConst(disp));
+      if (Assembler::operand_valid_for_add_sub_immediate(large_disp)) {
+        __ add(tmp, tmp, LIR_OprFact::intptrConst(large_disp));
         index = tmp;
       } else {
-        __ move(tmp, LIR_OprFact::intptrConst(disp));
+        __ move(tmp, LIR_OprFact::intptrConst(large_disp));
         __ add(tmp, index, tmp);
         index = tmp;
       }
-      disp = 0;
+      large_disp = 0;
     }
-  } else if (disp != 0 && !Address::offset_ok_for_immed(disp, shift)) {
+  } else if (large_disp != 0 && !Address::offset_ok_for_immed(large_disp, shift)) {
     // index is illegal so replace it with the displacement loaded into a register
     index = new_pointer_register();
-    __ move(LIR_OprFact::intptrConst(disp), index);
-    disp = 0;
+    __ move(LIR_OprFact::intptrConst(large_disp), index);
+    large_disp = 0;
   }
 
   // at this point we either have base + index or base + displacement
-  if (disp == 0) {
+  if (large_disp == 0) {
     return new LIR_Address(base, index, type);
   } else {
-    assert(Address::offset_ok_for_immed(disp, 0), "must be");
-    return new LIR_Address(base, disp, type);
+    assert(Address::offset_ok_for_immed(large_disp, 0), "must be");
+    return new LIR_Address(base, large_disp, type);
   }
 }
 
@@ -192,7 +193,7 @@ LIR_Address* LIRGenerator::emit_array_address(LIR_Opr array_opr, LIR_Opr index_o
   LIR_Address* addr;
   if (index_opr->is_constant()) {
     addr = new LIR_Address(array_opr,
-                           offset_in_bytes + index_opr->as_jint() * elem_size, type);
+                           offset_in_bytes + (intx)(index_opr->as_jint()) * elem_size, type);
   } else {
 // #ifdef _LP64
 //     if (index_opr->type() == T_INT) {

--- a/hotspot/src/cpu/sparc/vm/c1_LIRGenerator_sparc.cpp
+++ b/hotspot/src/cpu/sparc/vm/c1_LIRGenerator_sparc.cpp
@@ -146,10 +146,11 @@ LIR_Opr LIRGenerator::safepoint_poll_register() {
 LIR_Address* LIRGenerator::generate_address(LIR_Opr base, LIR_Opr index,
                                             int shift, int disp, BasicType type) {
   assert(base->is_register(), "must be");
+  intx large_disp = disp;
 
   // accumulate fixed displacements
   if (index->is_constant()) {
-    disp += index->as_constant_ptr()->as_jint() << shift;
+    large_disp += (intx)(index->as_constant_ptr()->as_jint()) << shift;
     index = LIR_OprFact::illegalOpr;
   }
 
@@ -160,31 +161,31 @@ LIR_Address* LIRGenerator::generate_address(LIR_Opr base, LIR_Opr index,
       __ shift_left(index, shift, tmp);
       index = tmp;
     }
-    if (disp != 0) {
+    if (large_disp != 0) {
       LIR_Opr tmp = new_pointer_register();
-      if (Assembler::is_simm13(disp)) {
-        __ add(tmp, LIR_OprFact::intptrConst(disp), tmp);
+      if (Assembler::is_simm13(large_disp)) {
+        __ add(tmp, LIR_OprFact::intptrConst(large_disp), tmp);
         index = tmp;
       } else {
-        __ move(LIR_OprFact::intptrConst(disp), tmp);
+        __ move(LIR_OprFact::intptrConst(large_disp), tmp);
         __ add(tmp, index, tmp);
         index = tmp;
       }
-      disp = 0;
+      large_disp = 0;
     }
-  } else if (disp != 0 && !Assembler::is_simm13(disp)) {
+  } else if (large_disp != 0 && !Assembler::is_simm13(large_disp)) {
     // index is illegal so replace it with the displacement loaded into a register
     index = new_pointer_register();
-    __ move(LIR_OprFact::intptrConst(disp), index);
-    disp = 0;
+    __ move(LIR_OprFact::intptrConst(large_disp), index);
+    large_disp = 0;
   }
 
   // at this point we either have base + index or base + displacement
-  if (disp == 0) {
+  if (large_disp == 0) {
     return new LIR_Address(base, index, type);
   } else {
-    assert(Assembler::is_simm13(disp), "must be");
-    return new LIR_Address(base, disp, type);
+    assert(Assembler::is_simm13(large_disp), "must be");
+    return new LIR_Address(base, large_disp, type);
   }
 }
 
@@ -195,11 +196,11 @@ LIR_Address* LIRGenerator::emit_array_address(LIR_Opr array_opr, LIR_Opr index_o
   int shift = exact_log2(elem_size);
 
   LIR_Opr base_opr;
-  int offset = arrayOopDesc::base_offset_in_bytes(type);
+  intx offset = arrayOopDesc::base_offset_in_bytes(type);
 
   if (index_opr->is_constant()) {
-    int i = index_opr->as_constant_ptr()->as_jint();
-    int array_offset = i * elem_size;
+    intx i = index_opr->as_constant_ptr()->as_jint();
+    intx array_offset = i * elem_size;
     if (Assembler::is_simm13(array_offset + offset)) {
       base_opr = array_opr;
       offset = array_offset + offset;

--- a/hotspot/src/cpu/x86/vm/c1_LIRGenerator_x86.cpp
+++ b/hotspot/src/cpu/x86/vm/c1_LIRGenerator_x86.cpp
@@ -151,7 +151,7 @@ LIR_Address* LIRGenerator::generate_address(LIR_Opr base, LIR_Opr index,
   assert(base->is_register(), "must be");
   if (index->is_constant()) {
     return new LIR_Address(base,
-                           (index->as_constant_ptr()->as_jint() << shift) + disp,
+                           ((intx)(index->as_constant_ptr()->as_jint()) << shift) + disp,
                            type);
   } else {
     return new LIR_Address(base, index, (LIR_Address::Scale)shift, disp, type);


### PR DESCRIPTION
I would like to backport this patch to 8u for parity with Oracle 8u331.

Bug: https://bugs.openjdk.java.net/browse/JDK-8166140
Patch: [http://hg.openjdk.java.net/jdk9/jdk9/hotspot/rev/f6c1ea29110e](https://hg.openjdk.java.net/jdk9/jdk9/hotspot/rev/f6c1ea29110e)

The patch does not apply cleanly:
1. ppc does not have compiler port in 8u.
2. Changes for `LIRGenerator::emit_array_address()` in `c1_LIRGenerator_x86.cpp` is obsoleted by [JDK-8272014](https://github.com/openjdk/jdk8u-dev/commit/3e26fd987a70473778e9ae06aa8dd5054483fa59)

Original code review thread: https://mail.openjdk.java.net/pipermail/jdk8u-dev/2022-January/014517.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8166140](https://bugs.openjdk.java.net/browse/JDK-8166140): C1: Possible integer overflow in LIRGenerator::generate_address on several platforms ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk8u-dev pull/46/head:pull/46` \
`$ git checkout pull/46`

Update a local copy of the PR: \
`$ git checkout pull/46` \
`$ git pull https://git.openjdk.java.net/jdk8u-dev pull/46/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 46`

View PR using the GUI difftool: \
`$ git pr show -t 46`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk8u-dev/pull/46.diff">https://git.openjdk.java.net/jdk8u-dev/pull/46.diff</a>

</details>
