### PR TITLE
8290000: Bump macOS GitHub actions to macOS 11

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -1276,7 +1276,7 @@ jobs:
 
   macos_x64_build:
     name: macOS x64
-    runs-on: "macos-10.15"
+    runs-on: "macos-11"
     needs: prerequisites
     if: needs.prerequisites.outputs.should_run != 'false' && needs.prerequisites.outputs.platform_macos_x64 != 'false'
 
@@ -1343,7 +1343,7 @@ jobs:
         run: brew install make
 
       - name: Select Xcode version
-        run: sudo xcode-select --switch /Applications/Xcode_11.3.1.app/Contents/Developer
+        run: sudo xcode-select --switch /Applications/Xcode_11.7.app/Contents/Developer
 
       - name: Configure
         run: >
@@ -1371,7 +1371,7 @@ jobs:
 
   macos_x64_test:
     name: macOS x64
-    runs-on: "macos-10.15"
+    runs-on: "macos-11"
     if: false
     needs:
       - prerequisites
@@ -1486,7 +1486,7 @@ jobs:
         run: brew install make
 
       - name: Select Xcode version
-        run: sudo xcode-select --switch /Applications/Xcode_11.3.1.app/Contents/Developer
+        run: sudo xcode-select --switch /Applications/Xcode_11.7.app/Contents/Developer
 
       - name: Find root of jdk image dir
         run: |


### PR DESCRIPTION
macOS 10.15 has been deprecated for some time and will be removed completely on August 30th. See https://github.com/actions/virtual-environments#available-environments and https://github.com/actions/virtual-environments/issues/5583 for context.

This PR doesn't apply cleanly because it was added to the GitHub actions rewrite in tip. As it's unlikely that I will have a backported rewrite by August 30th my preference is to backport this way round.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290000](https://bugs.openjdk.org/browse/JDK-8290000): Bump macOS GitHub actions to macOS 11


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/87/head:pull/87` \
`$ git checkout pull/87`

Update a local copy of the PR: \
`$ git checkout pull/87` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/87/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 87`

View PR using the GUI difftool: \
`$ git pr show -t 87`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/87.diff">https://git.openjdk.org/jdk8u-dev/pull/87.diff</a>

</details>
