### PR TITLE
8288763: Pack200 extraction failure with invalid size

### DIFF
--- a/jdk/src/share/classes/com/sun/java/util/jar/pack/Utils.java
+++ b/jdk/src/share/classes/com/sun/java/util/jar/pack/Utils.java
@@ -249,6 +249,7 @@ class Utils {
         }
         byte[] buffer = new byte[1 << 14];
         for (JarEntry je; (je = in.getNextJarEntry()) != null; ) {
+            je.setCompressedSize(-1);
             out.putNextEntry(je);
             for (int nr; 0 < (nr = in.read(buffer)); ) {
                 out.write(buffer, 0, nr);
@@ -260,6 +261,7 @@ class Utils {
     static void copyJarFile(JarFile in, JarOutputStream out) throws IOException {
         byte[] buffer = new byte[1 << 14];
         for (JarEntry je : Collections.list(in.entries())) {
+            je.setCompressedSize(-1);
             out.putNextEntry(je);
             InputStream ein = in.getInputStream(je);
             for (int nr; 0 < (nr = ein.read(buffer)); ) {


### PR DESCRIPTION
Backports this change to jdk8 to fix the pack200 compressed size issue here as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288763](https://bugs.openjdk.org/browse/JDK-8288763): Pack200 extraction failure with invalid size


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/86/head:pull/86` \
`$ git checkout pull/86`

Update a local copy of the PR: \
`$ git checkout pull/86` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/86/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 86`

View PR using the GUI difftool: \
`$ git pr show -t 86`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/86.diff">https://git.openjdk.org/jdk8u-dev/pull/86.diff</a>

</details>
