### PR TITLE
8273176: handle latest VS2019 in abstract_vm_version

### DIFF
--- a/hotspot/src/share/vm/runtime/vm_version.cpp
+++ b/hotspot/src/share/vm/runtime/vm_version.cpp
@@ -260,7 +260,9 @@ const char* Abstract_VM_Version::internal_vm_info_string() {
       #elif _MSC_VER == 1927
         #define HOTSPOT_BUILD_COMPILER "MS VC++ 16.7 (VS2019)"
       #elif _MSC_VER == 1928
-        #define HOTSPOT_BUILD_COMPILER "MS VC++ 16.8 (VS2019)"
+        #define HOTSPOT_BUILD_COMPILER "MS VC++ 16.8 / 16.9 (VS2019)"
+      #elif _MSC_VER == 1929
+        #define HOTSPOT_BUILD_COMPILER "MS VC++ 16.10 / 16.11 (VS2019)"
       #else
         #define HOTSPOT_BUILD_COMPILER "unknown MS VC++:" XSTR(_MSC_VER)
       #endif


### PR DESCRIPTION
Hi! Here is another backport from MSVS 2019 seria. This one additionally extends the list of supported VC++ compilers. The patch from 11u is applied cleanly except the path shuffling:

src/hotspot/share/runtime/abstract_vm_version.cpp -> hotspot/src/share/vm/runtime/vm_version.cpp

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273176](https://bugs.openjdk.org/browse/JDK-8273176): handle latest VS2019 in abstract_vm_version


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/82/head:pull/82` \
`$ git checkout pull/82`

Update a local copy of the PR: \
`$ git checkout pull/82` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/82/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 82`

View PR using the GUI difftool: \
`$ git pr show -t 82`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/82.diff">https://git.openjdk.org/jdk8u-dev/pull/82.diff</a>

</details>
