### PR TITLE
8248876: LoadObject with bad base address created for exec file on linux

### DIFF
--- a/hotspot/agent/src/os/linux/ps_core.c
+++ b/hotspot/agent/src/os/linux/ps_core.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -802,13 +802,14 @@ static bool read_interp_segments(struct ps_prochandle* ph) {
 }
 
 // process segments of a a.out
-static bool read_exec_segments(struct ps_prochandle* ph, ELF_EHDR* exec_ehdr) {
+static uintptr_t read_exec_segments(struct ps_prochandle* ph, ELF_EHDR* exec_ehdr) {
    int i = 0;
    ELF_PHDR* phbuf = NULL;
    ELF_PHDR* exec_php = NULL;
+   uintptr_t result = 0L;
 
    if ((phbuf = read_program_header_table(ph->core->exec_fd, exec_ehdr)) == NULL)
-      return false;
+      return 0L;
 
    for (exec_php = phbuf, i = 0; i < exec_ehdr->e_phnum; i++) {
       switch (exec_php->p_type) {
@@ -839,10 +840,10 @@ static bool read_exec_segments(struct ps_prochandle* ph, ELF_EHDR* exec_ehdr) {
          // from PT_DYNAMIC we want to read address of first link_map addr
          case PT_DYNAMIC: {
             if (exec_ehdr->e_type == ET_EXEC) {
+                result = exec_php->p_vaddr;
                 ph->core->dynamic_addr = exec_php->p_vaddr;
             } else { // ET_DYN
-                // dynamic_addr has entry point of executable.
-                // Thus we should substract it.
+                result = ph->core->dynamic_addr - exec_ehdr->e_entry;
                 ph->core->dynamic_addr += exec_php->p_vaddr - exec_ehdr->e_entry;
             }
             print_debug("address of _DYNAMIC is 0x%lx\n", ph->core->dynamic_addr);
@@ -854,10 +855,10 @@ static bool read_exec_segments(struct ps_prochandle* ph, ELF_EHDR* exec_ehdr) {
    } // for
 
    free(phbuf);
-   return true;
+   return result;
 err:
    free(phbuf);
-   return false;
+   return 0L;
 }
 
 
@@ -1108,13 +1109,12 @@ struct ps_prochandle* Pgrab_core(const char* exec_file, const char* core_file) {
   }
 
   // process exec file segments
-  if (read_exec_segments(ph, &exec_ehdr) != true) {
+  uintptr_t exec_base_addr = read_exec_segments(ph, &exec_ehdr);
+  if (exec_base_addr == 0L) {
     goto err;
   }
-
-  // exec file is also treated like a shared object for symbol search
-  if (add_lib_info_fd(ph, exec_file, ph->core->exec_fd,
-                      (uintptr_t)0 + find_base_address(ph->core->exec_fd, &exec_ehdr)) == NULL) {
+  print_debug("exec_base_addr = 0x%lx\n", exec_base_addr);
+  if (add_lib_info_fd(ph, exec_file, ph->core->exec_fd, exec_base_addr) == NULL) {
     goto err;
   }
 

--- a/hotspot/agent/src/os/linux/ps_core.c
+++ b/hotspot/agent/src/os/linux/ps_core.c
@@ -802,6 +802,7 @@ static bool read_interp_segments(struct ps_prochandle* ph) {
 }
 
 // process segments of a a.out
+// returns base address of executable.
 static uintptr_t read_exec_segments(struct ps_prochandle* ph, ELF_EHDR* exec_ehdr) {
    int i = 0;
    ELF_PHDR* phbuf = NULL;

--- a/hotspot/agent/src/share/classes/sun/jvm/hotspot/debugger/linux/LinuxCDebugger.java
+++ b/hotspot/agent/src/share/classes/sun/jvm/hotspot/debugger/linux/LinuxCDebugger.java
@@ -68,7 +68,7 @@ class LinuxCDebugger implements CDebugger {
       LoadObject ob = (LoadObject) objs.get(i);
       Address base = ob.getBase();
       long size = ob.getSize();
-      if ( pc.greaterThanOrEqual(base) && pc.lessThan(base.addOffsetTo(size))) {
+      if (pc.greaterThanOrEqual(base) && pc.lessThan(base.addOffsetTo(size))) {
         return ob;
       }
     }

--- a/hotspot/agent/src/share/classes/sun/jvm/hotspot/debugger/linux/LinuxCDebugger.java
+++ b/hotspot/agent/src/share/classes/sun/jvm/hotspot/debugger/linux/LinuxCDebugger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2015, Red Hat Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *


### PR DESCRIPTION
I would like to backport
8248876: LoadObject with bad base address created for exec file on linux.

The original patch does not apply cleanly to 8u, and this is a clean backport from 11u.

Testing:
build on Linux x86_64
tier1 on Linux x86_64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8248876](https://bugs.openjdk.java.net/browse/JDK-8248876): LoadObject with bad base address created for exec file on linux


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk8u-dev pull/47/head:pull/47` \
`$ git checkout pull/47`

Update a local copy of the PR: \
`$ git checkout pull/47` \
`$ git pull https://git.openjdk.java.net/jdk8u-dev pull/47/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 47`

View PR using the GUI difftool: \
`$ git pr show -t 47`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk8u-dev/pull/47.diff">https://git.openjdk.java.net/jdk8u-dev/pull/47.diff</a>

</details>
