### PR TITLE
8287191: [8u] Build failure without git information

### DIFF
--- a/make/common/MakeBase.gmk
+++ b/make/common/MakeBase.gmk
@@ -318,11 +318,13 @@ SCM_TIP_FILECMD := $(PRINTF) "$(SCM):%s" \
 # Emit the scm:id pair to $@
 define GetSourceTips
 	$(CD) $(SRC_ROOT) ; \
-	if [ -d $(SCM_DIR) -a "$(SCM_VERSION)" != "" ] ; then \
-	  $(ID_COMMAND) >> $@ ; \
-	elif [ -f $(SCM_TIP_FILENAME) ] ; then \
-          $(SCM_TIP_FILECMD) >> $@ ; \
-	fi;
+        if [ "$(SCM)" != "" ] ; then \
+          if [ -d $(SCM_DIR) -a "$(SCM_VERSION)" != "" ] ; then \
+            $(ID_COMMAND) >> $@ ; \
+          elif [ -f $(SCM_TIP_FILENAME) ] ; then \
+            $(SCM_TIP_FILECMD) >> $@ ; \
+          fi; \
+        fi;
 	$(PRINTF) "\n" >> $@
 endef
 


### PR DESCRIPTION
In 8u332, the commit "8210283: Support git as an SCM alternative in the build” used git as an SCM.
In the source package “https://github.com/openjdk/jdk8u/archive/refs/tags/jdk8u332-ga.tar.gz”， 
the .git directory has been removed in the source package. 

When we compile JDK with the source code from the package, we get the below error: 
``` 
Building 'linux-x86_64-normal-server-release' (matching CONF=release) 
/bin/sh: line 0: [: too many arguments 
``` 

The root cause is the lack of a non-empty check in the function 
``` 
define GetSourceTips 
        $(CD) $(SRC_ROOT) ; \ 
        if [ -d $(SCM_DIR) -a "$(SCM_VERSION)" != "" ] ; then \ 
          $(ID_COMMAND) >> $@ ; \ 
        elif [ -f $(SCM_TIP_FILENAME) ] ; then \ 
          $(SCM_TIP_FILECMD) >> $@ ; \ 
        fi; 
        $(PRINTF) "\n" >> $@ 
endef 
``` 

In the scenario， SCM_DIR，SCM_VERSION，SCM_TIP_FILECMD aren’t defined. That causes the build failure.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8287191](https://bugs.openjdk.java.net/browse/JDK-8287191): [8u] Build failure without git information


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk8u-dev pull/65/head:pull/65` \
`$ git checkout pull/65`

Update a local copy of the PR: \
`$ git checkout pull/65` \
`$ git pull https://git.openjdk.java.net/jdk8u-dev pull/65/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 65`

View PR using the GUI difftool: \
`$ git pr show -t 65`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk8u-dev/pull/65.diff">https://git.openjdk.java.net/jdk8u-dev/pull/65.diff</a>

</details>
