### PR TITLE
8136354: [TEST_BUG] Test  java/awt/image/RescaleOp/RescaleAlphaTest.java with Bad action for script

### DIFF
--- a/jdk/test/java/awt/image/RescaleOp/RescaleAlphaTest.java
+++ b/jdk/test/java/awt/image/RescaleOp/RescaleAlphaTest.java
@@ -22,8 +22,8 @@
  */
 /**
  * @test
- * @bug 8080287
- * @run RescaleAlphaTest
+ * @bug 8080287 8136354
+ * @run main RescaleAlphaTest
  * @summary RescaleOp with scaleFactor/alpha should copy alpha to destination
  * channel
  */


### PR DESCRIPTION
This is a clean backport of JDK-8136354: [TEST_BUG] Test java/awt/image/RescaleOp/RescaleAlphaTest.java with Bad action for script.
The test passed by applying this backport.

Could you please review this PR?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8136354](https://bugs.openjdk.org/browse/JDK-8136354): [TEST_BUG] Test  java/awt/image/RescaleOp/RescaleAlphaTest.java with Bad action for script


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/78/head:pull/78` \
`$ git checkout pull/78`

Update a local copy of the PR: \
`$ git checkout pull/78` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/78/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 78`

View PR using the GUI difftool: \
`$ git pr show -t 78`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/78.diff">https://git.openjdk.org/jdk8u-dev/pull/78.diff</a>

</details>
