### PR TITLE
8130895: Test javax/swing/system/6799345/TestShutdown.java fails on Solaris11 Sparcv9

### DIFF
--- a/jdk/src/share/classes/java/awt/KeyboardFocusManager.java
+++ b/jdk/src/share/classes/java/awt/KeyboardFocusManager.java
@@ -325,23 +325,6 @@ public abstract class KeyboardFocusManager
     };
 
     /**
-     * The default strokes for initializing the default focus traversal keys.
-     */
-    private static final AWTKeyStroke[][] defaultFocusTraversalKeyStrokes = {
-        {
-            AWTKeyStroke.getAWTKeyStroke(KeyEvent.VK_TAB, 0, false),
-            AWTKeyStroke.getAWTKeyStroke(KeyEvent.VK_TAB, InputEvent.CTRL_DOWN_MASK | InputEvent.CTRL_MASK, false),
-        },
-        {
-            AWTKeyStroke.getAWTKeyStroke(KeyEvent.VK_TAB, InputEvent.SHIFT_DOWN_MASK | InputEvent.SHIFT_MASK, false),
-            AWTKeyStroke.getAWTKeyStroke(KeyEvent.VK_TAB,
-                                         InputEvent.SHIFT_DOWN_MASK | InputEvent.SHIFT_MASK | InputEvent.CTRL_DOWN_MASK | InputEvent.CTRL_MASK,
-                                         false),
-        },
-        {},
-        {},
-      };
-    /**
      * The default focus traversal keys. Each array of traversal keys will be
      * in effect on all Windows that have no such array of their own explicitly
      * set. Each array will also be inherited, recursively, by any child
@@ -430,6 +413,27 @@ public abstract class KeyboardFocusManager
      * Initializes a KeyboardFocusManager.
      */
     public KeyboardFocusManager() {
+        AWTKeyStroke[][] defaultFocusTraversalKeyStrokes = {
+                {
+                        AWTKeyStroke.getAWTKeyStroke(KeyEvent.VK_TAB, 0, false),
+                        AWTKeyStroke.getAWTKeyStroke(KeyEvent.VK_TAB,
+                                InputEvent.CTRL_DOWN_MASK |
+                                        InputEvent.CTRL_MASK, false),
+                },
+                {
+                        AWTKeyStroke.getAWTKeyStroke(KeyEvent.VK_TAB,
+                                InputEvent.SHIFT_DOWN_MASK |
+                                        InputEvent.SHIFT_MASK, false),
+                        AWTKeyStroke.getAWTKeyStroke(KeyEvent.VK_TAB,
+                                InputEvent.SHIFT_DOWN_MASK |
+                                        InputEvent.SHIFT_MASK |
+                                        InputEvent.CTRL_DOWN_MASK |
+                                        InputEvent.CTRL_MASK,
+                                false),
+                },
+                {},
+                {},
+        };
         for (int i = 0; i < TRAVERSAL_KEY_LENGTH; i++) {
             Set<AWTKeyStroke> work_set = new HashSet<>();
             for (int j = 0; j < defaultFocusTraversalKeyStrokes[i].length; j++) {

--- a/jdk/src/share/classes/sun/awt/KeyboardFocusManagerPeerImpl.java
+++ b/jdk/src/share/classes/sun/awt/KeyboardFocusManagerPeerImpl.java
@@ -45,8 +45,10 @@ public abstract class KeyboardFocusManagerPeerImpl implements KeyboardFocusManag
 
     private static final PlatformLogger focusLog = PlatformLogger.getLogger("sun.awt.focus.KeyboardFocusManagerPeerImpl");
 
-    private static AWTAccessor.KeyboardFocusManagerAccessor kfmAccessor =
-        AWTAccessor.getKeyboardFocusManagerAccessor();
+    private static class KfmAccessor {
+        private static AWTAccessor.KeyboardFocusManagerAccessor instance =
+                AWTAccessor.getKeyboardFocusManagerAccessor();
+    }
 
     // The constants are copied from java.awt.KeyboardFocusManager
     public static final int SNFH_FAILURE         = 0;
@@ -156,12 +158,13 @@ public abstract class KeyboardFocusManagerPeerImpl implements KeyboardFocusManag
                                                      long time,
                                                      CausedFocusEvent.Cause cause)
     {
-        return kfmAccessor.shouldNativelyFocusHeavyweight(
-            heavyweight, descendant, temporary, focusedWindowChangeAllowed, time, cause);
+        return KfmAccessor.instance.shouldNativelyFocusHeavyweight(
+            heavyweight, descendant, temporary, focusedWindowChangeAllowed,
+                time, cause);
     }
 
     public static void removeLastFocusRequest(Component heavyweight) {
-        kfmAccessor.removeLastFocusRequest(heavyweight);
+        KfmAccessor.instance.removeLastFocusRequest(heavyweight);
     }
 
     // WARNING: Don't call it on the Toolkit thread.
@@ -171,7 +174,8 @@ public abstract class KeyboardFocusManagerPeerImpl implements KeyboardFocusManag
                                                                 boolean focusedWindowChangeAllowed,
                                                                 long time)
     {
-        return kfmAccessor.processSynchronousLightweightTransfer(
-            heavyweight, descendant, temporary, focusedWindowChangeAllowed, time);
+        return KfmAccessor.instance.processSynchronousLightweightTransfer(
+            heavyweight, descendant, temporary, focusedWindowChangeAllowed,
+                time);
     }
 }


### PR DESCRIPTION
I would like to backport
JDK-8130895: Test javax/swing/system/6799345/TestShutdown.java fails on Solaris11 Sparcv9
The original patch applies cleanly after paths changes.

Testing:
build on Solaris11.4 sparcv9
tire1, jdk_awt and javax/swing/system/6799345/TestShutdown.java on Solaris11.4 sparcv9

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8130895](https://bugs.openjdk.org/browse/JDK-8130895): Test javax/swing/system/6799345/TestShutdown.java fails on Solaris11 Sparcv9


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/57/head:pull/57` \
`$ git checkout pull/57`

Update a local copy of the PR: \
`$ git checkout pull/57` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/57/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 57`

View PR using the GUI difftool: \
`$ git pr show -t 57`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/57.diff">https://git.openjdk.org/jdk8u-dev/pull/57.diff</a>

</details>
