### PR TITLE
8285445: cannot open file "NUL:"

### DIFF
--- a/jdk/src/windows/classes/java/io/WinNTFileSystem.java
+++ b/jdk/src/windows/classes/java/io/WinNTFileSystem.java
@@ -57,16 +57,15 @@ class WinNTFileSystem extends FileSystem {
 
     // Whether to enable alternative data streams (ADS) by suppressing
     // checking the path for invalid characters, in particular ":".
-    // ADS support will be enabled if and only if the property is set and
-    // is the empty string or is equal, ignoring case, to the string "true".
-    // By default ADS support is disabled.
+    // By default, ADS support is enabled and will be disabled if and
+    // only if the property is set, ignoring case, to the string "false".
     private static final boolean ENABLE_ADS;
     static {
         String enableADS = GetPropertyAction.privilegedGetProperty("jdk.io.File.enableADS");
         if (enableADS != null) {
-            ENABLE_ADS = "".equals(enableADS) || Boolean.parseBoolean(enableADS);
+            ENABLE_ADS = !enableADS.equalsIgnoreCase(Boolean.FALSE.toString());
         } else {
-            ENABLE_ADS = false;
+            ENABLE_ADS = true;
         }
     }
 

--- a/jdk/test/java/io/FileOutputStream/OpenNUL.java
+++ b/jdk/test/java/io/FileOutputStream/OpenNUL.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8285445
+ * @requires (os.family == "windows")
+ * @summary Verify behavior of opening "NUL:" with ADS enabled and disabled.
+ * @run main/othervm -Djdk.io.File.enableADS OpenNUL
+ * @run main/othervm -Djdk.io.File.enableADS=true OpenNUL
+ */
+
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+public class OpenNUL {
+    public static void main(String args[]) throws IOException {
+        String enableADS = System.getProperty("jdk.io.File.enableADS");
+        boolean fails = enableADS.equalsIgnoreCase(Boolean.FALSE.toString());
+
+        FileOutputStream fos;
+        try {
+            fos = new FileOutputStream("NUL:");
+            if (fails)
+                throw new RuntimeException("Should have failed");
+        } catch (FileNotFoundException fnfe) {
+            if (!fails)
+                throw new RuntimeException("Should not have failed");
+        }
+    }
+}


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [03cbb48e](https://github.com/openjdk/jdk/commit/03cbb48e6a1d806f204a39bbdbb4bc9be9e57a41) from the [openjdk/jdk](https://git.openjdk.java.net/jdk) repository.
The commit being backported was authored by Brian Burkhalter on 23 Apr 2022 and was reviewed by Mikael Vidstedt.
Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8285445](https://bugs.openjdk.java.net/browse/JDK-8285445): cannot open file "NUL:"
 * [JDK-8285500](https://bugs.openjdk.java.net/browse/JDK-8285500): cannot open file "NUL:" (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk8u-dev pull/49/head:pull/49` \
`$ git checkout pull/49`

Update a local copy of the PR: \
`$ git checkout pull/49` \
`$ git pull https://git.openjdk.java.net/jdk8u-dev pull/49/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 49`

View PR using the GUI difftool: \
`$ git pr show -t 49`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk8u-dev/pull/49.diff">https://git.openjdk.java.net/jdk8u-dev/pull/49.diff</a>

</details>
