### PR TITLE
8286989: Build failure on macOS after 8281814

### DIFF
--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -530,7 +530,7 @@ define SetupNativeCompilation
             # to be rebuilt properly.
             $$($1_DEBUGINFO_ZIP): $$($1_DEBUGINFO_FILES) $$($1_TARGET)
 		$(CD) $$($1_OBJECT_DIR) \
-		&& $(ZIP) -q $$@ $$(subst $$($1_OBJECT_DIR)/,, $$($1_DEBUGINFO_FILES))
+		&& $(ZIP) -q $$@ $$(subst $$($1_OBJECT_DIR)/,,$$($1_DEBUGINFO_FILES))
           endif
         else
           ifneq ($$($1_STRIP_POLICY), no_strip)

--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -530,7 +530,7 @@ define SetupNativeCompilation
             # to be rebuilt properly.
             $$($1_DEBUGINFO_ZIP): $$($1_DEBUGINFO_FILES) $$($1_TARGET)
 		$(CD) $$($1_OBJECT_DIR) \
-		&& $(ZIP) -q $$@ $$(notdir $$($1_DEBUGINFO_FILES))
+		&& $(ZIP) -q $$@ $$(subst $$($1_OBJECT_DIR)/,, $$($1_DEBUGINFO_FILES))
           endif
         else
           ifneq ($$($1_STRIP_POLICY), no_strip)


### PR DESCRIPTION
This fixes wrong paths to debuginfo files passed to zip command, causing build failure on MacOS in github workflow. Problem was introduced by JDK-8281814 [1] (integrated, while github workflow PR was still in progress). 

I have done some experiments [2] and found out, that on macos, debuginfo files are stored in additional directories, relative to directory where object files are stored. Removing all directory components is therefore not correct on macos. Two seemingly equivalent fixes were were considered in JDK-8281814 (using notdir and using subst), but chosen one was not the correct one.

Follows example which illustrates difference of different variants of said zip command:

**Prior to JDK-8281814:**
`$(ZIP) -q $$@ $$($1_DEBUGINFO_FILES)`
- macos:
/usr/bin/zip -q /Users/runner/work/jdk8u-dev/jdk8u-dev/jdk/build/macos-x64/jdk/objs/libverify/libverify.diz /Users/runner/work/jdk8u-dev/jdk8u-dev/jdk/build/macos-x64/jdk/objs/libverify/libverify.dylib.dSYM/Contents/Info.plist /Users/runner/work/jdk8u-dev/jdk8u-dev/jdk/build/macos-x64/jdk/objs/libverify/libverify.dylib.dSYM/Contents/Resources/DWARF/libverify.dylib
- linux:
/home/runner/work/jdk8u-dev/jdk8u-dev/jdk/build/linux-x64/jdk/objs/libverify/libverify.diz /home/runner/work/jdk8u-dev/jdk8u-dev/jdk/build/linux-x64/jdk/objs/libverify/libverify.debuginfo
- windows:
/usr/bin/zip -q /cygdrive/d/a/jdk8u-dev/jdk8u-dev/jdk/build/windows-x64/jdk/objs/libverify/verify.diz /cygdrive/d/a/jdk8u-dev/jdk8u-dev/jdk/build/windows-x64/jdk/objs/libverify/verify.pdb /cygdrive/d/a/jdk8u-dev/jdk8u-dev/jdk/build/windows-x64/jdk/objs/libverify/verify.map

**After JDK-8281814 (not correct):**
`$(ZIP) -q $$@ $$(notdir $$($1_DEBUGINFO_FILES))`
- macos:
/usr/bin/zip -q /Users/runner/work/jdk8u-dev/jdk8u-dev/jdk/build/macos-x64/jdk/objs/libverify/libverify.diz Info.plist libverify.dylib
- linux:
/usr/bin/zip -q /home/runner/work/jdk8u-dev/jdk8u-dev/jdk/build/linux-x64/jdk/objs/libverify/libverify.diz libverify.debuginfo
- windows:
/usr/bin/zip -q /cygdrive/d/a/jdk8u-dev/jdk8u-dev/jdk/build/windows-x64/jdk/objs/libverify/verify.diz verify.pdb verify.map

**After this PR:**
`$(ZIP) -q $$@ $$(subst $$($1_OBJECT_DIR)/,,$$($1_DEBUGINFO_FILES))`
- macos:
/usr/bin/zip -q /Users/runner/work/jdk8u-dev/jdk8u-dev/jdk/build/macos-x64/jdk/objs/libverify/libverify.diz libverify.dylib.dSYM/Contents/Info.plist libverify.dylib.dSYM/Contents/Resources/DWARF/libverify.dylib
- linux:
/usr/bin/zip -q /home/runner/work/jdk8u-dev/jdk8u-dev/jdk/build/linux-x64/jdk/objs/libverify/libverify.diz libverify.debuginfo
- windows:
/usr/bin/zip -q /cygdrive/d/a/jdk8u-dev/jdk8u-dev/jdk/build/windows-x64/jdk/objs/libverify/verify.diz verify.pdb verify.map

[1] https://bugs.openjdk.java.net/browse/JDK-8281814
[2] https://github.com/zzambers/jdk8u-dev/commit/6d7e7cf6fcb1b203fe6a51a84398da08feb0e231

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286989](https://bugs.openjdk.java.net/browse/JDK-8286989): Build failure on macOS after 8281814


### Reviewers
 * [Severin Gehwolf](https://openjdk.java.net/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk8u-dev pull/61/head:pull/61` \
`$ git checkout pull/61`

Update a local copy of the PR: \
`$ git checkout pull/61` \
`$ git pull https://git.openjdk.java.net/jdk8u-dev pull/61/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 61`

View PR using the GUI difftool: \
`$ git pr show -t 61`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk8u-dev/pull/61.diff">https://git.openjdk.java.net/jdk8u-dev/pull/61.diff</a>

</details>
