### PR TITLE
8035467: Xerces Update: Move to Xalan based DOM L3 serializer. Deprecate Xerces' native serializer.

### DIFF
--- a/jaxp/src/com/sun/org/apache/xerces/internal/dom/CoreDOMImplementationImpl.java
+++ b/jaxp/src/com/sun/org/apache/xerces/internal/dom/CoreDOMImplementationImpl.java
@@ -3,11 +3,12 @@
  * DO NOT REMOVE OR ALTER!
  */
 /*
- * Copyright 1999-2005 The Apache Software Foundation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -385,8 +386,18 @@ public class CoreDOMImplementationImpl
          * reference to the default error handler.
          */
         public LSSerializer createLSSerializer() {
-        return new DOMSerializerImpl();
-    }
+            try {
+                Class serializerClass = ObjectFactory.findProviderClass(
+                    "com.sun.org.apache.xml.internal.serializer.dom3.LSSerializerImpl",
+                    ObjectFactory.findClassLoader(), true);
+                return (LSSerializer) serializerClass.newInstance();
+            }
+            catch (Exception e) {}
+            // Fall back to Xerces' deprecated serializer if
+            // the Xalan based serializer is unavailable.
+            return new DOMSerializerImpl();
+        }
+
         /**
          * DOM Level 3 LS CR - Experimental.
          * Create a new empty input source.

--- a/jaxp/src/com/sun/org/apache/xml/internal/serialize/BaseMarkupSerializer.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serialize/BaseMarkupSerializer.java
@@ -122,6 +122,11 @@ import org.xml.sax.ext.LexicalHandler;
  * @author Sunitha Reddy, Sun Microsystems
  * @see Serializer
  * @see org.w3c.dom.ls.LSSerializer
+ *
+ * @deprecated As of JDK 1.9, Xerces 2.9.0, Xerces DOM L3 Serializer implementation
+ * is replaced by that of Xalan. Main class
+ * {@link com.sun.org.apache.xml.internal.serialize.DOMSerializerImpl} is replaced
+ * by {@link com.sun.org.apache.xml.internal.serializer.dom3.LSSerializerImpl}.
  */
 public abstract class BaseMarkupSerializer
     implements ContentHandler, DocumentHandler, LexicalHandler,

--- a/jaxp/src/com/sun/org/apache/xml/internal/serialize/DOMSerializer.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serialize/DOMSerializer.java
@@ -3,11 +3,12 @@
  * DO NOT REMOVE OR ALTER!
  */
 /*
- * Copyright 1999-2002,2004 The Apache Software Foundation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -35,6 +36,11 @@ import org.w3c.dom.DocumentFragment;
  *
  * @author <a href="mailto:Scott_Boag/CAM/Lotus@lotus.com">Scott Boag</a>
  * @author <a href="mailto:arkin@intalio.com">Assaf Arkin</a>
+ *
+ * @deprecated As of JDK 1.9, Xerces 2.9.0, Xerces DOM L3 Serializer implementation
+ * is replaced by that of Xalan. Main class
+ * {@link com.sun.org.apache.xml.internal.serialize.DOMSerializerImpl} is replaced
+ * by {@link com.sun.org.apache.xml.internal.serializer.dom3.LSSerializerImpl}.
  */
 public interface DOMSerializer
 {

--- a/jaxp/src/com/sun/org/apache/xml/internal/serialize/DOMSerializerImpl.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serialize/DOMSerializerImpl.java
@@ -73,6 +73,9 @@ import org.w3c.dom.ls.LSSerializerFilter;
  * @author Gopal Sharma, Sun Microsystems
  * @author Arun Yadav, Sun Microsystems
  * @author Sunitha Reddy, Sun Microsystems
+ *
+ * @deprecated As of JDK 1.9, Xerces 2.9.0, replaced by
+ * {@link com.sun.org.apache.xml.internal.serializer.dom3.LSSerializerImpl}
  */
 public class DOMSerializerImpl implements LSSerializer, DOMConfiguration {
 

--- a/jaxp/src/com/sun/org/apache/xml/internal/serialize/ElementState.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serialize/ElementState.java
@@ -28,9 +28,13 @@ import java.util.Map;
 /**
  * Holds the state of the currently serialized element.
  *
- *
  * @author <a href="mailto:arkin@intalio.com">Assaf Arkin</a>
  * @see BaseMarkupSerializer
+ *
+ * @deprecated As of JDK 1.9, Xerces 2.9.0, Xerces DOM L3 Serializer implementation
+ * is replaced by that of Xalan. Main class
+ * {@link com.sun.org.apache.xml.internal.serialize.DOMSerializerImpl} is replaced
+ * by {@link com.sun.org.apache.xml.internal.serializer.dom3.LSSerializerImpl}.
  */
 public class ElementState
 {

--- a/jaxp/src/com/sun/org/apache/xml/internal/serialize/EncodingInfo.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serialize/EncodingInfo.java
@@ -3,11 +3,12 @@
  * DO NOT REMOVE OR ALTER!
  */
 /*
- * Copyright 2000-2002,2004,2005 The Apache Software Foundation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -29,6 +30,10 @@ import com.sun.org.apache.xerces.internal.util.EncodingMap;
 /**
  * This class represents an encoding.
  *
+ * @deprecated As of JDK 1.9, Xerces 2.9.0, Xerces DOM L3 Serializer implementation
+ * is replaced by that of Xalan. Main class
+ * {@link com.sun.org.apache.xml.internal.serialize.DOMSerializerImpl} is replaced
+ * by {@link com.sun.org.apache.xml.internal.serializer.dom3.LSSerializerImpl}.
  */
 public class EncodingInfo {
 

--- a/jaxp/src/com/sun/org/apache/xml/internal/serialize/Encodings.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serialize/Encodings.java
@@ -36,6 +36,11 @@ import java.util.concurrent.ConcurrentHashMap;
  * for each encoding.
  *
  * @author <a href="mailto:arkin@intalio.com">Assaf Arkin</a>
+ *
+ * @deprecated As of JDK 1.9, Xerces 2.9.0, Xerces DOM L3 Serializer implementation
+ * is replaced by that of Xalan. Main class
+ * {@link com.sun.org.apache.xml.internal.serialize.DOMSerializerImpl} is replaced
+ * by {@link com.sun.org.apache.xml.internal.serializer.dom3.LSSerializerImpl}.
  */
 class Encodings
 {

--- a/jaxp/src/com/sun/org/apache/xml/internal/serialize/HTMLdtd.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serialize/HTMLdtd.java
@@ -44,8 +44,12 @@ import java.util.Map;
  * from value to name. A small entities resource is loaded into memory the
  * first time any of these methods is called for fast and efficient access.
  *
- *
  * @author <a href="mailto:arkin@intalio.com">Assaf Arkin</a>
+ *
+ * @deprecated As of JDK 1.9, Xerces 2.9.0, Xerces DOM L3 Serializer implementation
+ * is replaced by that of Xalan. Main class
+ * {@link com.sun.org.apache.xml.internal.serialize.DOMSerializerImpl} is replaced
+ * by {@link com.sun.org.apache.xml.internal.serializer.dom3.LSSerializerImpl}.
  */
 public final class HTMLdtd
 {

--- a/jaxp/src/com/sun/org/apache/xml/internal/serialize/IndentPrinter.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serialize/IndentPrinter.java
@@ -3,11 +3,12 @@
  * DO NOT REMOVE OR ALTER!
  */
 /*
- * Copyright 1999-2002,2004 The Apache Software Foundation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -32,6 +33,11 @@ import java.io.IOException;
  * wrapping.
  *
  * @author <a href="mailto:arkin@intalio.com">Assaf Arkin</a>
+ *
+ * @deprecated As of JDK 1.9, Xerces 2.9.0, Xerces DOM L3 Serializer implementation
+ * is replaced by that of Xalan. Main class
+ * {@link com.sun.org.apache.xml.internal.serialize.DOMSerializerImpl} is replaced
+ * by {@link com.sun.org.apache.xml.internal.serializer.dom3.LSSerializerImpl}.
  */
 public class IndentPrinter
     extends Printer

--- a/jaxp/src/com/sun/org/apache/xml/internal/serialize/LineSeparator.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serialize/LineSeparator.java
@@ -3,11 +3,12 @@
  * DO NOT REMOVE OR ALTER!
  */
 /*
- * Copyright 1999-2002,2004 The Apache Software Foundation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -25,6 +26,11 @@ package com.sun.org.apache.xml.internal.serialize;
 /**
  * @author <a href="mailto:arkin@intalio..com">Assaf Arkin</a>
  * @see OutputFormat
+ *
+ * @deprecated As of JDK 1.9, Xerces 2.9.0, Xerces DOM L3 Serializer implementation
+ * is replaced by that of Xalan. Main class
+ * {@link com.sun.org.apache.xml.internal.serialize.DOMSerializerImpl} is replaced
+ * by {@link com.sun.org.apache.xml.internal.serializer.dom3.LSSerializerImpl}.
  */
 public final class LineSeparator
 {

--- a/jaxp/src/com/sun/org/apache/xml/internal/serialize/Method.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serialize/Method.java
@@ -3,11 +3,12 @@
  * DO NOT REMOVE OR ALTER!
  */
 /*
- * Copyright 1999-2002,2004 The Apache Software Foundation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -25,6 +26,11 @@ package com.sun.org.apache.xml.internal.serialize;
 /**
  * @author <a href="mailto:arkin@intalio.com">Assaf Arkin</a>
  * @see OutputFormat
+ *
+ * @deprecated As of JDK 1.9, Xerces 2.9.0, Xerces DOM L3 Serializer implementation
+ * is replaced by that of Xalan. Main class
+ * {@link com.sun.org.apache.xml.internal.serialize.DOMSerializerImpl} is replaced
+ * by {@link com.sun.org.apache.xml.internal.serializer.dom3.LSSerializerImpl}.
  */
 public final class Method
 {

--- a/jaxp/src/com/sun/org/apache/xml/internal/serialize/OutputFormat.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serialize/OutputFormat.java
@@ -3,11 +3,12 @@
  * DO NOT REMOVE OR ALTER!
  */
 /*
- * Copyright 1999-2002,2004 The Apache Software Foundation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -59,6 +60,11 @@ import org.w3c.dom.html.HTMLDocument;
  * @see Serializer
  * @see Method
  * @see LineSeparator
+ *
+ * @deprecated As of JDK 1.9, Xerces 2.9.0, Xerces DOM L3 Serializer implementation
+ * is replaced by that of Xalan. Main class
+ * {@link com.sun.org.apache.xml.internal.serialize.DOMSerializerImpl} is replaced
+ * by {@link com.sun.org.apache.xml.internal.serializer.dom3.LSSerializerImpl}.
  */
 public class OutputFormat
 {

--- a/jaxp/src/com/sun/org/apache/xml/internal/serialize/Printer.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serialize/Printer.java
@@ -3,11 +3,12 @@
  * DO NOT REMOVE OR ALTER!
  */
 /*
- * Copyright 1999-2002,2004 The Apache Software Foundation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -40,6 +41,11 @@ import java.io.IOException;
  * extending this class.
  *
  * @author <a href="mailto:arkin@intalio.com">Assaf Arkin</a>
+ *
+ * @deprecated As of JDK 1.9, Xerces 2.9.0, Xerces DOM L3 Serializer implementation
+ * is replaced by that of Xalan. Main class
+ * {@link com.sun.org.apache.xml.internal.serialize.DOMSerializerImpl} is replaced
+ * by {@link com.sun.org.apache.xml.internal.serializer.dom3.LSSerializerImpl}.
  */
 public class Printer
 {

--- a/jaxp/src/com/sun/org/apache/xml/internal/serialize/Serializer.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serialize/Serializer.java
@@ -3,11 +3,12 @@
  * DO NOT REMOVE OR ALTER!
  */
 /*
- * Copyright 1999-2002,2004 The Apache Software Foundation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -60,6 +61,11 @@ import org.xml.sax.DocumentHandler;
  * @see ContentHandler
  * @see OutputFormat
  * @see DOMSerializer
+ *
+ * @deprecated As of JDK 1.9, Xerces 2.9.0, Xerces DOM L3 Serializer implementation
+ * is replaced by that of Xalan. Main class
+ * {@link com.sun.org.apache.xml.internal.serialize.DOMSerializerImpl} is replaced
+ * by {@link com.sun.org.apache.xml.internal.serializer.dom3.LSSerializerImpl}.
  */
 public interface Serializer
 {

--- a/jaxp/src/com/sun/org/apache/xml/internal/serialize/SerializerFactory.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serialize/SerializerFactory.java
@@ -36,6 +36,11 @@ import java.util.StringTokenizer;
  *
  * @author <a href="mailto:Scott_Boag/CAM/Lotus@lotus.com">Scott Boag</a>
  * @author <a href="mailto:arkin@intalio.com">Assaf Arkin</a>
+ *
+ * @deprecated As of JDK 1.9, Xerces 2.9.0, Xerces DOM L3 Serializer implementation
+ * is replaced by that of Xalan. Main class
+ * {@link com.sun.org.apache.xml.internal.serialize.DOMSerializerImpl} is replaced
+ * by {@link com.sun.org.apache.xml.internal.serializer.dom3.LSSerializerImpl}.
  */
 public abstract class SerializerFactory
 {

--- a/jaxp/src/com/sun/org/apache/xml/internal/serialize/SerializerFactoryImpl.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serialize/SerializerFactoryImpl.java
@@ -3,11 +3,12 @@
  * DO NOT REMOVE OR ALTER!
  */
 /*
- * Copyright 1999-2002,2004 The Apache Software Foundation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -34,6 +35,11 @@ import com.sun.org.apache.xerces.internal.dom.DOMMessageFormatter;
  *
  * @author <a href="mailto:Scott_Boag/CAM/Lotus@lotus.com">Scott Boag</a>
  * @author <a href="mailto:arkin@intalio.com">Assaf Arkin</a>
+ *
+ * @deprecated As of JDK 1.9, Xerces 2.9.0, Xerces DOM L3 Serializer implementation
+ * is replaced by that of Xalan. Main class
+ * {@link com.sun.org.apache.xml.internal.serialize.DOMSerializerImpl} is replaced
+ * by {@link com.sun.org.apache.xml.internal.serializer.dom3.LSSerializerImpl}.
  */
 final class SerializerFactoryImpl
     extends SerializerFactory

--- a/jaxp/src/com/sun/org/apache/xml/internal/serialize/TextSerializer.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serialize/TextSerializer.java
@@ -3,11 +3,12 @@
  * DO NOT REMOVE OR ALTER!
  */
 /*
- * Copyright 1999-2002,2004 The Apache Software Foundation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -58,6 +59,11 @@ import org.xml.sax.SAXException;
  *
  * @author <a href="mailto:arkin@intalio.com">Assaf Arkin</a>
  * @see Serializer
+ *
+ * @deprecated As of JDK 1.9, Xerces 2.9.0, Xerces DOM L3 Serializer implementation
+ * is replaced by that of Xalan. Main class
+ * {@link com.sun.org.apache.xml.internal.serialize.DOMSerializerImpl} is replaced
+ * by {@link com.sun.org.apache.xml.internal.serializer.dom3.LSSerializerImpl}.
  */
 public class TextSerializer
     extends BaseMarkupSerializer

--- a/jaxp/src/com/sun/org/apache/xml/internal/serialize/XML11Serializer.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serialize/XML11Serializer.java
@@ -73,10 +73,16 @@ import org.xml.sax.SAXException;
  * boundaries, indent lines, and serialize elements on separate
  * lines. Line terminators will be regarded as spaces, and
  * spaces at beginning of line will be stripped.
+ *
  * @author <a href="mailto:arkin@intalio.com">Assaf Arkin</a>
  * @author <a href="mailto:rahul.srivastava@sun.com">Rahul Srivastava</a>
  * @author Elena Litani IBM
  * @see Serializer
+ *
+ * @deprecated As of JDK 1.9, Xerces 2.9.0, Xerces DOM L3 Serializer implementation
+ * is replaced by that of Xalan. Main class
+ * {@link com.sun.org.apache.xml.internal.serialize.DOMSerializerImpl} is replaced
+ * by {@link com.sun.org.apache.xml.internal.serializer.dom3.LSSerializerImpl}.
  */
 public class XML11Serializer
 extends XMLSerializer {

--- a/jaxp/src/com/sun/org/apache/xml/internal/serialize/XMLSerializer.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serialize/XMLSerializer.java
@@ -82,10 +82,16 @@ import org.xml.sax.helpers.AttributesImpl;
  * boundaries, indent lines, and serialize elements on separate
  * lines. Line terminators will be regarded as spaces, and
  * spaces at beginning of line will be stripped.
+ *
  * @author <a href="mailto:arkin@intalio.com">Assaf Arkin</a>
  * @author <a href="mailto:rahul.srivastava@sun.com">Rahul Srivastava</a>
  * @author Elena Litani IBM
  * @see Serializer
+ *
+ * @deprecated As of JDK 1.9, Xerces 2.9.0, Xerces DOM L3 Serializer implementation
+ * is replaced by that of Xalan. Main class
+ * {@link com.sun.org.apache.xml.internal.serialize.DOMSerializerImpl} is replaced
+ * by {@link com.sun.org.apache.xml.internal.serializer.dom3.LSSerializerImpl}.
  */
 public class XMLSerializer
 extends BaseMarkupSerializer {

--- a/jaxp/src/com/sun/org/apache/xml/internal/serializer/DOM3Serializer.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serializer/DOM3Serializer.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the  "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * $Id:  $
+ */
+
+package com.sun.org.apache.xml.internal.serializer;
+
+import java.io.IOException;
+
+import org.w3c.dom.Node;
+import org.w3c.dom.DOMErrorHandler;
+import org.w3c.dom.ls.LSSerializerFilter;
+
+/**
+ * Interface for a DOM serializer capable of serializing DOMs as specified in
+ * the DOM Level 3 Save Recommendation.
+ * <p>
+ * The DOM3Serializer is a facet of a serializer and is obtained from the
+ * asDOM3Serializer() method of the org.apache.xml.serializer.Serializer interface.
+ * A serializer may or may not support a level 3 DOM serializer, if it does not then the
+ * return value from asDOM3Serializer() is null.
+ * <p>
+ * Example:
+ * <pre>
+ * Document     doc;
+ * Serializer   ser;
+ * OutputStream os;
+ * DOMErrorHandler handler;
+ *
+ * ser = ...;
+ * os = ...;
+ * handler = ...;
+ *
+ * ser.setOutputStream( os );
+ * DOM3Serialzier dser = (DOM3Serialzier)ser.asDOM3Serializer();
+ * dser.setErrorHandler(handler);
+ * dser.serialize(doc);
+ * </pre>
+ *
+ * @see org.apache.xml.serializer.Serializer
+ *
+ * @xsl.usage general
+ *
+ */
+public interface DOM3Serializer {
+    /**
+     * Serializes the Level 3 DOM node. Throws an exception only if an I/O
+     * exception occured while serializing.
+     *
+     * This interface is a public API.
+     *
+     * @param node the Level 3 DOM node to serialize
+     * @throws IOException if an I/O exception occured while serializing
+     */
+    public void serializeDOM3(Node node) throws IOException;
+
+    /**
+     * Sets a DOMErrorHandler on the DOM Level 3 Serializer.
+     *
+     * This interface is a public API.
+     *
+     * @param handler the Level 3 DOMErrorHandler
+     */
+    public void setErrorHandler(DOMErrorHandler handler);
+
+    /**
+     * Returns a DOMErrorHandler set on the DOM Level 3 Serializer.
+     *
+     * This interface is a public API.
+     *
+     * @return A Level 3 DOMErrorHandler
+     */
+    public DOMErrorHandler getErrorHandler();
+
+    /**
+     * Sets a LSSerializerFilter on the DOM Level 3 Serializer to filter nodes
+     * during serialization.
+     *
+     * This interface is a public API.
+     *
+     * @param filter the Level 3 LSSerializerFilter
+     */
+    public void setNodeFilter(LSSerializerFilter filter);
+
+    /**
+     * Returns a LSSerializerFilter set on the DOM Level 3 Serializer to filter nodes
+     * during serialization.
+     *
+     * This interface is a public API.
+     *
+     * @return The Level 3 LSSerializerFilter
+     */
+    public LSSerializerFilter getNodeFilter();
+
+    /**
+     * Sets the new line character to be used during serialization
+     * @param newLine a String that is the end-of-line character sequence to be
+     * used in serialization.
+     */
+    public void setNewLine(String newLine);
+}

--- a/jaxp/src/com/sun/org/apache/xml/internal/serializer/EmptySerializer.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serializer/EmptySerializer.java
@@ -770,4 +770,13 @@ public class EmptySerializer implements SerializationHandler
         aMethodIsCalled();
 
     }
+
+    /**
+     * @see org.apache.xml.serializer.Serializer#asDOM3Serializer()
+     */
+    public Object asDOM3Serializer() throws IOException
+    {
+        couldThrowIOException();
+        return null;
+    }
 }

--- a/jaxp/src/com/sun/org/apache/xml/internal/serializer/Encodings.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serializer/Encodings.java
@@ -152,6 +152,24 @@ public final class Encodings extends Object
     }
 
     /**
+     * Determines if the encoding specified was recognized by the
+     * serializer or not.
+     *
+     * @param encoding The encoding
+     * @return boolean - true if the encoding was recognized else false
+     */
+    public static boolean isRecognizedEncoding(String encoding)
+    {
+        EncodingInfo ei;
+
+        String normalizedEncoding = toUpperCaseFast(encoding);
+        ei = _encodingInfos.findEncoding(normalizedEncoding);
+        if (ei != null)
+            return true;
+        return false;
+    }
+
+    /**
      * A fast and cheap way to uppercase a String that is
      * only made of printable ASCII characters.
      * <p>

--- a/jaxp/src/com/sun/org/apache/xml/internal/serializer/SerializationHandler.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serializer/SerializationHandler.java
@@ -3,9 +3,11 @@
  * DO NOT REMOVE OR ALTER!
  */
 /*
- * Copyright 2003-2004 The Apache Software Foundation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the  "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -110,9 +112,29 @@ public interface SerializationHandler
     public void setNamespaceMappings(NamespaceMappings mappings);
 
     /**
-     * Flush any pending events currently queued up in the serializer. This will
-     * flush any input that the serializer has which it has not yet sent as
-     * output.
+     * A SerializationHandler accepts SAX-like events, so
+     * it can accumulate attributes or namespace nodes after
+     * a startElement().
+     * <p>
+     * If the SerializationHandler has a Writer or OutputStream,
+     * a call to this method will flush such accumulated
+     * events as a closed start tag for an element.
+     * <p>
+     * If the SerializationHandler wraps a ContentHandler,
+     * a call to this method will flush such accumulated
+     * events as a SAX (not SAX-like) calls to
+     * startPrefixMapping() and startElement().
+     * <p>
+     * If one calls endDocument() then one need not call
+     * this method since a call to endDocument() will
+     * do what this method does. However, in some
+     * circumstances, such as with document fragments,
+     * endDocument() is not called and it may be
+     * necessary to call this method to flush
+     * any pending events.
+     * <p>
+     * For performance reasons this method should not be called
+     * very often.
      */
     public void flushPending() throws SAXException;
 

--- a/jaxp/src/com/sun/org/apache/xml/internal/serializer/Serializer.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serializer/Serializer.java
@@ -3,9 +3,11 @@
  * DO NOT REMOVE OR ALTER!
  */
 /*
- * Copyright 1999-2004 The Apache Software Foundation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the  "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -220,4 +222,20 @@ public interface Serializer {
      * @return True if serializer has been reset and can be reused
      */
     public boolean reset();
+
+    /**
+     * Return an Object into this serializer to be cast to a DOM3Serializer.
+     * Through the returned object the document to be serialized,
+     * a DOM (Level 3), can be provided to the serializer.
+     * If the serializer does not support casting to a {@link DOM3Serializer}
+     * interface, it should return null.
+     * <p>
+     * In principle only one of asDOM3Serializer() or asContentHander()
+     * should be called.
+     *
+     * @return An Object to be cast to a DOM3Serializer interface into this serializer,
+     *  or null if the serializer is not DOM capable
+     * @throws IOException An I/O exception occured
+     */
+    public Object asDOM3Serializer() throws IOException;
 }

--- a/jaxp/src/com/sun/org/apache/xml/internal/serializer/SerializerBase.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serializer/SerializerBase.java
@@ -1559,6 +1559,21 @@ public abstract class SerializerBase
     }
 
     /**
+     * Return a {@link DOM3Serializer} interface into this serializer. If the
+     * serializer does not support the {@link DOM3Serializer} interface, it should
+     * return null.
+     *
+     * @return A {@link DOM3Serializer} interface into this serializer,  or null
+     * if the serializer is not DOM capable
+     * @throws IOException An I/O exception occured
+     * @see org.apache.xml.serializer.Serializer#asDOM3Serializer()
+     */
+    public Object asDOM3Serializer() throws IOException
+    {
+        return new com.sun.org.apache.xml.internal.serializer.dom3.DOM3SerializerImpl(this);
+    }
+
+    /**
      * Get the default value of an xsl:output property,
      * which would be null only if no default value exists
      * for the property.

--- a/jaxp/src/com/sun/org/apache/xml/internal/serializer/SerializerFactory.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serializer/SerializerFactory.java
@@ -127,7 +127,7 @@ public final class SerializerFactory
         if (obj instanceof SerializationHandler)
         {
               // this is one of the supplied serializers
-            ser = (Serializer) cls.newInstance();
+            ser = (Serializer) obj;
             ser.setOutputFormat(format);
         }
         else

--- a/jaxp/src/com/sun/org/apache/xml/internal/serializer/ToStream.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serializer/ToStream.java
@@ -539,7 +539,7 @@ abstract public class ToStream extends SerializerBase
                 if (OutputPropertiesFactory.S_KEY_INDENT_AMOUNT.equals(name)) {
                     setIndentAmount(Integer.parseInt(val));
                 } else if (OutputKeys.INDENT.equals(name)) {
-                    boolean b = "yes".equals(val) ? true : false;
+                    boolean b = val.endsWith("yes") ? true : false;
                     m_doIndent = b;
                 }
 
@@ -558,7 +558,7 @@ abstract public class ToStream extends SerializerBase
                 break;
             case 'o':
                 if (OutputKeys.OMIT_XML_DECLARATION.equals(name)) {
-                    boolean b = "yes".equals(val) ? true : false;
+                    boolean b = val.endsWith("yes") ? true : false;
                     this.m_shouldNotWriteXMLHeader = b;
                 }
                 break;

--- a/jaxp/src/com/sun/org/apache/xml/internal/serializer/ToUnknownStream.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serializer/ToUnknownStream.java
@@ -1335,4 +1335,12 @@ public final class ToUnknownStream extends SerializerBase
                 ch.length);
         }
     }
+
+    /**
+     * @see org.apache.xml.serializer.Serializer#asDOM3Serializer()
+     */
+    public Object asDOM3Serializer() throws IOException
+    {
+        return m_handler.asDOM3Serializer();
+    }
 }

--- a/jaxp/src/com/sun/org/apache/xml/internal/serializer/dom3/DOM3SerializerImpl.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serializer/dom3/DOM3SerializerImpl.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the  "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.sun.org.apache.xml.internal.serializer.dom3;
+
+import java.io.IOException;
+
+import com.sun.org.apache.xml.internal.serializer.DOM3Serializer;
+import com.sun.org.apache.xml.internal.serializer.SerializationHandler;
+import com.sun.org.apache.xml.internal.serializer.utils.WrappedRuntimeException;
+import org.w3c.dom.DOMErrorHandler;
+import org.w3c.dom.Node;
+import org.w3c.dom.ls.LSSerializerFilter;
+
+/**
+ * This class implements the DOM3Serializer interface.
+ *
+ * @xsl.usage internal
+ */
+public final class DOM3SerializerImpl implements DOM3Serializer {
+
+    /**
+     * Private class members
+     */
+    // The DOMErrorHandler
+    private DOMErrorHandler fErrorHandler;
+
+    // A LSSerializerFilter
+    private LSSerializerFilter fSerializerFilter;
+
+    // The end-of-line character sequence
+    private String fNewLine;
+
+    // A SerializationHandler ex. an instance of ToXMLStream
+    private SerializationHandler fSerializationHandler;
+
+    /**
+     * Constructor
+     *
+     * @param handler An instance of the SerializationHandler interface.
+     */
+    public DOM3SerializerImpl(SerializationHandler handler) {
+        fSerializationHandler = handler;
+    }
+
+    // Public memebers
+
+    /**
+     * Returns a DOMErrorHandler set on the DOM Level 3 Serializer.
+     *
+     * This interface is a public API.
+     *
+     * @return A Level 3 DOMErrorHandler
+     */
+    public DOMErrorHandler getErrorHandler() {
+        return fErrorHandler;
+    }
+
+    /**
+     * Returns a LSSerializerFilter set on the DOM Level 3 Serializer to filter nodes
+     * during serialization.
+     *
+     * This interface is a public API.
+     *
+     * @return The Level 3 LSSerializerFilter
+     */
+    public LSSerializerFilter getNodeFilter() {
+        return fSerializerFilter;
+    }
+
+
+    /**
+     * Serializes the Level 3 DOM node by creating an instance of DOM3TreeWalker
+     * which traverses the DOM tree and invokes handler events to serialize
+     * the DOM NOde. Throws an exception only if an I/O exception occured
+     * while serializing.
+     * This interface is a public API.
+     *
+     * @param node the Level 3 DOM node to serialize
+     * @throws IOException if an I/O exception occured while serializing
+     */
+    public void serializeDOM3(Node node) throws IOException {
+        try {
+            DOM3TreeWalker walker = new DOM3TreeWalker(fSerializationHandler,
+                    fErrorHandler, fSerializerFilter, fNewLine);
+
+            walker.traverse(node);
+        } catch (org.xml.sax.SAXException se) {
+            throw new WrappedRuntimeException(se);
+        }
+    }
+
+    /**
+     * Sets a DOMErrorHandler on the DOM Level 3 Serializer.
+     *
+     * This interface is a public API.
+     *
+     * @param handler the Level 3 DOMErrorHandler
+     */
+    public void setErrorHandler(DOMErrorHandler handler) {
+        fErrorHandler = handler;
+    }
+
+    /**
+     * Sets a LSSerializerFilter on the DOM Level 3 Serializer to filter nodes
+     * during serialization.
+     *
+     * This interface is a public API.
+     *
+     * @param filter the Level 3 LSSerializerFilter
+     */
+    public void setNodeFilter(LSSerializerFilter filter) {
+        fSerializerFilter = filter;
+    }
+
+    /**
+     * Sets a SerializationHandler on the DOM Serializer.
+     *
+     * This interface is a public API.
+     *
+     * @param handler An instance of SerializationHandler
+     */
+    public void setSerializationHandler(SerializationHandler handler) {
+        fSerializationHandler = handler;
+    }
+
+    /**
+     * Sets the new line character to be used during serialization
+     * @param newLine a String that is the end-of-line character sequence to be
+     * used in serialization.
+     */
+    public void setNewLine(String newLine) {
+        fNewLine = newLine;
+    }
+}

--- a/jaxp/src/com/sun/org/apache/xml/internal/serializer/dom3/DOM3TreeWalker.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serializer/dom3/DOM3TreeWalker.java
@@ -1,0 +1,2145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the  "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * $Id:  $
+ */
+
+package com.sun.org.apache.xml.internal.serializer.dom3;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Enumeration;
+import java.util.Hashtable;
+import java.util.Properties;
+
+import com.sun.org.apache.xml.internal.serializer.OutputPropertiesFactory;
+import com.sun.org.apache.xml.internal.serializer.SerializationHandler;
+import com.sun.org.apache.xml.internal.serializer.utils.MsgKey;
+import com.sun.org.apache.xml.internal.serializer.utils.Utils;
+import com.sun.org.apache.xerces.internal.util.XML11Char;
+import com.sun.org.apache.xerces.internal.util.XMLChar;
+import org.w3c.dom.Attr;
+import org.w3c.dom.CDATASection;
+import org.w3c.dom.Comment;
+import org.w3c.dom.DOMError;
+import org.w3c.dom.DOMErrorHandler;
+import org.w3c.dom.Document;
+import org.w3c.dom.DocumentType;
+import org.w3c.dom.Element;
+import org.w3c.dom.Entity;
+import org.w3c.dom.EntityReference;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.w3c.dom.ProcessingInstruction;
+import org.w3c.dom.Text;
+import org.w3c.dom.ls.LSSerializerFilter;
+import org.w3c.dom.traversal.NodeFilter;
+import org.xml.sax.Locator;
+import org.xml.sax.SAXException;
+import org.xml.sax.ext.LexicalHandler;
+import org.xml.sax.helpers.LocatorImpl;
+
+/**
+ * Built on org.apache.xml.serializer.TreeWalker and adds functionality to
+ * traverse and serialize a DOM Node (Level 2 or Level 3) as specified in
+ * the DOM Level 3 LS Recommedation by evaluating and applying DOMConfiguration
+ * parameters and filters if any during serialization.
+ *
+ * @xsl.usage internal
+ */
+final class DOM3TreeWalker {
+
+    /**
+     * The SerializationHandler, it extends ContentHandler and when
+     * this class is instantiated via the constructor provided, a
+     * SerializationHandler object is passed to it.
+     */
+    private SerializationHandler fSerializer = null;
+
+    /** We do not need DOM2Helper since DOM Level 3 LS applies to DOM Level 2 or newer */
+
+    /** Locator object for this TreeWalker          */
+    private LocatorImpl fLocator = new LocatorImpl();
+
+    /** ErrorHandler */
+    private DOMErrorHandler fErrorHandler = null;
+
+    /** LSSerializerFilter */
+    private LSSerializerFilter fFilter = null;
+
+    /** If the serializer is an instance of a LexicalHandler */
+    private LexicalHandler fLexicalHandler = null;
+
+    private int fWhatToShowFilter;
+
+    /** New Line character to use in serialization */
+    private String fNewLine = null;
+
+    /** DOMConfiguration Properties */
+    private Properties fDOMConfigProperties = null;
+
+    /** Keeps track if we are in an entity reference when entities=true */
+    private boolean fInEntityRef = false;
+
+    /** Stores the version of the XML document to be serialize */
+    private String fXMLVersion = null;
+
+    /** XML Version, default 1.0 */
+    private boolean fIsXMLVersion11 = false;
+
+    /** Is the Node a Level 3 DOM node */
+    private boolean fIsLevel3DOM = false;
+
+    /** DOM Configuration Parameters */
+    private int fFeatures = 0;
+
+    /** Flag indicating whether following text to be processed is raw text          */
+    boolean fNextIsRaw = false;
+
+    //
+    private static final String XMLNS_URI = "http://www.w3.org/2000/xmlns/";
+
+    //
+    private static final String XMLNS_PREFIX = "xmlns";
+
+    //
+    private static final String XML_URI = "http://www.w3.org/XML/1998/namespace";
+
+    //
+    private static final String XML_PREFIX = "xml";
+
+    /** stores namespaces in scope */
+    protected NamespaceSupport fNSBinder;
+
+    /** stores all namespace bindings on the current element */
+    protected NamespaceSupport fLocalNSBinder;
+
+    /** stores the current element depth */
+    private int fElementDepth = 0;
+
+    // ***********************************************************************
+    // DOMConfiguration paramter settings
+    // ***********************************************************************
+    // Parameter canonical-form, true [optional] - NOT SUPPORTED
+    private final static int CANONICAL = 0x1 << 0;
+
+    // Parameter cdata-sections, true [required] (default)
+    private final static int CDATA = 0x1 << 1;
+
+    // Parameter check-character-normalization, true [optional] - NOT SUPPORTED
+    private final static int CHARNORMALIZE = 0x1 << 2;
+
+    // Parameter comments, true [required] (default)
+    private final static int COMMENTS = 0x1 << 3;
+
+    // Parameter datatype-normalization, true [optional] - NOT SUPPORTED
+    private final static int DTNORMALIZE = 0x1 << 4;
+
+    // Parameter element-content-whitespace, true [required] (default) - value - false [optional] NOT SUPPORTED
+    private final static int ELEM_CONTENT_WHITESPACE = 0x1 << 5;
+
+    // Parameter entities, true [required] (default)
+    private final static int ENTITIES = 0x1 << 6;
+
+    // Parameter infoset, true [required] (default), false has no effect --> True has no effect for the serializer
+    private final static int INFOSET = 0x1 << 7;
+
+    // Parameter namespaces, true [required] (default)
+    private final static int NAMESPACES = 0x1 << 8;
+
+    // Parameter namespace-declarations, true [required] (default)
+    private final static int NAMESPACEDECLS = 0x1 << 9;
+
+    // Parameter normalize-characters, true [optional] - NOT SUPPORTED
+    private final static int NORMALIZECHARS = 0x1 << 10;
+
+    // Parameter split-cdata-sections, true [required] (default)
+    private final static int SPLITCDATA = 0x1 << 11;
+
+    // Parameter validate, true [optional] - NOT SUPPORTED
+    private final static int VALIDATE = 0x1 << 12;
+
+    // Parameter validate-if-schema, true [optional] - NOT SUPPORTED
+    private final static int SCHEMAVALIDATE = 0x1 << 13;
+
+    // Parameter split-cdata-sections, true [required] (default)
+    private final static int WELLFORMED = 0x1 << 14;
+
+    // Parameter discard-default-content, true [required] (default)
+    // Not sure how this will be used in level 2 Documents
+    private final static int DISCARDDEFAULT = 0x1 << 15;
+
+    // Parameter format-pretty-print, true [optional]
+    private final static int PRETTY_PRINT = 0x1 << 16;
+
+    // Parameter ignore-unknown-character-denormalizations, true [required] (default)
+    // We currently do not support XML 1.1 character normalization
+    private final static int IGNORE_CHAR_DENORMALIZE = 0x1 << 17;
+
+    // Parameter discard-default-content, true [required] (default)
+    private final static int XMLDECL = 0x1 << 18;
+
+    /**
+     * Constructor.
+     * @param   contentHandler serialHandler The implemention of the SerializationHandler interface
+     */
+    DOM3TreeWalker(
+        SerializationHandler serialHandler,
+        DOMErrorHandler errHandler,
+        LSSerializerFilter filter,
+        String newLine) {
+        fSerializer = serialHandler;
+        //fErrorHandler = errHandler == null ? new DOMErrorHandlerImpl() : errHandler; // Should we be using the default?
+        fErrorHandler = errHandler;
+        fFilter = filter;
+        fLexicalHandler = null;
+        fNewLine = newLine;
+
+        fNSBinder = new NamespaceSupport();
+        fLocalNSBinder = new NamespaceSupport();
+
+        fDOMConfigProperties = fSerializer.getOutputFormat();
+        fSerializer.setDocumentLocator(fLocator);
+        initProperties(fDOMConfigProperties);
+
+        try {
+            // Bug see Bugzilla  26741
+            fLocator.setSystemId(
+                System.getProperty("user.dir") + File.separator + "dummy.xsl");
+        } catch (SecurityException se) { // user.dir not accessible from applet
+
+        }
+    }
+
+    /**
+     * Perform a pre-order traversal non-recursive style.
+     *
+     * Note that TreeWalker assumes that the subtree is intended to represent
+     * a complete (though not necessarily well-formed) document and, during a
+     * traversal, startDocument and endDocument will always be issued to the
+     * SAX listener.
+     *
+     * @param pos Node in the tree where to start traversal
+     *
+     * @throws TransformerException
+     */
+    public void traverse(Node pos) throws org.xml.sax.SAXException {
+        this.fSerializer.startDocument();
+
+        // Determine if the Node is a DOM Level 3 Core Node.
+        if (pos.getNodeType() != Node.DOCUMENT_NODE) {
+            Document ownerDoc = pos.getOwnerDocument();
+            if (ownerDoc != null
+                && ownerDoc.getImplementation().hasFeature("Core", "3.0")) {
+                fIsLevel3DOM = true;
+            }
+        } else {
+            if (((Document) pos)
+                .getImplementation()
+                .hasFeature("Core", "3.0")) {
+                fIsLevel3DOM = true;
+            }
+        }
+
+        if (fSerializer instanceof LexicalHandler) {
+            fLexicalHandler = ((LexicalHandler) this.fSerializer);
+        }
+
+        if (fFilter != null)
+            fWhatToShowFilter = fFilter.getWhatToShow();
+
+        Node top = pos;
+
+        while (null != pos) {
+            startNode(pos);
+
+            Node nextNode = null;
+
+            nextNode = pos.getFirstChild();
+
+            while (null == nextNode) {
+                endNode(pos);
+
+                if (top.equals(pos))
+                    break;
+
+                nextNode = pos.getNextSibling();
+
+                if (null == nextNode) {
+                    pos = pos.getParentNode();
+
+                    if ((null == pos) || (top.equals(pos))) {
+                        if (null != pos)
+                            endNode(pos);
+
+                        nextNode = null;
+
+                        break;
+                    }
+                }
+            }
+
+            pos = nextNode;
+        }
+        this.fSerializer.endDocument();
+    }
+
+    /**
+     * Perform a pre-order traversal non-recursive style.
+
+     * Note that TreeWalker assumes that the subtree is intended to represent
+     * a complete (though not necessarily well-formed) document and, during a
+     * traversal, startDocument and endDocument will always be issued to the
+     * SAX listener.
+     *
+     * @param pos Node in the tree where to start traversal
+     * @param top Node in the tree where to end traversal
+     *
+     * @throws TransformerException
+     */
+    public void traverse(Node pos, Node top) throws org.xml.sax.SAXException {
+
+        this.fSerializer.startDocument();
+
+        // Determine if the Node is a DOM Level 3 Core Node.
+        if (pos.getNodeType() != Node.DOCUMENT_NODE) {
+            Document ownerDoc = pos.getOwnerDocument();
+            if (ownerDoc != null
+                && ownerDoc.getImplementation().hasFeature("Core", "3.0")) {
+                fIsLevel3DOM = true;
+            }
+        } else {
+            if (((Document) pos)
+                .getImplementation()
+                .hasFeature("Core", "3.0")) {
+                fIsLevel3DOM = true;
+            }
+        }
+
+        if (fSerializer instanceof LexicalHandler) {
+            fLexicalHandler = ((LexicalHandler) this.fSerializer);
+        }
+
+        if (fFilter != null)
+            fWhatToShowFilter = fFilter.getWhatToShow();
+
+        while (null != pos) {
+            startNode(pos);
+
+            Node nextNode = null;
+
+            nextNode = pos.getFirstChild();
+
+            while (null == nextNode) {
+                endNode(pos);
+
+                if ((null != top) && top.equals(pos))
+                    break;
+
+                nextNode = pos.getNextSibling();
+
+                if (null == nextNode) {
+                    pos = pos.getParentNode();
+
+                    if ((null == pos) || ((null != top) && top.equals(pos))) {
+                        nextNode = null;
+
+                        break;
+                    }
+                }
+            }
+
+            pos = nextNode;
+        }
+        this.fSerializer.endDocument();
+    }
+
+    /**
+     * Optimized dispatch of characters.
+     */
+    private final void dispatachChars(Node node)
+        throws org.xml.sax.SAXException {
+        if (fSerializer != null) {
+            this.fSerializer.characters(node);
+        } else {
+            String data = ((Text) node).getData();
+            this.fSerializer.characters(data.toCharArray(), 0, data.length());
+        }
+    }
+
+    /**
+     * Start processing given node
+     *
+     * @param node Node to process
+     *
+     * @throws org.xml.sax.SAXException
+     */
+    protected void startNode(Node node) throws org.xml.sax.SAXException {
+        if (node instanceof Locator) {
+            Locator loc = (Locator) node;
+            fLocator.setColumnNumber(loc.getColumnNumber());
+            fLocator.setLineNumber(loc.getLineNumber());
+            fLocator.setPublicId(loc.getPublicId());
+            fLocator.setSystemId(loc.getSystemId());
+        } else {
+            fLocator.setColumnNumber(0);
+            fLocator.setLineNumber(0);
+        }
+
+        switch (node.getNodeType()) {
+            case Node.DOCUMENT_TYPE_NODE :
+                serializeDocType((DocumentType) node, true);
+                break;
+            case Node.COMMENT_NODE :
+                serializeComment((Comment) node);
+                break;
+            case Node.DOCUMENT_FRAGMENT_NODE :
+                // Children are traversed
+                break;
+            case Node.DOCUMENT_NODE :
+                break;
+            case Node.ELEMENT_NODE :
+                serializeElement((Element) node, true);
+                break;
+            case Node.PROCESSING_INSTRUCTION_NODE :
+                serializePI((ProcessingInstruction) node);
+                break;
+            case Node.CDATA_SECTION_NODE :
+                serializeCDATASection((CDATASection) node);
+                break;
+            case Node.TEXT_NODE :
+                serializeText((Text) node);
+                break;
+            case Node.ENTITY_REFERENCE_NODE :
+                serializeEntityReference((EntityReference) node, true);
+                break;
+            default :
+                }
+    }
+
+    /**
+     * End processing of given node
+     *
+     *
+     * @param node Node we just finished processing
+     *
+     * @throws org.xml.sax.SAXException
+     */
+    protected void endNode(Node node) throws org.xml.sax.SAXException {
+
+        switch (node.getNodeType()) {
+            case Node.DOCUMENT_NODE :
+                break;
+            case Node.DOCUMENT_TYPE_NODE :
+                serializeDocType((DocumentType) node, false);
+                break;
+            case Node.ELEMENT_NODE :
+                serializeElement((Element) node, false);
+                break;
+            case Node.CDATA_SECTION_NODE :
+                break;
+            case Node.ENTITY_REFERENCE_NODE :
+                serializeEntityReference((EntityReference) node, false);
+                break;
+            default :
+                }
+    }
+
+    // ***********************************************************************
+    // Node serialization methods
+    // ***********************************************************************
+    /**
+     * Applies a filter on the node to serialize
+     *
+     * @param node The Node to serialize
+     * @return True if the node is to be serialized else false if the node
+     *         is to be rejected or skipped.
+     */
+    protected boolean applyFilter(Node node, int nodeType) {
+        if (fFilter != null && (fWhatToShowFilter & nodeType) != 0) {
+
+            short code = fFilter.acceptNode(node);
+            switch (code) {
+                case NodeFilter.FILTER_REJECT :
+                case NodeFilter.FILTER_SKIP :
+                    return false; // skip the node
+                default : // fall through..
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Serializes a Document Type Node.
+     *
+     * @param node The Docuemnt Type Node to serialize
+     * @param bStart Invoked at the start or end of node.  Default true.
+     */
+    protected void serializeDocType(DocumentType node, boolean bStart)
+        throws SAXException {
+        // The DocType and internalSubset can not be modified in DOM and is
+        // considered to be well-formed as the outcome of successful parsing.
+        String docTypeName = node.getNodeName();
+        String publicId = node.getPublicId();
+        String systemId = node.getSystemId();
+        String internalSubset = node.getInternalSubset();
+
+        //DocumentType nodes are never passed to the filter
+
+        if (internalSubset != null && !"".equals(internalSubset)) {
+
+            if (bStart) {
+                try {
+                    // The Serializer does not provide a way to write out the
+                    // DOCTYPE internal subset via an event call, so we write it
+                    // out here.
+                    Writer writer = fSerializer.getWriter();
+                    StringBuffer dtd = new StringBuffer();
+
+                    dtd.append("<!DOCTYPE ");
+                    dtd.append(docTypeName);
+                    if (null != publicId) {
+                        dtd.append(" PUBLIC \"");
+                        dtd.append(publicId);
+                        dtd.append('\"');
+                    }
+
+                    if (null != systemId) {
+                        if (null == publicId) {
+                            dtd.append(" SYSTEM \"");
+                        } else {
+                            dtd.append(" \"");
+                        }
+                        dtd.append(systemId);
+                        dtd.append('\"');
+                    }
+
+                    dtd.append(" [ ");
+
+                    dtd.append(fNewLine);
+                    dtd.append(internalSubset);
+                    dtd.append("]>");
+                    dtd.append(fNewLine);
+
+                    writer.write(dtd.toString());
+                    writer.flush();
+
+                } catch (IOException e) {
+                    throw new SAXException(Utils.messages.createMessage(
+                            MsgKey.ER_WRITING_INTERNAL_SUBSET, null), e);
+                }
+            } // else if !bStart do nothing
+
+        } else {
+
+            if (bStart) {
+                if (fLexicalHandler != null) {
+                    fLexicalHandler.startDTD(docTypeName, publicId, systemId);
+                }
+            } else {
+                if (fLexicalHandler != null) {
+                    fLexicalHandler.endDTD();
+                }
+            }
+        }
+    }
+
+    /**
+     * Serializes a Comment Node.
+     *
+     * @param node The Comment Node to serialize
+     */
+    protected void serializeComment(Comment node) throws SAXException {
+        // comments=true
+        if ((fFeatures & COMMENTS) != 0) {
+            String data = node.getData();
+
+            // well-formed=true
+            if ((fFeatures & WELLFORMED) != 0) {
+                isCommentWellFormed(data);
+            }
+
+            if (fLexicalHandler != null) {
+                // apply the LSSerializer filter after the operations requested by the
+                // DOMConfiguration parameters have been applied
+                if (!applyFilter(node, NodeFilter.SHOW_COMMENT)) {
+                    return;
+                }
+
+                fLexicalHandler.comment(data.toCharArray(), 0, data.length());
+            }
+        }
+    }
+
+    /**
+     * Serializes an Element Node.
+     *
+     * @param node The Element Node to serialize
+     * @param bStart Invoked at the start or end of node.
+     */
+    protected void serializeElement(Element node, boolean bStart)
+        throws SAXException {
+        if (bStart) {
+            fElementDepth++;
+
+            // We use the Xalan specific startElement and starPrefixMapping calls
+            // (and addAttribute and namespaceAfterStartElement) as opposed to
+            // SAX specific, for performance reasons as they reduce the overhead
+            // of creating an AttList object upfront.
+
+            // well-formed=true
+            if ((fFeatures & WELLFORMED) != 0) {
+                isElementWellFormed(node);
+            }
+
+            // REVISIT: We apply the LSSerializer filter for elements before
+            // namesapce fixup
+            if (!applyFilter(node, NodeFilter.SHOW_ELEMENT)) {
+                return;
+            }
+
+            // namespaces=true, record and fixup namspaced element
+            if ((fFeatures & NAMESPACES) != 0) {
+                fNSBinder.pushContext();
+                fLocalNSBinder.reset();
+
+                recordLocalNSDecl(node);
+                fixupElementNS(node);
+            }
+
+            // Namespace normalization
+            fSerializer.startElement(
+                        node.getNamespaceURI(),
+                    node.getLocalName(),
+                    node.getNodeName());
+
+            serializeAttList(node);
+
+        } else {
+                fElementDepth--;
+
+            // apply the LSSerializer filter
+            if (!applyFilter(node, NodeFilter.SHOW_ELEMENT)) {
+                return;
+            }
+
+            this.fSerializer.endElement(
+                node.getNamespaceURI(),
+                node.getLocalName(),
+                node.getNodeName());
+            // since endPrefixMapping was not used by SerializationHandler it was removed
+            // for performance reasons.
+
+            if ((fFeatures & NAMESPACES) != 0 ) {
+                    fNSBinder.popContext();
+            }
+
+        }
+    }
+
+    /**
+     * Serializes the Attr Nodes of an Element.
+     *
+     * @param node The OwnerElement whose Attr Nodes are to be serialized.
+     */
+    protected void serializeAttList(Element node) throws SAXException {
+        NamedNodeMap atts = node.getAttributes();
+        int nAttrs = atts.getLength();
+
+        for (int i = 0; i < nAttrs; i++) {
+            Node attr = atts.item(i);
+
+            String localName = attr.getLocalName();
+            String attrName = attr.getNodeName();
+            String attrPrefix = attr.getPrefix() == null ? "" : attr.getPrefix();
+            String attrValue = attr.getNodeValue();
+
+            // Determine the Attr's type.
+            String type = null;
+            if (fIsLevel3DOM) {
+                type = ((Attr) attr).getSchemaTypeInfo().getTypeName();
+            }
+            type = type == null ? "CDATA" : type;
+
+            String attrNS = attr.getNamespaceURI();
+            if (attrNS !=null && attrNS.length() == 0) {
+                attrNS=null;
+                // we must remove prefix for this attribute
+                attrName=attr.getLocalName();
+            }
+
+            boolean isSpecified = ((Attr) attr).getSpecified();
+            boolean addAttr = true;
+            boolean applyFilter = false;
+            boolean xmlnsAttr =
+                attrName.equals("xmlns") || attrName.startsWith("xmlns:");
+
+            // well-formed=true
+            if ((fFeatures & WELLFORMED) != 0) {
+                isAttributeWellFormed(attr);
+            }
+
+            //-----------------------------------------------------------------
+            // start Attribute namespace fixup
+            //-----------------------------------------------------------------
+            // namespaces=true, normalize all non-namespace attributes
+            // Step 3. Attribute
+            if ((fFeatures & NAMESPACES) != 0 && !xmlnsAttr) {
+
+                        // If the Attr has a namespace URI
+                        if (attrNS != null) {
+                                attrPrefix = attrPrefix == null ? "" : attrPrefix;
+
+                                String declAttrPrefix = fNSBinder.getPrefix(attrNS);
+                                String declAttrNS = fNSBinder.getURI(attrPrefix);
+
+                                // attribute has no prefix (default namespace decl does not apply to
+                                // attributes)
+                                // OR
+                                // attribute prefix is not declared
+                                // OR
+                                // conflict: attribute has a prefix that conflicts with a binding
+                                if ("".equals(attrPrefix) || "".equals(declAttrPrefix)
+                                                || !attrPrefix.equals(declAttrPrefix)) {
+
+                                        // namespaceURI matches an in scope declaration of one or
+                                        // more prefixes
+                                        if (declAttrPrefix != null && !"".equals(declAttrPrefix)) {
+                                                // pick the prefix that was found and change attribute's
+                                                // prefix and nodeName.
+                                                attrPrefix = declAttrPrefix;
+
+                                                if (declAttrPrefix.length() > 0 ) {
+                                                        attrName = declAttrPrefix + ":" + localName;
+                                                } else {
+                                                        attrName = localName;
+                                                }
+                                        } else {
+                                                // The current prefix is not null and it has no in scope
+                                                // declaration
+                                                if (attrPrefix != null && !"".equals(attrPrefix)
+                                                                && declAttrNS == null) {
+                                                        // declare this prefix
+                                                        if ((fFeatures & NAMESPACEDECLS) != 0) {
+                                                                fSerializer.addAttribute(XMLNS_URI, attrPrefix,
+                                                                                XMLNS_PREFIX + ":" + attrPrefix, "CDATA",
+                                                                                attrNS);
+                                                                fNSBinder.declarePrefix(attrPrefix, attrNS);
+                                                                fLocalNSBinder.declarePrefix(attrPrefix, attrNS);
+                                                        }
+                                                } else {
+                                                        // find a prefix following the pattern "NS" +index
+                                                        // (starting at 1)
+                                                        // make sure this prefix is not declared in the current
+                                                        // scope.
+                                                        int counter = 1;
+                                                        attrPrefix = "NS" + counter++;
+
+                                                        while (fLocalNSBinder.getURI(attrPrefix) != null) {
+                                                                attrPrefix = "NS" + counter++;
+                                                        }
+                                                        // change attribute's prefix and Name
+                                                        attrName = attrPrefix + ":" + localName;
+
+                                                        // create a local namespace declaration attribute
+                                                        // Add the xmlns declaration attribute
+                                                        if ((fFeatures & NAMESPACEDECLS) != 0) {
+
+                                                                fSerializer.addAttribute(XMLNS_URI, attrPrefix,
+                                                                                XMLNS_PREFIX + ":" + attrPrefix, "CDATA",
+                                                                                attrNS);
+                                                        fNSBinder.declarePrefix(attrPrefix, attrNS);
+                                                        fLocalNSBinder.declarePrefix(attrPrefix, attrNS);
+                                                        }
+                                                }
+                                        }
+                                }
+
+                        } else { // if the Attr has no namespace URI
+                                // Attr has no localName
+                                if (localName == null) {
+                                        // DOM Level 1 node!
+                                        String msg = Utils.messages.createMessage(
+                                                        MsgKey.ER_NULL_LOCAL_ELEMENT_NAME,
+                                                        new Object[] { attrName });
+
+                                        if (fErrorHandler != null) {
+                                                fErrorHandler
+                                                                .handleError(new DOMErrorImpl(
+                                                                                DOMError.SEVERITY_ERROR, msg,
+                                                                                MsgKey.ER_NULL_LOCAL_ELEMENT_NAME, null,
+                                                                                null, null));
+                                        }
+
+                                } else { // uri=null and no colon
+                                        // attr has no namespace URI and no prefix
+                                        // no action is required, since attrs don't use default
+                                }
+                        }
+
+            }
+
+
+            // discard-default-content=true
+            // Default attr's are not passed to the filter and this contraint
+            // is applied only when discard-default-content=true
+            // What about default xmlns attributes???? check for xmlnsAttr
+            if ((((fFeatures & DISCARDDEFAULT) != 0) && isSpecified)
+                || ((fFeatures & DISCARDDEFAULT) == 0)) {
+                applyFilter = true;
+            } else {
+                addAttr = false;
+            }
+
+            if (applyFilter) {
+                // apply the filter for Attributes that are not default attributes
+                // or namespace decl attributes
+                if (fFilter != null
+                    && (fFilter.getWhatToShow() & NodeFilter.SHOW_ATTRIBUTE)
+                        != 0) {
+
+                    if (!xmlnsAttr) {
+                        short code = fFilter.acceptNode(attr);
+                        switch (code) {
+                            case NodeFilter.FILTER_REJECT :
+                            case NodeFilter.FILTER_SKIP :
+                                addAttr = false;
+                                break;
+                            default : //fall through..
+                        }
+                    }
+                }
+            }
+
+            // if the node is a namespace node
+            if (addAttr && xmlnsAttr) {
+                // If namespace-declarations=true, add the node , else don't add it
+                if ((fFeatures & NAMESPACEDECLS) != 0) {
+                        // The namespace may have been fixed up, in that case don't add it.
+                        if (localName != null && !"".equals(localName)) {
+                                fSerializer.addAttribute(attrNS, localName, attrName, type, attrValue);
+                        }
+                }
+            } else if (
+                addAttr && !xmlnsAttr) { // if the node is not a namespace node
+                // If namespace-declarations=true, add the node with the Attr nodes namespaceURI
+                // else add the node setting it's namespace to null or else the serializer will later
+                // attempt to add a xmlns attr for the prefixed attribute
+                if (((fFeatures & NAMESPACEDECLS) != 0) && (attrNS != null)) {
+                    fSerializer.addAttribute(
+                        attrNS,
+                        localName,
+                        attrName,
+                        type,
+                        attrValue);
+                } else {
+                    fSerializer.addAttribute(
+                        "",
+                        localName,
+                        attrName,
+                        type,
+                        attrValue);
+                }
+            }
+
+            //
+            if (xmlnsAttr && ((fFeatures & NAMESPACEDECLS) != 0)) {
+                int index;
+                // Use "" instead of null, as Xerces likes "" for the
+                // name of the default namespace.  Fix attributed
+                // to "Steven Murray" <smurray@ebt.com>.
+                String prefix =
+                    (index = attrName.indexOf(":")) < 0
+                        ? ""
+                        : attrName.substring(index + 1);
+
+                if (!"".equals(prefix)) {
+                    fSerializer.namespaceAfterStartElement(prefix, attrValue);
+                }
+            }
+        }
+
+    }
+
+    /**
+     * Serializes an ProcessingInstruction Node.
+     *
+     * @param node The ProcessingInstruction Node to serialize
+     */
+    protected void serializePI(ProcessingInstruction node)
+        throws SAXException {
+        ProcessingInstruction pi = node;
+        String name = pi.getNodeName();
+
+        // well-formed=true
+        if ((fFeatures & WELLFORMED) != 0) {
+            isPIWellFormed(node);
+        }
+
+        // apply the LSSerializer filter
+        if (!applyFilter(node, NodeFilter.SHOW_PROCESSING_INSTRUCTION)) {
+            return;
+        }
+
+        // String data = pi.getData();
+        if (name.equals("xslt-next-is-raw")) {
+            fNextIsRaw = true;
+        } else {
+            this.fSerializer.processingInstruction(name, pi.getData());
+        }
+    }
+
+    /**
+     * Serializes an CDATASection Node.
+     *
+     * @param node The CDATASection Node to serialize
+     */
+    protected void serializeCDATASection(CDATASection node)
+        throws SAXException {
+        // well-formed=true
+        if ((fFeatures & WELLFORMED) != 0) {
+            isCDATASectionWellFormed(node);
+        }
+
+        // cdata-sections = true
+        if ((fFeatures & CDATA) != 0) {
+
+            // split-cdata-sections = true
+            // Assumption: This parameter has an effect only when
+                        // cdata-sections=true
+            // ToStream, by default splits cdata-sections. Hence the check
+                        // below.
+            String nodeValue = node.getNodeValue();
+            int endIndex = nodeValue.indexOf("]]>");
+            if ((fFeatures & SPLITCDATA) != 0) {
+                if (endIndex >= 0) {
+                    // The first node split will contain the ]] markers
+                    String relatedData = nodeValue.substring(0, endIndex + 2);
+
+                    String msg =
+                        Utils.messages.createMessage(
+                            MsgKey.ER_CDATA_SECTIONS_SPLIT,
+                            null);
+
+                    if (fErrorHandler != null) {
+                        fErrorHandler.handleError(
+                            new DOMErrorImpl(
+                                DOMError.SEVERITY_WARNING,
+                                msg,
+                                MsgKey.ER_CDATA_SECTIONS_SPLIT,
+                                null,
+                                relatedData,
+                                null));
+                    }
+                }
+            } else {
+                if (endIndex >= 0) {
+                    // The first node split will contain the ]] markers
+                    String relatedData = nodeValue.substring(0, endIndex + 2);
+
+                    String msg =
+                        Utils.messages.createMessage(
+                            MsgKey.ER_CDATA_SECTIONS_SPLIT,
+                            null);
+
+                    if (fErrorHandler != null) {
+                        fErrorHandler.handleError(
+                            new DOMErrorImpl(
+                                DOMError.SEVERITY_ERROR,
+                                msg,
+                                MsgKey.ER_CDATA_SECTIONS_SPLIT));
+                    }
+                    // Report an error and return.  What error???
+                    return;
+                }
+            }
+
+            // apply the LSSerializer filter
+            if (!applyFilter(node, NodeFilter.SHOW_CDATA_SECTION)) {
+                return;
+            }
+
+            // splits the cdata-section
+            if (fLexicalHandler != null) {
+                fLexicalHandler.startCDATA();
+            }
+            dispatachChars(node);
+            if (fLexicalHandler != null) {
+                fLexicalHandler.endCDATA();
+            }
+        } else {
+            dispatachChars(node);
+        }
+    }
+
+    /**
+     * Serializes an Text Node.
+     *
+     * @param node The Text Node to serialize
+     */
+    protected void serializeText(Text node) throws SAXException {
+        if (fNextIsRaw) {
+            fNextIsRaw = false;
+            fSerializer.processingInstruction(
+                javax.xml.transform.Result.PI_DISABLE_OUTPUT_ESCAPING,
+                "");
+            dispatachChars(node);
+            fSerializer.processingInstruction(
+                javax.xml.transform.Result.PI_ENABLE_OUTPUT_ESCAPING,
+                "");
+        } else {
+            // keep track of dispatch or not to avoid duplicaiton of filter code
+            boolean bDispatch = false;
+
+            // well-formed=true
+            if ((fFeatures & WELLFORMED) != 0) {
+                isTextWellFormed(node);
+            }
+
+            // if the node is whitespace
+            // Determine the Attr's type.
+            boolean isElementContentWhitespace = false;
+            if (fIsLevel3DOM) {
+                isElementContentWhitespace =
+                       node.isElementContentWhitespace();
+            }
+
+            if (isElementContentWhitespace) {
+                // element-content-whitespace=true
+                if ((fFeatures & ELEM_CONTENT_WHITESPACE) != 0) {
+                    bDispatch = true;
+                }
+            } else {
+                bDispatch = true;
+            }
+
+            // apply the LSSerializer filter
+            if (!applyFilter(node, NodeFilter.SHOW_TEXT)) {
+                return;
+            }
+
+            if (bDispatch) {
+                dispatachChars(node);
+            }
+        }
+    }
+
+    /**
+     * Serializes an EntityReference Node.
+     *
+     * @param node The EntityReference Node to serialize
+     * @param bStart Inicates if called from start or endNode
+     */
+    protected void serializeEntityReference(
+        EntityReference node,
+        boolean bStart)
+        throws SAXException {
+        if (bStart) {
+            EntityReference eref = node;
+            // entities=true
+            if ((fFeatures & ENTITIES) != 0) {
+
+                // perform well-formedness and other checking only if
+                // entities = true
+
+                // well-formed=true
+                if ((fFeatures & WELLFORMED) != 0) {
+                    isEntityReferneceWellFormed(node);
+                }
+
+                // check "unbound-prefix-in-entity-reference" [fatal]
+                // Raised if the configuration parameter "namespaces" is set to true
+                if ((fFeatures & NAMESPACES) != 0) {
+                    checkUnboundPrefixInEntRef(node);
+                }
+
+                // The filter should not apply in this case, since the
+                // EntityReference is not being expanded.
+                // should we pass entity reference nodes to the filter???
+            }
+
+            if (fLexicalHandler != null) {
+
+                // startEntity outputs only Text but not Element, Attr, Comment
+                // and PI child nodes.  It does so by setting the m_inEntityRef
+                // in ToStream and using this to decide if a node is to be
+                // serialized or not.
+                fLexicalHandler.startEntity(eref.getNodeName());
+            }
+
+        } else {
+            EntityReference eref = node;
+            // entities=true or false,
+            if (fLexicalHandler != null) {
+                fLexicalHandler.endEntity(eref.getNodeName());
+            }
+        }
+    }
+
+
+    // ***********************************************************************
+    // Methods to check well-formedness
+    // ***********************************************************************
+    /**
+     * Taken from org.apache.xerces.dom.CoreDocumentImpl
+     *
+     * Check the string against XML's definition of acceptable names for
+     * elements and attributes and so on using the XMLCharacterProperties
+     * utility class
+     */
+    protected boolean isXMLName(String s, boolean xml11Version) {
+
+        if (s == null) {
+            return false;
+        }
+        if (!xml11Version)
+            return XMLChar.isValidName(s);
+        else
+            return XML11Char.isXML11ValidName(s);
+    }
+
+    /**
+     * Taken from org.apache.xerces.dom.CoreDocumentImpl
+     *
+     * Checks if the given qualified name is legal with respect
+     * to the version of XML to which this document must conform.
+     *
+     * @param prefix prefix of qualified name
+     * @param local local part of qualified name
+     */
+    protected boolean isValidQName(
+        String prefix,
+        String local,
+        boolean xml11Version) {
+
+        // check that both prefix and local part match NCName
+        if (local == null)
+            return false;
+        boolean validNCName = false;
+
+        if (!xml11Version) {
+            validNCName =
+                (prefix == null || XMLChar.isValidNCName(prefix))
+                    && XMLChar.isValidNCName(local);
+        } else {
+            validNCName =
+                (prefix == null || XML11Char.isXML11ValidNCName(prefix))
+                    && XML11Char.isXML11ValidNCName(local);
+        }
+
+        return validNCName;
+    }
+
+    /**
+     * Checks if a XML character is well-formed
+     *
+     * @param characters A String of characters to be checked for Well-Formedness
+     * @param refInvalidChar A reference to the character to be returned that was determined invalid.
+     */
+    protected boolean isWFXMLChar(String chardata, Character refInvalidChar) {
+        if (chardata == null || (chardata.length() == 0)) {
+            return true;
+        }
+
+        char[] dataarray = chardata.toCharArray();
+        int datalength = dataarray.length;
+
+        // version of the document is XML 1.1
+        if (fIsXMLVersion11) {
+            //we need to check all characters as per production rules of XML11
+            int i = 0;
+            while (i < datalength) {
+                if (XML11Char.isXML11Invalid(dataarray[i++])) {
+                    // check if this is a supplemental character
+                    char ch = dataarray[i - 1];
+                    if (XMLChar.isHighSurrogate(ch) && i < datalength) {
+                        char ch2 = dataarray[i++];
+                        if (XMLChar.isLowSurrogate(ch2)
+                            && XMLChar.isSupplemental(
+                                XMLChar.supplemental(ch, ch2))) {
+                            continue;
+                        }
+                    }
+                    // Reference to invalid character which is returned
+                    refInvalidChar = new Character(ch);
+                    return false;
+                }
+            }
+        } // version of the document is XML 1.0
+        else {
+            // we need to check all characters as per production rules of XML 1.0
+            int i = 0;
+            while (i < datalength) {
+                if (XMLChar.isInvalid(dataarray[i++])) {
+                    // check if this is a supplemental character
+                    char ch = dataarray[i - 1];
+                    if (XMLChar.isHighSurrogate(ch) && i < datalength) {
+                        char ch2 = dataarray[i++];
+                        if (XMLChar.isLowSurrogate(ch2)
+                            && XMLChar.isSupplemental(
+                                XMLChar.supplemental(ch, ch2))) {
+                            continue;
+                        }
+                    }
+                    // Reference to invalid character which is returned
+                    refInvalidChar = new Character(ch);
+                    return false;
+                }
+            }
+        } // end-else fDocument.isXMLVersion()
+
+        return true;
+    } // isXMLCharWF
+
+    /**
+     * Checks if a XML character is well-formed.  If there is a problem with
+     * the character a non-null Character is returned else null is returned.
+     *
+     * @param characters A String of characters to be checked for Well-Formedness
+     * @return Character A reference to the character to be returned that was determined invalid.
+     */
+    protected Character isWFXMLChar(String chardata) {
+        Character refInvalidChar;
+        if (chardata == null || (chardata.length() == 0)) {
+            return null;
+        }
+
+        char[] dataarray = chardata.toCharArray();
+        int datalength = dataarray.length;
+
+        // version of the document is XML 1.1
+        if (fIsXMLVersion11) {
+            //we need to check all characters as per production rules of XML11
+            int i = 0;
+            while (i < datalength) {
+                if (XML11Char.isXML11Invalid(dataarray[i++])) {
+                    // check if this is a supplemental character
+                    char ch = dataarray[i - 1];
+                    if (XMLChar.isHighSurrogate(ch) && i < datalength) {
+                        char ch2 = dataarray[i++];
+                        if (XMLChar.isLowSurrogate(ch2)
+                            && XMLChar.isSupplemental(
+                                XMLChar.supplemental(ch, ch2))) {
+                            continue;
+                        }
+                    }
+                    // Reference to invalid character which is returned
+                    refInvalidChar = new Character(ch);
+                    return refInvalidChar;
+                }
+            }
+        } // version of the document is XML 1.0
+        else {
+            // we need to check all characters as per production rules of XML 1.0
+            int i = 0;
+            while (i < datalength) {
+                if (XMLChar.isInvalid(dataarray[i++])) {
+                    // check if this is a supplemental character
+                    char ch = dataarray[i - 1];
+                    if (XMLChar.isHighSurrogate(ch) && i < datalength) {
+                        char ch2 = dataarray[i++];
+                        if (XMLChar.isLowSurrogate(ch2)
+                            && XMLChar.isSupplemental(
+                                XMLChar.supplemental(ch, ch2))) {
+                            continue;
+                        }
+                    }
+                    // Reference to invalid character which is returned
+                    refInvalidChar = new Character(ch);
+                    return refInvalidChar;
+                }
+            }
+        } // end-else fDocument.isXMLVersion()
+
+        return null;
+    } // isXMLCharWF
+
+    /**
+     * Checks if a comment node is well-formed
+     *
+     * @param data The contents of the comment node
+     * @return a boolean indiacating if the comment is well-formed or not.
+     */
+    protected void isCommentWellFormed(String data) {
+        if (data == null || (data.length() == 0)) {
+            return;
+        }
+
+        char[] dataarray = data.toCharArray();
+        int datalength = dataarray.length;
+
+        // version of the document is XML 1.1
+        if (fIsXMLVersion11) {
+            // we need to check all chracters as per production rules of XML11
+            int i = 0;
+            while (i < datalength) {
+                char c = dataarray[i++];
+                if (XML11Char.isXML11Invalid(c)) {
+                    // check if this is a supplemental character
+                    if (XMLChar.isHighSurrogate(c) && i < datalength) {
+                        char c2 = dataarray[i++];
+                        if (XMLChar.isLowSurrogate(c2)
+                            && XMLChar.isSupplemental(
+                                XMLChar.supplemental(c, c2))) {
+                            continue;
+                        }
+                    }
+                    String msg =
+                        Utils.messages.createMessage(
+                            MsgKey.ER_WF_INVALID_CHARACTER_IN_COMMENT,
+                            new Object[] { new Character(c)});
+
+                    if (fErrorHandler != null) {
+                        fErrorHandler.handleError(
+                            new DOMErrorImpl(
+                                DOMError.SEVERITY_FATAL_ERROR,
+                                msg,
+                                MsgKey.ER_WF_INVALID_CHARACTER,
+                                null,
+                                null,
+                                null));
+                    }
+                } else if (c == '-' && i < datalength && dataarray[i] == '-') {
+                    String msg =
+                        Utils.messages.createMessage(
+                            MsgKey.ER_WF_DASH_IN_COMMENT,
+                            null);
+
+                    if (fErrorHandler != null) {
+                        fErrorHandler.handleError(
+                            new DOMErrorImpl(
+                                DOMError.SEVERITY_FATAL_ERROR,
+                                msg,
+                                MsgKey.ER_WF_INVALID_CHARACTER,
+                                null,
+                                null,
+                                null));
+                    }
+                }
+            }
+        } // version of the document is XML 1.0
+        else {
+            // we need to check all chracters as per production rules of XML 1.0
+            int i = 0;
+            while (i < datalength) {
+                char c = dataarray[i++];
+                if (XMLChar.isInvalid(c)) {
+                    // check if this is a supplemental character
+                    if (XMLChar.isHighSurrogate(c) && i < datalength) {
+                        char c2 = dataarray[i++];
+                        if (XMLChar.isLowSurrogate(c2)
+                            && XMLChar.isSupplemental(
+                                XMLChar.supplemental(c, c2))) {
+                            continue;
+                        }
+                    }
+                    String msg =
+                        Utils.messages.createMessage(
+                            MsgKey.ER_WF_INVALID_CHARACTER_IN_COMMENT,
+                            new Object[] { new Character(c)});
+
+                    if (fErrorHandler != null) {
+                        fErrorHandler.handleError(
+                            new DOMErrorImpl(
+                                DOMError.SEVERITY_FATAL_ERROR,
+                                msg,
+                                MsgKey.ER_WF_INVALID_CHARACTER,
+                                null,
+                                null,
+                                null));
+                    }
+                } else if (c == '-' && i < datalength && dataarray[i] == '-') {
+                    String msg =
+                        Utils.messages.createMessage(
+                            MsgKey.ER_WF_DASH_IN_COMMENT,
+                            null);
+
+                    if (fErrorHandler != null) {
+                        fErrorHandler.handleError(
+                            new DOMErrorImpl(
+                                DOMError.SEVERITY_FATAL_ERROR,
+                                msg,
+                                MsgKey.ER_WF_INVALID_CHARACTER,
+                                null,
+                                null,
+                                null));
+                    }
+                }
+            }
+        }
+        return;
+    }
+
+    /**
+     * Checks if an element node is well-formed, by checking its Name for well-formedness.
+     *
+     * @param data The contents of the comment node
+     * @return a boolean indiacating if the comment is well-formed or not.
+     */
+    protected void isElementWellFormed(Node node) {
+        boolean isNameWF = false;
+        if ((fFeatures & NAMESPACES) != 0) {
+            isNameWF =
+                isValidQName(
+                    node.getPrefix(),
+                    node.getLocalName(),
+                    fIsXMLVersion11);
+        } else {
+            isNameWF = isXMLName(node.getNodeName(), fIsXMLVersion11);
+        }
+
+        if (!isNameWF) {
+            String msg =
+                Utils.messages.createMessage(
+                    MsgKey.ER_WF_INVALID_CHARACTER_IN_NODE_NAME,
+                    new Object[] { "Element", node.getNodeName()});
+
+            if (fErrorHandler != null) {
+                fErrorHandler.handleError(
+                    new DOMErrorImpl(
+                        DOMError.SEVERITY_FATAL_ERROR,
+                        msg,
+                        MsgKey.ER_WF_INVALID_CHARACTER_IN_NODE_NAME,
+                        null,
+                        null,
+                        null));
+            }
+        }
+    }
+
+    /**
+     * Checks if an attr node is well-formed, by checking it's Name and value
+     * for well-formedness.
+     *
+     * @param data The contents of the comment node
+     * @return a boolean indiacating if the comment is well-formed or not.
+     */
+    protected void isAttributeWellFormed(Node node) {
+        boolean isNameWF = false;
+        if ((fFeatures & NAMESPACES) != 0) {
+            isNameWF =
+                isValidQName(
+                    node.getPrefix(),
+                    node.getLocalName(),
+                    fIsXMLVersion11);
+        } else {
+            isNameWF = isXMLName(node.getNodeName(), fIsXMLVersion11);
+        }
+
+        if (!isNameWF) {
+            String msg =
+                Utils.messages.createMessage(
+                    MsgKey.ER_WF_INVALID_CHARACTER_IN_NODE_NAME,
+                    new Object[] { "Attr", node.getNodeName()});
+
+            if (fErrorHandler != null) {
+                fErrorHandler.handleError(
+                    new DOMErrorImpl(
+                        DOMError.SEVERITY_FATAL_ERROR,
+                        msg,
+                        MsgKey.ER_WF_INVALID_CHARACTER_IN_NODE_NAME,
+                        null,
+                        null,
+                        null));
+            }
+        }
+
+        // Check the Attr's node value
+        // WFC: No < in Attribute Values
+        String value = node.getNodeValue();
+        if (value.indexOf('<') >= 0) {
+            String msg =
+                Utils.messages.createMessage(
+                    MsgKey.ER_WF_LT_IN_ATTVAL,
+                    new Object[] {
+                        ((Attr) node).getOwnerElement().getNodeName(),
+                        node.getNodeName()});
+
+            if (fErrorHandler != null) {
+                fErrorHandler.handleError(
+                    new DOMErrorImpl(
+                        DOMError.SEVERITY_FATAL_ERROR,
+                        msg,
+                        MsgKey.ER_WF_LT_IN_ATTVAL,
+                        null,
+                        null,
+                        null));
+            }
+        }
+
+        // we need to loop through the children of attr nodes and check their values for
+        // well-formedness
+        NodeList children = node.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            Node child = children.item(i);
+            // An attribute node with no text or entity ref child for example
+            // doc.createAttributeNS("http://www.w3.org/2000/xmlns/", "xmlns:ns");
+            // followes by
+            // element.setAttributeNodeNS(attribute);
+            // can potentially lead to this situation.  If the attribute
+            // was a prefix Namespace attribute declaration then then DOM Core
+            // should have some exception defined for this.
+            if (child == null) {
+                // we should probably report an error
+                continue;
+            }
+            switch (child.getNodeType()) {
+                case Node.TEXT_NODE :
+                    isTextWellFormed((Text) child);
+                    break;
+                case Node.ENTITY_REFERENCE_NODE :
+                    isEntityReferneceWellFormed((EntityReference) child);
+                    break;
+                default :
+            }
+        }
+
+        // TODO:
+        // WFC: Check if the attribute prefix is bound to
+        // http://www.w3.org/2000/xmlns/
+
+        // WFC: Unique Att Spec
+        // Perhaps pass a seen boolean value to this method.  serializeAttList will determine
+        // if the attr was seen before.
+    }
+
+    /**
+     * Checks if a PI node is well-formed, by checking it's Name and data
+     * for well-formedness.
+     *
+     * @param data The contents of the comment node
+     */
+    protected void isPIWellFormed(ProcessingInstruction node) {
+        // Is the PI Target a valid XML name
+        if (!isXMLName(node.getNodeName(), fIsXMLVersion11)) {
+            String msg =
+                Utils.messages.createMessage(
+                    MsgKey.ER_WF_INVALID_CHARACTER_IN_NODE_NAME,
+                    new Object[] { "ProcessingInstruction", node.getTarget()});
+
+            if (fErrorHandler != null) {
+                fErrorHandler.handleError(
+                    new DOMErrorImpl(
+                        DOMError.SEVERITY_FATAL_ERROR,
+                        msg,
+                        MsgKey.ER_WF_INVALID_CHARACTER_IN_NODE_NAME,
+                        null,
+                        null,
+                        null));
+            }
+        }
+
+        // Does the PI Data carry valid XML characters
+
+        // REVISIT: Should we check if the PI DATA contains a ?> ???
+        Character invalidChar = isWFXMLChar(node.getData());
+        if (invalidChar != null) {
+            String msg =
+                Utils.messages.createMessage(
+                    MsgKey.ER_WF_INVALID_CHARACTER_IN_PI,
+                    new Object[] { Integer.toHexString(Character.getNumericValue(invalidChar.charValue())) });
+
+            if (fErrorHandler != null) {
+                fErrorHandler.handleError(
+                    new DOMErrorImpl(
+                        DOMError.SEVERITY_FATAL_ERROR,
+                        msg,
+                        MsgKey.ER_WF_INVALID_CHARACTER,
+                        null,
+                        null,
+                        null));
+            }
+        }
+    }
+
+    /**
+     * Checks if an CDATASection node is well-formed, by checking it's data
+     * for well-formedness.  Note that the presence of a CDATA termination mark
+     * in the contents of a CDATASection is handled by the parameter
+     * spli-cdata-sections
+     *
+     * @param data The contents of the comment node
+     */
+    protected void isCDATASectionWellFormed(CDATASection node) {
+        // Does the data valid XML character data
+        Character invalidChar = isWFXMLChar(node.getData());
+        //if (!isWFXMLChar(node.getData(), invalidChar)) {
+        if (invalidChar != null) {
+            String msg =
+                Utils.messages.createMessage(
+                    MsgKey.ER_WF_INVALID_CHARACTER_IN_CDATA,
+                    new Object[] { Integer.toHexString(Character.getNumericValue(invalidChar.charValue())) });
+
+            if (fErrorHandler != null) {
+                fErrorHandler.handleError(
+                    new DOMErrorImpl(
+                        DOMError.SEVERITY_FATAL_ERROR,
+                        msg,
+                        MsgKey.ER_WF_INVALID_CHARACTER,
+                        null,
+                        null,
+                        null));
+            }
+        }
+    }
+
+    /**
+     * Checks if an Text node is well-formed, by checking if it contains invalid
+     * XML characters.
+     *
+     * @param data The contents of the comment node
+     */
+    protected void isTextWellFormed(Text node) {
+        // Does the data valid XML character data
+        Character invalidChar = isWFXMLChar(node.getData());
+        if (invalidChar != null) {
+            String msg =
+                Utils.messages.createMessage(
+                    MsgKey.ER_WF_INVALID_CHARACTER_IN_TEXT,
+                    new Object[] { Integer.toHexString(Character.getNumericValue(invalidChar.charValue())) });
+
+            if (fErrorHandler != null) {
+                fErrorHandler.handleError(
+                    new DOMErrorImpl(
+                        DOMError.SEVERITY_FATAL_ERROR,
+                        msg,
+                        MsgKey.ER_WF_INVALID_CHARACTER,
+                        null,
+                        null,
+                        null));
+            }
+        }
+    }
+
+    /**
+     * Checks if an EntityRefernece node is well-formed, by checking it's node name.  Then depending
+     * on whether it is referenced in Element content or in an Attr Node, checks if the EntityReference
+     * references an unparsed entity or a external entity and if so throws raises the
+     * appropriate well-formedness error.
+     *
+     * @param data The contents of the comment node
+     * @parent The parent of the EntityReference Node
+     */
+    protected void isEntityReferneceWellFormed(EntityReference node) {
+        // Is the EntityReference name a valid XML name
+        if (!isXMLName(node.getNodeName(), fIsXMLVersion11)) {
+            String msg =
+                Utils.messages.createMessage(
+                    MsgKey.ER_WF_INVALID_CHARACTER_IN_NODE_NAME,
+                    new Object[] { "EntityReference", node.getNodeName()});
+
+            if (fErrorHandler != null) {
+                fErrorHandler.handleError(
+                    new DOMErrorImpl(
+                        DOMError.SEVERITY_FATAL_ERROR,
+                        msg,
+                        MsgKey.ER_WF_INVALID_CHARACTER_IN_NODE_NAME,
+                        null,
+                        null,
+                        null));
+            }
+        }
+
+        // determine the parent node
+        Node parent = node.getParentNode();
+
+        // Traverse the declared entities and check if the nodeName and namespaceURI
+        // of the EntityReference matches an Entity.  If so, check the if the notationName
+        // is not null, if so, report an error.
+        DocumentType docType = node.getOwnerDocument().getDoctype();
+        if (docType != null) {
+            NamedNodeMap entities = docType.getEntities();
+            for (int i = 0; i < entities.getLength(); i++) {
+                Entity ent = (Entity) entities.item(i);
+
+                String nodeName =
+                    node.getNodeName() == null ? "" : node.getNodeName();
+                String nodeNamespaceURI =
+                    node.getNamespaceURI() == null
+                        ? ""
+                        : node.getNamespaceURI();
+                String entName =
+                    ent.getNodeName() == null ? "" : ent.getNodeName();
+                String entNamespaceURI =
+                    ent.getNamespaceURI() == null ? "" : ent.getNamespaceURI();
+                // If referenced in Element content
+                // WFC: Parsed Entity
+                if (parent.getNodeType() == Node.ELEMENT_NODE) {
+                    if (entNamespaceURI.equals(nodeNamespaceURI)
+                        && entName.equals(nodeName)) {
+
+                        if (ent.getNotationName() != null) {
+                            String msg =
+                                Utils.messages.createMessage(
+                                    MsgKey.ER_WF_REF_TO_UNPARSED_ENT,
+                                    new Object[] { node.getNodeName()});
+
+                            if (fErrorHandler != null) {
+                                fErrorHandler.handleError(
+                                    new DOMErrorImpl(
+                                        DOMError.SEVERITY_FATAL_ERROR,
+                                        msg,
+                                        MsgKey.ER_WF_REF_TO_UNPARSED_ENT,
+                                        null,
+                                        null,
+                                        null));
+                            }
+                        }
+                    }
+                } // end if WFC: Parsed Entity
+
+                // If referenced in an Attr value
+                // WFC: No External Entity References
+                if (parent.getNodeType() == Node.ATTRIBUTE_NODE) {
+                    if (entNamespaceURI.equals(nodeNamespaceURI)
+                        && entName.equals(nodeName)) {
+
+                        if (ent.getPublicId() != null
+                            || ent.getSystemId() != null
+                            || ent.getNotationName() != null) {
+                            String msg =
+                                Utils.messages.createMessage(
+                                    MsgKey.ER_WF_REF_TO_EXTERNAL_ENT,
+                                    new Object[] { node.getNodeName()});
+
+                            if (fErrorHandler != null) {
+                                fErrorHandler.handleError(
+                                    new DOMErrorImpl(
+                                        DOMError.SEVERITY_FATAL_ERROR,
+                                        msg,
+                                        MsgKey.ER_WF_REF_TO_EXTERNAL_ENT,
+                                        null,
+                                        null,
+                                        null));
+                            }
+                        }
+                    }
+                } //end if WFC: No External Entity References
+            }
+        }
+    } // isEntityReferneceWellFormed
+
+    /**
+     * If the configuration parameter "namespaces" is set to true, this methods
+     * checks if an entity whose replacement text contains unbound namespace
+     * prefixes is referenced in a location where there are no bindings for
+     * the namespace prefixes and if so raises a LSException with the error-type
+     * "unbound-prefix-in-entity-reference"
+     *
+     * @param Node, The EntityReference nodes whose children are to be checked
+     */
+    protected void checkUnboundPrefixInEntRef(Node node) {
+        Node child, next;
+        for (child = node.getFirstChild(); child != null; child = next) {
+            next = child.getNextSibling();
+
+            if (child.getNodeType() == Node.ELEMENT_NODE) {
+
+                //If a NamespaceURI is not declared for the current
+                //node's prefix, raise a fatal error.
+                String prefix = child.getPrefix();
+                if (prefix != null
+                                && fNSBinder.getURI(prefix) == null) {
+                    String msg =
+                        Utils.messages.createMessage(
+                            MsgKey.ER_ELEM_UNBOUND_PREFIX_IN_ENTREF,
+                            new Object[] {
+                                node.getNodeName(),
+                                child.getNodeName(),
+                                prefix });
+
+                    if (fErrorHandler != null) {
+                        fErrorHandler.handleError(
+                            new DOMErrorImpl(
+                                DOMError.SEVERITY_FATAL_ERROR,
+                                msg,
+                                MsgKey.ER_ELEM_UNBOUND_PREFIX_IN_ENTREF,
+                                null,
+                                null,
+                                null));
+                    }
+                }
+
+                NamedNodeMap attrs = child.getAttributes();
+
+                for (int i = 0; i < attrs.getLength(); i++) {
+                    String attrPrefix = attrs.item(i).getPrefix();
+                    if (attrPrefix != null
+                                && fNSBinder.getURI(attrPrefix) == null) {
+                        String msg =
+                            Utils.messages.createMessage(
+                                MsgKey.ER_ATTR_UNBOUND_PREFIX_IN_ENTREF,
+                                new Object[] {
+                                    node.getNodeName(),
+                                    child.getNodeName(),
+                                    attrs.item(i)});
+
+                        if (fErrorHandler != null) {
+                            fErrorHandler.handleError(
+                                new DOMErrorImpl(
+                                    DOMError.SEVERITY_FATAL_ERROR,
+                                    msg,
+                                    MsgKey.ER_ATTR_UNBOUND_PREFIX_IN_ENTREF,
+                                    null,
+                                    null,
+                                    null));
+                        }
+                    }
+                }
+            }
+
+            if (child.hasChildNodes()) {
+                checkUnboundPrefixInEntRef(child);
+            }
+        }
+    }
+
+    // ***********************************************************************
+    // Namespace normalization
+    // ***********************************************************************
+    /**
+     * Records local namespace declarations, to be used for normalization later
+     *
+     * @param Node, The element node, whose namespace declarations are to be recorded
+     */
+    protected void recordLocalNSDecl(Node node) {
+        NamedNodeMap atts = ((Element) node).getAttributes();
+        int length = atts.getLength();
+
+        for (int i = 0; i < length; i++) {
+            Node attr = atts.item(i);
+
+            String localName = attr.getLocalName();
+            String attrPrefix = attr.getPrefix();
+            String attrValue = attr.getNodeValue();
+            String attrNS = attr.getNamespaceURI();
+
+            localName =
+                localName == null
+                    || XMLNS_PREFIX.equals(localName) ? "" : localName;
+            attrPrefix = attrPrefix == null ? "" : attrPrefix;
+            attrValue = attrValue == null ? "" : attrValue;
+            attrNS = attrNS == null ? "" : attrNS;
+
+            // check if attribute is a namespace decl
+            if (XMLNS_URI.equals(attrNS)) {
+
+                // No prefix may be bound to http://www.w3.org/2000/xmlns/.
+                if (XMLNS_URI.equals(attrValue)) {
+                    String msg =
+                        Utils.messages.createMessage(
+                            MsgKey.ER_NS_PREFIX_CANNOT_BE_BOUND,
+                            new Object[] { attrPrefix, XMLNS_URI });
+
+                    if (fErrorHandler != null) {
+                        fErrorHandler.handleError(
+                            new DOMErrorImpl(
+                                DOMError.SEVERITY_ERROR,
+                                msg,
+                                MsgKey.ER_NS_PREFIX_CANNOT_BE_BOUND,
+                                null,
+                                null,
+                                null));
+                    }
+                } else {
+                    // store the namespace-declaration
+                        if (XMLNS_PREFIX.equals(attrPrefix) ) {
+                        // record valid decl
+                        if (attrValue.length() != 0) {
+                            fNSBinder.declarePrefix(localName, attrValue);
+                        } else {
+                            // Error; xmlns:prefix=""
+                        }
+                    } else { // xmlns
+                        // empty prefix is always bound ("" or some string)
+                        fNSBinder.declarePrefix("", attrValue);
+                    }
+                }
+
+            }
+        }
+    }
+
+    /**
+     * Fixes an element's namespace
+     *
+     * @param Node, The element node, whose namespace is to be fixed
+     */
+    protected void fixupElementNS(Node node) throws SAXException {
+        String namespaceURI = ((Element) node).getNamespaceURI();
+        String prefix = ((Element) node).getPrefix();
+        String localName = ((Element) node).getLocalName();
+
+        if (namespaceURI != null) {
+            //if ( Element's prefix/namespace pair (or default namespace,
+            // if no prefix) are within the scope of a binding )
+            prefix = prefix == null ? "" : prefix;
+            String inScopeNamespaceURI = fNSBinder.getURI(prefix);
+
+            if ((inScopeNamespaceURI != null
+                && inScopeNamespaceURI.equals(namespaceURI))) {
+                // do nothing, declaration in scope is inherited
+
+            } else {
+                // Create a local namespace declaration attr for this namespace,
+                // with Element's current prefix (or a default namespace, if
+                // no prefix). If there's a conflicting local declaration
+                // already present, change its value to use this namespace.
+
+                // Add the xmlns declaration attribute
+                //fNSBinder.pushNamespace(prefix, namespaceURI, fElementDepth);
+                if ((fFeatures & NAMESPACEDECLS) != 0) {
+                    if ("".equals(prefix) || "".equals(namespaceURI)) {
+                        ((Element)node).setAttributeNS(XMLNS_URI, XMLNS_PREFIX, namespaceURI);
+                    } else {
+                        ((Element)node).setAttributeNS(XMLNS_URI, XMLNS_PREFIX + ":" + prefix, namespaceURI);
+                    }
+                }
+                fLocalNSBinder.declarePrefix(prefix, namespaceURI);
+                fNSBinder.declarePrefix(prefix, namespaceURI);
+
+            }
+        } else {
+            // Element has no namespace
+            // DOM Level 1
+            if (localName == null || "".equals(localName)) {
+                //  DOM Level 1 node!
+                String msg =
+                    Utils.messages.createMessage(
+                        MsgKey.ER_NULL_LOCAL_ELEMENT_NAME,
+                        new Object[] { node.getNodeName()});
+
+                if (fErrorHandler != null) {
+                    fErrorHandler.handleError(
+                        new DOMErrorImpl(
+                            DOMError.SEVERITY_ERROR,
+                            msg,
+                            MsgKey.ER_NULL_LOCAL_ELEMENT_NAME,
+                            null,
+                            null,
+                            null));
+                }
+            } else {
+                namespaceURI = fNSBinder.getURI("");
+                if (namespaceURI !=null && namespaceURI.length() > 0) {
+                    ((Element)node).setAttributeNS(XMLNS_URI, XMLNS_PREFIX, "");
+                        fLocalNSBinder.declarePrefix("", "");
+                    fNSBinder.declarePrefix("", "");
+                }
+            }
+        }
+    }
+    /**
+     * This table is a quick lookup of a property key (String) to the integer that
+     * is the bit to flip in the fFeatures field, so the integers should have
+     * values 1,2,4,8,16...
+     *
+     */
+    private static final Hashtable s_propKeys = new Hashtable();
+    static {
+
+        // Initialize the mappings of property keys to bit values (Integer objects)
+        // or mappings to a String object "", which indicates we are interested
+        // in the property, but it does not have a simple bit value to flip
+
+        // cdata-sections
+        int i = CDATA;
+        Integer val = new Integer(i);
+        s_propKeys.put(
+            DOMConstants.S_DOM3_PROPERTIES_NS + DOMConstants.DOM_CDATA_SECTIONS,
+            val);
+
+        // comments
+        int i1 = COMMENTS;
+        val = new Integer(i1);
+        s_propKeys.put(
+            DOMConstants.S_DOM3_PROPERTIES_NS + DOMConstants.DOM_COMMENTS,
+            val);
+
+        // element-content-whitespace
+        int i2 = ELEM_CONTENT_WHITESPACE;
+        val = new Integer(i2);
+        s_propKeys.put(
+            DOMConstants.S_DOM3_PROPERTIES_NS
+                + DOMConstants.DOM_ELEMENT_CONTENT_WHITESPACE,
+            val);
+        int i3 = ENTITIES;
+
+        // entities
+        val = new Integer(i3);
+        s_propKeys.put(
+            DOMConstants.S_DOM3_PROPERTIES_NS + DOMConstants.DOM_ENTITIES,
+            val);
+
+        // namespaces
+        int i4 = NAMESPACES;
+        val = new Integer(i4);
+        s_propKeys.put(
+            DOMConstants.S_DOM3_PROPERTIES_NS + DOMConstants.DOM_NAMESPACES,
+            val);
+
+        // namespace-declarations
+        int i5 = NAMESPACEDECLS;
+        val = new Integer(i5);
+        s_propKeys.put(
+            DOMConstants.S_DOM3_PROPERTIES_NS
+                + DOMConstants.DOM_NAMESPACE_DECLARATIONS,
+            val);
+
+        // split-cdata-sections
+        int i6 = SPLITCDATA;
+        val = new Integer(i6);
+        s_propKeys.put(
+            DOMConstants.S_DOM3_PROPERTIES_NS + DOMConstants.DOM_SPLIT_CDATA,
+            val);
+
+        // discard-default-content
+        int i7 = WELLFORMED;
+        val = new Integer(i7);
+        s_propKeys.put(
+            DOMConstants.S_DOM3_PROPERTIES_NS + DOMConstants.DOM_WELLFORMED,
+            val);
+
+        // discard-default-content
+        int i8 = DISCARDDEFAULT;
+        val = new Integer(i8);
+        s_propKeys.put(
+            DOMConstants.S_DOM3_PROPERTIES_NS
+                + DOMConstants.DOM_DISCARD_DEFAULT_CONTENT,
+            val);
+
+        // We are interested in these properties, but they don't have a simple
+        // bit value to deal with.
+        s_propKeys.put(
+            DOMConstants.S_DOM3_PROPERTIES_NS
+                + DOMConstants.DOM_FORMAT_PRETTY_PRINT,
+            "");
+        s_propKeys.put(DOMConstants.S_XSL_OUTPUT_OMIT_XML_DECL, "");
+        s_propKeys.put(
+            DOMConstants.S_XERCES_PROPERTIES_NS + DOMConstants.S_XML_VERSION,
+            "");
+        s_propKeys.put(DOMConstants.S_XSL_OUTPUT_ENCODING, "");
+        s_propKeys.put(OutputPropertiesFactory.S_KEY_ENTITIES, "");
+    }
+
+    /**
+     * Initializes fFeatures based on the DOMConfiguration Parameters set.
+     *
+     * @param properties DOMConfiguraiton properties that were set and which are
+     * to be used while serializing the DOM.
+     */
+    protected void initProperties(Properties properties) {
+
+        for (Enumeration keys = properties.keys(); keys.hasMoreElements();) {
+
+            final String key = (String) keys.nextElement();
+
+            // caonical-form
+            // Other features will be enabled or disabled when this is set to true or false.
+
+            // error-handler; set via the constructor
+
+            // infoset
+            // Other features will be enabled or disabled when this is set to true
+
+            // A quick lookup for the given set of properties (cdata-sections ...)
+            final Object iobj = s_propKeys.get(key);
+            if (iobj != null) {
+                if (iobj instanceof Integer) {
+                    // Dealing with a property that has a simple bit value that
+                    // we need to set
+
+                    // cdata-sections
+                    // comments
+                    // element-content-whitespace
+                    // entities
+                    // namespaces
+                    // namespace-declarations
+                    // split-cdata-sections
+                    // well-formed
+                    // discard-default-content
+                    final int BITFLAG = ((Integer) iobj).intValue();
+                    if ((properties.getProperty(key).endsWith("yes"))) {
+                        fFeatures = fFeatures | BITFLAG;
+                    } else {
+                        fFeatures = fFeatures & ~BITFLAG;
+                    }
+                } else {
+                    // We are interested in the property, but it is not
+                    // a simple bit that we need to set.
+
+                    if ((DOMConstants.S_DOM3_PROPERTIES_NS
+                        + DOMConstants.DOM_FORMAT_PRETTY_PRINT)
+                        .equals(key)) {
+                        // format-pretty-print; set internally on the serializers via xsl:output properties in LSSerializer
+                        if ((properties.getProperty(key).endsWith("yes"))) {
+                            fSerializer.setIndent(true);
+                            fSerializer.setIndentAmount(4);
+                        } else {
+                            fSerializer.setIndent(false);
+                        }
+                    } else if (
+                        (DOMConstants.S_XSL_OUTPUT_OMIT_XML_DECL).equals(
+                            key)) {
+                        // omit-xml-declaration; set internally on the serializers via xsl:output properties in LSSerializer
+                        if ((properties.getProperty(key).endsWith("yes"))) {
+                            fSerializer.setOmitXMLDeclaration(true);
+                        } else {
+                            fSerializer.setOmitXMLDeclaration(false);
+                        }
+                    } else if (
+                        (
+                            DOMConstants.S_XERCES_PROPERTIES_NS
+                                + DOMConstants.S_XML_VERSION).equals(
+                            key)) {
+                        // Retreive the value of the XML Version attribute via the xml-version
+                        String version = properties.getProperty(key);
+                        if ("1.1".equals(version)) {
+                            fIsXMLVersion11 = true;
+                            fSerializer.setVersion(version);
+                        } else {
+                            fSerializer.setVersion("1.0");
+                        }
+                    } else if (
+                        (DOMConstants.S_XSL_OUTPUT_ENCODING).equals(key)) {
+                        // Retreive the value of the XML Encoding attribute
+                        String encoding = properties.getProperty(key);
+                        if (encoding != null) {
+                            fSerializer.setEncoding(encoding);
+                        }
+                    } else if ((OutputPropertiesFactory.S_KEY_ENTITIES).equals(key)) {
+                        // Retreive the value of the XML Encoding attribute
+                        String entities = properties.getProperty(key);
+                        if (DOMConstants.S_XSL_VALUE_ENTITIES.equals(entities)) {
+                            fSerializer.setDTDEntityExpansion(false);
+                        }
+                    } else {
+                        // We shouldn't get here, ever, now what?
+                    }
+                }
+            }
+        }
+        // Set the newLine character to use
+        if (fNewLine != null) {
+            fSerializer.setOutputProperty(OutputPropertiesFactory.S_KEY_LINE_SEPARATOR, fNewLine);
+        }
+    }
+
+} //TreeWalker

--- a/jaxp/src/com/sun/org/apache/xml/internal/serializer/dom3/DOMConstants.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serializer/dom3/DOMConstants.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the  "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * $Id:  $
+ */
+
+package com.sun.org.apache.xml.internal.serializer.dom3;
+
+/**
+ * DOM Constants used by the DOM Level 3 LSSerializer implementation.
+ *
+ * @xsl.usage internal
+ */
+final class DOMConstants {
+    //
+    // Constants: DOM Level 3 feature ids
+    //
+    public static final String DOM3_REC_URL = "http://www.w3.org/TR/DOM-Level-3-LS";
+
+    public static final String XERCES_URL = "http://xml.apache.org/xerces-2j";
+
+    // The namespace used to qualified DOM Level 3 DOMConfiguration parameters
+    public static final String S_DOM3_PROPERTIES_NS = "{"
+            + DOMConstants.DOM3_REC_URL + "}";
+
+    public static final String S_XERCES_PROPERTIES_NS = "{"
+            + DOMConstants.XERCES_URL + "}";
+
+    // xmlns namespaces
+    private static final String XMLNS_URI = "http://www.w3.org/2000/xmlns/";
+
+    // namespace prefix
+    private static final String XMLNS_PREFIX = "xmlns";
+
+    // ************************************************************************
+    // DOM Level 3 DOM Configuration parameter names
+    // ************************************************************************
+    // DOM Level 3 parameters defined in Core
+    public static final String DOM_CANONICAL_FORM = "canonical-form"; // Unsupported, we only appear to support this
+
+    public static final String DOM_CDATA_SECTIONS = "cdata-sections";
+
+    public static final String DOM_CHECK_CHAR_NORMALIZATION = "check-character-normalization"; // Unsupported
+
+    public static final String DOM_COMMENTS = "comments";
+
+    public static final String DOM_DATATYPE_NORMALIZATION = "datatype-normalization"; // Unsupported
+
+    public static final String DOM_ELEMENT_CONTENT_WHITESPACE = "element-content-whitespace";
+
+    public static final String DOM_ENTITIES = "entities";
+
+    public static final String DOM_INFOSET = "infoset";
+
+    public static final String DOM_NAMESPACES = "namespaces";
+
+    public static final String DOM_NAMESPACE_DECLARATIONS = "namespace-declarations";
+
+    public static final String DOM_NORMALIZE_CHARACTERS = "normalize-characters"; // Unsupported
+
+    public static final String DOM_SPLIT_CDATA = "split-cdata-sections";
+
+    public static final String DOM_VALIDATE_IF_SCHEMA = "validate-if-schema"; // Unsopported
+
+    public static final String DOM_VALIDATE = "validate"; // Unsopported
+
+    public static final String DOM_WELLFORMED = "well-formed";
+
+    // DOM Level 3 Save
+    public static final String DOM_DISCARD_DEFAULT_CONTENT = "discard-default-content";
+
+    public static final String DOM_FORMAT_PRETTY_PRINT = "format-pretty-print";
+
+    public static final String DOM_IGNORE_UNKNOWN_CHARACTER_DENORMALIZATIONS = "ignore-unknown-character-denormalizations"; // Unsupported
+
+    public static final String DOM_XMLDECL = "xml-declaration";
+
+    // DOM Properties
+    public static final String DOM_ERROR_HANDLER = "error-handler";
+
+    public static final String DOM_SCHEMA_TYPE = "schema-type"; // Unsupported
+
+    public static final String DOM_SCHEMA_LOCATION = "schema-location"; // Unsupported
+
+    // ************************************************************************
+
+    // XSL Output properties
+    // The xsl:output 'indent' property used in LSSerializer
+    public static final String S_XSL_OUTPUT_INDENT = "indent";
+
+    // The xsl:output 'indent' property used in LSSerializer
+    public static final String S_XSL_OUTPUT_ENCODING = "encoding";
+
+    // The xsl:output 'omit-xml-declaration' property used in LSSerializer
+    public static final String S_XSL_OUTPUT_OMIT_XML_DECL = "omit-xml-declaration";
+
+    // The xerces serializer specific 'omit-xml-declaration' property used in LSSerializer
+    public static final String S_XML_VERSION = "xml-version";
+
+    //
+    public static final String S_XSL_VALUE_ENTITIES = "com/sun/org/apache/xml/internal/serializer/XMLEntities";
+
+    // Parameter values
+    public static final String DOM3_EXPLICIT_TRUE = "explicit:yes";
+
+    public static final String DOM3_DEFAULT_TRUE = "default:yes";
+
+    public static final String DOM3_EXPLICIT_FALSE = "explicit:no";
+
+    public static final String DOM3_DEFAULT_FALSE = "default:no";
+
+    // DOM Exceptions
+    public static final String DOM_EXCEPTION_FEATURE_NOT_FOUND = "FEATURE_NOT_FOUND";
+
+    public static final String DOM_EXCEPTION_FEATURE_NOT_SUPPORTED = "FEATURE_NOT_SUPPORTED";
+
+    public static final String DOM_LSEXCEPTION_SERIALIZER_ERR = "SERIALIZER_ERROR";
+
+}

--- a/jaxp/src/com/sun/org/apache/xml/internal/serializer/dom3/DOMErrorHandlerImpl.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serializer/dom3/DOMErrorHandlerImpl.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the  "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * $Id:  $
+ */
+
+package com.sun.org.apache.xml.internal.serializer.dom3;
+
+import org.w3c.dom.DOMError;
+import org.w3c.dom.DOMErrorHandler;
+
+/**
+ * This is the default implementation of the ErrorHandler interface and is
+ * used if one is not provided.  The default implementation simply reports
+ * DOMErrors to System.err.
+ *
+ * @xsl.usage internal
+ */
+final class DOMErrorHandlerImpl implements DOMErrorHandler {
+
+    /**
+     * Default Constructor
+     */
+    DOMErrorHandlerImpl() {
+    }
+
+    /**
+     * Implementation of DOMErrorHandler.handleError that
+     * adds copy of error to list for later retrieval.
+     *
+     */
+    public boolean handleError(DOMError error) {
+        boolean fail = true;
+        String severity = null;
+        if (error.getSeverity() == DOMError.SEVERITY_WARNING) {
+            fail = false;
+            severity = "[Warning]";
+        } else if (error.getSeverity() == DOMError.SEVERITY_ERROR) {
+            severity = "[Error]";
+        } else if (error.getSeverity() == DOMError.SEVERITY_FATAL_ERROR) {
+            severity = "[Fatal Error]";
+        }
+
+        System.err.println(severity + ": " + error.getMessage() + "\t");
+        System.err.println("Type : " + error.getType() + "\t" + "Related Data: "
+                + error.getRelatedData() + "\t" + "Related Exception: "
+                + error.getRelatedException() );
+
+        return fail;
+    }
+}

--- a/jaxp/src/com/sun/org/apache/xml/internal/serializer/dom3/DOMErrorImpl.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serializer/dom3/DOMErrorImpl.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the  "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * $Id:  $
+ */
+
+package com.sun.org.apache.xml.internal.serializer.dom3;
+
+import org.w3c.dom.DOMError;
+import org.w3c.dom.DOMLocator;
+
+/**
+ * Implementation of the DOM Level 3 DOMError interface.
+ *
+ * <p>See also the <a href='http://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/core.html#ERROR-Interfaces-DOMError'>DOMError Interface definition from Document Object Model (DOM) Level 3 Core Specification</a>.
+ *
+ * @xsl.usage internal
+ */
+
+final class DOMErrorImpl implements DOMError {
+
+    /** private data members */
+
+    // The DOMError Severity
+    private short fSeverity = DOMError.SEVERITY_WARNING;
+
+    // The Error message
+    private String fMessage = null;
+
+    //  A String indicating which related data is expected in relatedData.
+    private String fType;
+
+    // The platform related exception
+    private Exception fException = null;
+
+    //
+    private Object fRelatedData;
+
+    // The location of the exception
+    private DOMLocatorImpl fLocation = new DOMLocatorImpl();
+
+
+    //
+    // Constructors
+    //
+
+    /**
+     * Default constructor.
+     */
+    DOMErrorImpl () {
+    }
+
+    /**
+     * @param severity
+     * @param message
+     * @param type
+     */
+    DOMErrorImpl(short severity, String message, String type) {
+        fSeverity = severity;
+        fMessage = message;
+        fType = type;
+    }
+
+    /**
+     * @param severity
+     * @param message
+     * @param type
+     * @param exception
+     */
+    DOMErrorImpl(short severity, String message, String type,
+            Exception exception) {
+        fSeverity = severity;
+        fMessage = message;
+        fType = type;
+        fException = exception;
+    }
+
+    /**
+     * @param severity
+     * @param message
+     * @param type
+     * @param exception
+     * @param relatedData
+     * @param location
+     */
+    DOMErrorImpl(short severity, String message, String type,
+            Exception exception, Object relatedData, DOMLocatorImpl location) {
+        fSeverity = severity;
+        fMessage = message;
+        fType = type;
+        fException = exception;
+        fRelatedData = relatedData;
+        fLocation = location;
+    }
+
+
+    /**
+     * The severity of the error, either <code>SEVERITY_WARNING</code>,
+     * <code>SEVERITY_ERROR</code>, or <code>SEVERITY_FATAL_ERROR</code>.
+     *
+     * @return A short containing the DOMError severity
+     */
+    public short getSeverity() {
+        return fSeverity;
+    }
+
+    /**
+     * The DOMError message string.
+     *
+     * @return String
+     */
+    public String getMessage() {
+        return fMessage;
+    }
+
+    /**
+     * The location of the DOMError.
+     *
+     * @return A DOMLocator object containing the DOMError location.
+     */
+    public DOMLocator getLocation() {
+        return fLocation;
+    }
+
+    /**
+     * The related platform dependent exception if any.
+     *
+     * @return A java.lang.Exception
+     */
+    public Object getRelatedException(){
+        return fException;
+    }
+
+    /**
+     * Returns a String indicating which related data is expected in relatedData.
+     *
+     * @return A String
+     */
+    public String getType(){
+        return fType;
+    }
+
+    /**
+     * The related DOMError.type dependent data if any.
+     *
+     * @return java.lang.Object
+     */
+    public Object getRelatedData(){
+        return fRelatedData;
+    }
+
+    public void reset(){
+        fSeverity = DOMError.SEVERITY_WARNING;
+        fException = null;
+        fMessage = null;
+        fType = null;
+        fRelatedData = null;
+        fLocation = null;
+    }
+
+}// class DOMErrorImpl

--- a/jaxp/src/com/sun/org/apache/xml/internal/serializer/dom3/DOMLocatorImpl.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serializer/dom3/DOMLocatorImpl.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the  "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * $Id:  $
+ */
+
+package com.sun.org.apache.xml.internal.serializer.dom3;
+
+import org.w3c.dom.DOMLocator;
+import org.w3c.dom.Node;
+
+
+/**
+ * <code>DOMLocatorImpl</code> is an implementaion that describes a location (e.g.
+ * where an error occured).
+ * <p>See also the <a href='http://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407'>Document Object Model (DOM) Level 3 Core Specification</a>.
+ * This class is a copy of the Xerces-2J class org.apache.xerces.dom.DOMLocatorImpl.java v 1.10
+ *
+ * @author Gopal Sharma, SUN Microsystems Inc.
+ * @version $Id:
+ *
+ * @xsl.usage internal
+ */
+final class DOMLocatorImpl implements DOMLocator {
+
+    //
+    // Data
+    //
+
+    /**
+     * The column number where the error occured,
+     * or -1 if there is no column number available.
+     */
+    private final int fColumnNumber;
+
+    /**
+     * The line number where the error occured,
+     * or -1 if there is no line number available.
+     */
+    private final int fLineNumber;
+
+    /** related data node*/
+    private final Node fRelatedNode;
+
+    /**
+     * The URI where the error occured,
+     * or null if there is no URI available.
+     */
+    private final String fUri;
+
+    /**
+     * The byte offset into the input source this locator is pointing to or -1
+     * if there is no byte offset available
+     */
+    private final int fByteOffset;
+
+    /**
+     * The UTF-16, as defined in [Unicode] and Amendment 1 of [ISO/IEC 10646],
+     * offset into the input source this locator is pointing to or -1 if there
+     * is no UTF-16 offset available.
+     */
+    private final int fUtf16Offset;
+
+    //
+    // Constructors
+    //
+
+    DOMLocatorImpl(){
+        fColumnNumber = -1;
+        fLineNumber = -1;
+        fRelatedNode = null;
+        fUri = null;
+        fByteOffset = -1;
+        fUtf16Offset = -1;
+    }
+
+    DOMLocatorImpl (int lineNumber, int columnNumber, String uri ){
+        fLineNumber = lineNumber ;
+        fColumnNumber = columnNumber ;
+        fUri = uri;
+
+        fRelatedNode = null;
+        fByteOffset = -1;
+        fUtf16Offset = -1;
+    } // DOMLocatorImpl (int lineNumber, int columnNumber, String uri )
+
+    DOMLocatorImpl (int lineNumber, int columnNumber, int utf16Offset, String uri ){
+        fLineNumber = lineNumber ;
+        fColumnNumber = columnNumber ;
+        fUri = uri;
+        fUtf16Offset = utf16Offset;
+
+
+        fRelatedNode = null;
+        fByteOffset = -1;
+    } // DOMLocatorImpl (int lineNumber, int columnNumber, int utf16Offset, String uri )
+
+    DOMLocatorImpl (int lineNumber, int columnNumber, int byteoffset, Node relatedData, String uri ){
+        fLineNumber = lineNumber ;
+        fColumnNumber = columnNumber ;
+        fByteOffset = byteoffset ;
+        fRelatedNode = relatedData ;
+        fUri = uri;
+
+        fUtf16Offset = -1;
+    } // DOMLocatorImpl (int lineNumber, int columnNumber, int offset, Node errorNode, String uri )
+
+    DOMLocatorImpl (int lineNumber, int columnNumber, int byteoffset, Node relatedData, String uri, int utf16Offset ){
+        fLineNumber = lineNumber ;
+        fColumnNumber = columnNumber ;
+        fByteOffset = byteoffset ;
+        fRelatedNode = relatedData ;
+        fUri = uri;
+        fUtf16Offset = utf16Offset;
+    } // DOMLocatorImpl (int lineNumber, int columnNumber, int offset, Node errorNode, String uri )
+
+
+    /**
+     * The line number where the error occured, or -1 if there is no line
+     * number available.
+     */
+    public int getLineNumber(){
+        return fLineNumber;
+    }
+
+    /**
+     * The column number where the error occured, or -1 if there is no column
+     * number available.
+     */
+    public int getColumnNumber(){
+        return fColumnNumber;
+    }
+
+
+    /**
+     * The URI where the error occured, or null if there is no URI available.
+     */
+    public String getUri(){
+        return fUri;
+    }
+
+
+    public Node getRelatedNode(){
+        return fRelatedNode;
+    }
+
+
+    /**
+     * The byte offset into the input source this locator is pointing to or -1
+     * if there is no byte offset available
+     */
+    public int getByteOffset(){
+        return fByteOffset;
+    }
+
+    /**
+     * The UTF-16, as defined in [Unicode] and Amendment 1 of [ISO/IEC 10646],
+     * offset into the input source this locator is pointing to or -1 if there
+     * is no UTF-16 offset available.
+     */
+    public int getUtf16Offset(){
+        return fUtf16Offset;
+    }
+
+}// class DOMLocatorImpl

--- a/jaxp/src/com/sun/org/apache/xml/internal/serializer/dom3/DOMOutputImpl.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serializer/dom3/DOMOutputImpl.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the  "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * $Id:  $
+ */
+
+package org.apache.xml.serializer.dom3;
+
+import org.w3c.dom.ls.LSOutput;
+
+import java.io.Writer;
+import java.io.OutputStream;
+
+/**
+ * This is a copy of the Xerces-2J class org.apache.xerces.dom.DOMOutputImpl.java
+ *
+ * This class represents an output destination for data.
+ * This interface allows an application to encapsulate information about an
+ * output destination in a single object, which may include a URI, a byte stream
+ * (possibly with a specifiedencoding), a base URI, and/or a character stream.
+ * The exact definitions of a byte stream and a character stream are binding
+ * dependent.
+ * The application is expected to provide objects that implement this interface
+ * whenever such objects are needed. The application can either provide its
+ * own objects that implement this interface, or it can use the generic factory
+ * method DOMImplementationLS.createLSOutput() to create objects that
+ * implement this interface.
+ * The DOMSerializer will use the LSOutput object to determine where to
+ * serialize the output to. The DOMSerializer will look at the different
+ * outputs specified in the LSOutput in the following order to know which one
+ * to output to, the first one that data can be output to will be used:
+ * 1.LSOutput.characterStream
+ * 2.LSOutput.byteStream
+ * 3.LSOutput.systemId
+ * LSOutput objects belong to the application. The DOM implementation will
+ * never modify them (though it may make copies and modify the copies,
+ * if necessary).
+ *
+ *
+ * @author Arun Yadav, Sun Microsytems
+ * @author Gopal Sharma, Sun Microsystems
+ * @version $Id :
+ * @xsl.usage internal
+ */
+
+final class DOMOutputImpl implements LSOutput {
+
+    private Writer fCharStream = null;
+    private OutputStream fByteStream = null;
+    private String fSystemId = null;
+    private String fEncoding = null;
+
+    /**
+     * Default Constructor
+     */
+    DOMOutputImpl() {}
+
+    /**
+     * An attribute of a language and binding dependent type that represents a
+     * writable stream of bytes. If the application knows the character encoding
+     * of the byte stream, it should set the encoding attribute. Setting the
+     * encoding in this way will override any encoding specified in an XML
+     * declaration in the data.
+     */
+
+    public Writer getCharacterStream(){
+        return fCharStream;
+    };
+
+    /**
+     * An attribute of a language and binding dependent type that represents a
+     * writable stream of bytes. If the application knows the character encoding
+     * of the byte stream, it should set the encoding attribute. Setting the
+     * encoding in this way will override any encoding specified in an XML
+     * declaration in the data.
+     */
+
+    public void setCharacterStream(Writer characterStream){
+        fCharStream = characterStream;
+    };
+
+    /**
+     * Depending on the language binding in use, this attribute may not be
+     * available. An attribute of a language and binding dependent type that
+     * represents a writable stream to which 16-bit units can be output. The
+     * application must encode the stream using UTF-16 (defined in [Unicode] and
+     *  Amendment 1 of [ISO/IEC 10646]).
+     */
+
+    public OutputStream getByteStream(){
+        return fByteStream;
+    };
+
+    /**
+     * Depending on the language binding in use, this attribute may not be
+     * available. An attribute of a language and binding dependent type that
+     * represents a writable stream to which 16-bit units can be output. The
+     * application must encode the stream using UTF-16 (defined in [Unicode] and
+     *  Amendment 1 of [ISO/IEC 10646]).
+     */
+
+    public void setByteStream(OutputStream byteStream){
+        fByteStream = byteStream;
+    };
+
+    /**
+     * The system identifier, a URI reference [IETF RFC 2396], for this output
+     *  destination. If the application knows the character encoding of the
+     *  object pointed to by the system identifier, it can set the encoding
+     *  using the encoding attribute. If the system ID is a relative URI
+     *  reference (see section 5 in [IETF RFC 2396]), the behavior is
+     *  implementation dependent.
+     */
+
+    public String getSystemId(){
+        return fSystemId;
+    };
+
+    /**
+     * The system identifier, a URI reference [IETF RFC 2396], for this output
+     *  destination. If the application knows the character encoding of the
+     *  object pointed to by the system identifier, it can set the encoding
+     *  using the encoding attribute. If the system ID is a relative URI
+     *  reference (see section 5 in [IETF RFC 2396]), the behavior is
+     *  implementation dependent.
+     */
+
+    public void setSystemId(String systemId){
+        fSystemId = systemId;
+    };
+
+    /**
+     * The character encoding, if known. The encoding must be a string
+     * acceptable for an XML encoding declaration ([XML 1.0] section 4.3.3
+     * "Character Encoding in Entities"). This attribute has no effect when the
+     * application provides a character stream or string data. For other sources
+     * of input, an encoding specified by means of this attribute will override
+     * any encoding specified in the XML declaration or the Text declaration, or
+     * an encoding obtained from a higher level protocol, such as HTTP
+     * [IETF RFC 2616].
+     */
+
+    public String getEncoding(){
+        return fEncoding;
+    };
+
+    /**
+     * The character encoding, if known. The encoding must be a string
+     * acceptable for an XML encoding declaration ([XML 1.0] section 4.3.3
+     * "Character Encoding in Entities"). This attribute has no effect when the
+     * application provides a character stream or string data. For other sources
+     * of input, an encoding specified by means of this attribute will override
+     * any encoding specified in the XML declaration or the Text declaration, or
+     * an encoding obtained from a higher level protocol, such as HTTP
+     * [IETF RFC 2616].
+     */
+
+    public void setEncoding(String encoding){
+        fEncoding = encoding;
+    };
+
+}//DOMOutputImpl

--- a/jaxp/src/com/sun/org/apache/xml/internal/serializer/dom3/DOMStringListImpl.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serializer/dom3/DOMStringListImpl.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the  "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * $Id:  $
+ */
+package com.sun.org.apache.xml.internal.serializer.dom3;
+
+import java.util.Vector;
+
+//import org.apache.xerces.dom3.DOMStringList;
+import org.w3c.dom.DOMStringList;
+
+/**
+ * This class implemets the DOM Level 3 Core interface DOMStringList.
+ *
+ * @xsl.usage internal
+ */
+final class DOMStringListImpl implements DOMStringList {
+
+    //A collection of DOMString values
+    private Vector fStrings;
+
+    /**
+     * Construct an empty list of DOMStringListImpl
+     */
+    DOMStringListImpl() {
+        fStrings = new Vector();
+    }
+
+    /**
+     * Construct an empty list of DOMStringListImpl
+     */
+    DOMStringListImpl(Vector params) {
+        fStrings = params;
+    }
+
+    /**
+     * Construct an empty list of DOMStringListImpl
+     */
+    DOMStringListImpl(String[] params ) {
+        fStrings = new Vector();
+        if (params != null) {
+            for (int i=0; i < params.length; i++) {
+                fStrings.add(params[i]);
+            }
+        }
+    }
+
+    /**
+     * @see org.apache.xerces.dom3.DOMStringList#item(int)
+     */
+    public String item(int index) {
+        try {
+            return (String) fStrings.elementAt(index);
+        } catch (ArrayIndexOutOfBoundsException e) {
+            return null;
+        }
+    }
+
+    /**
+     * @see org.apache.xerces.dom3.DOMStringList#getLength()
+     */
+    public int getLength() {
+        return fStrings.size();
+    }
+
+    /**
+     * @see org.apache.xerces.dom3.DOMStringList#contains(String)
+     */
+    public boolean contains(String param) {
+        return fStrings.contains(param) ;
+    }
+
+    /**
+     * DOM Internal:
+     * Add a <code>DOMString</code> to the list.
+     *
+     * @param domString A string to add to the list
+     */
+    public void add(String param) {
+        fStrings.add(param);
+    }
+
+}

--- a/jaxp/src/com/sun/org/apache/xml/internal/serializer/dom3/LSSerializerImpl.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serializer/dom3/LSSerializerImpl.java
@@ -1,0 +1,1405 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the  "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * $Id:  $
+ */
+
+package com.sun.org.apache.xml.internal.serializer.dom3;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.StringWriter;
+import java.io.UnsupportedEncodingException;
+import java.io.Writer;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Properties;
+
+import com.sun.org.apache.xml.internal.serializer.DOM3Serializer;
+import com.sun.org.apache.xml.internal.serializer.Encodings;
+import com.sun.org.apache.xml.internal.serializer.Serializer;
+import com.sun.org.apache.xml.internal.serializer.OutputPropertiesFactory;
+import com.sun.org.apache.xml.internal.serializer.SerializerFactory;
+import com.sun.org.apache.xml.internal.serializer.utils.MsgKey;
+import com.sun.org.apache.xml.internal.serializer.utils.Utils;
+import com.sun.org.apache.xml.internal.serializer.utils.SystemIDResolver;
+import org.w3c.dom.DOMConfiguration;
+import org.w3c.dom.DOMError;
+import org.w3c.dom.DOMErrorHandler;
+import org.w3c.dom.DOMException;
+import org.w3c.dom.DOMStringList;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.ls.LSException;
+import org.w3c.dom.ls.LSOutput;
+import org.w3c.dom.ls.LSSerializer;
+import org.w3c.dom.ls.LSSerializerFilter;
+
+
+/**
+ * Implemenatation of DOM Level 3 org.w3c.ls.LSSerializer and
+ * org.w3c.dom.ls.DOMConfiguration.  Serialization is achieved by delegating
+ * serialization calls to <CODE>org.apache.xml.serializer.ToStream</CODE> or
+ * one of its derived classes depending on the serialization method, while walking
+ * the DOM in DOM3TreeWalker.
+ * @see <a href="http://www.w3.org/TR/2004/REC-DOM-Level-3-LS-20040407/load-save.html#LS-LSSerializer">org.w3c.dom.ls.LSSerializer</a>
+ * @see <a href="http://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/core.html#DOMConfiguration">org.w3c.dom.DOMConfiguration</a>
+ *
+ * @version $Id:
+ *
+ * @xsl.usage internal
+ */
+final public class LSSerializerImpl implements DOMConfiguration, LSSerializer {
+
+    /** private data members */
+    private Serializer fXMLSerializer = null;
+
+    // Tracks DOMConfiguration features.
+    protected int fFeatures = 0;
+
+    // Common DOM serializer
+    private  DOM3Serializer fDOMSerializer = null;
+
+    // A filter set on the LSSerializer
+    private LSSerializerFilter fSerializerFilter = null;
+
+    // Stores the nodeArg parameter to speed up multiple writes of the same node.
+    private Node fVisitedNode = null;
+
+    // The end-of-line character sequence used in serialization.  "\n" is whats used on the web.
+    private String fEndOfLine = "\n";
+
+    // The DOMErrorhandler.
+    private DOMErrorHandler fDOMErrorHandler = null;
+
+    // The Configuration parameter to pass to the Underlying serilaizer.
+    private Properties fDOMConfigProperties = null;
+
+    // The encoding to use during serialization.
+    private String fEncoding;
+
+    // ************************************************************************
+    // DOM Level 3 DOM Configuration parameter names
+    // ************************************************************************
+    // Parameter canonical-form, true [optional] - NOT SUPPORTED
+    private final static int CANONICAL = 0x1 << 0;
+
+    // Parameter cdata-sections, true [required] (default)
+    private final static int CDATA = 0x1 << 1;
+
+    // Parameter check-character-normalization, true [optional] - NOT SUPPORTED
+    private final static int CHARNORMALIZE = 0x1 << 2;
+
+    // Parameter comments, true [required] (default)
+    private final static int COMMENTS = 0x1 << 3;
+
+    // Parameter datatype-normalization, true [optional] - NOT SUPPORTED
+    private final static int DTNORMALIZE = 0x1 << 4;
+
+    // Parameter element-content-whitespace, true [required] (default) - value - false [optional] NOT SUPPORTED
+    private final static int ELEM_CONTENT_WHITESPACE = 0x1 << 5;
+
+    // Parameter entities, true [required] (default)
+    private final static int ENTITIES = 0x1 << 6;
+
+    // Parameter infoset, true [required] (default), false has no effect --> True has no effect for the serializer
+    private final static int INFOSET = 0x1 << 7;
+
+    // Parameter namespaces, true [required] (default)
+    private final static int NAMESPACES = 0x1 << 8;
+
+    // Parameter namespace-declarations, true [required] (default)
+    private final static int NAMESPACEDECLS = 0x1 << 9;
+
+    // Parameter normalize-characters, true [optional] - NOT SUPPORTED
+    private final static int NORMALIZECHARS = 0x1 << 10;
+
+    // Parameter split-cdata-sections, true [required] (default)
+    private final static int SPLITCDATA = 0x1 << 11;
+
+    // Parameter validate, true [optional] - NOT SUPPORTED
+    private final static int VALIDATE = 0x1 << 12;
+
+    // Parameter validate-if-schema, true [optional] - NOT SUPPORTED
+    private final static int SCHEMAVALIDATE = 0x1 << 13;
+
+    // Parameter split-cdata-sections, true [required] (default)
+    private final static int WELLFORMED = 0x1 << 14;
+
+    // Parameter discard-default-content, true [required] (default)
+    // Not sure how this will be used in level 2 Documents
+    private final static int DISCARDDEFAULT = 0x1 << 15;
+
+    // Parameter format-pretty-print, true [optional]
+    private final static int PRETTY_PRINT = 0x1 << 16;
+
+    // Parameter ignore-unknown-character-denormalizations, true [required] (default)
+    // We currently do not support XML 1.1 character normalization
+    private final static int IGNORE_CHAR_DENORMALIZE = 0x1 << 17;
+
+    // Parameter discard-default-content, true [required] (default)
+    private final static int XMLDECL = 0x1 << 18;
+    // ************************************************************************
+
+    // Recognized parameters for which atleast one value can be set
+    private String fRecognizedParameters [] = {
+            DOMConstants.DOM_CANONICAL_FORM,
+            DOMConstants.DOM_CDATA_SECTIONS,
+            DOMConstants.DOM_CHECK_CHAR_NORMALIZATION,
+            DOMConstants.DOM_COMMENTS,
+            DOMConstants.DOM_DATATYPE_NORMALIZATION,
+            DOMConstants.DOM_ELEMENT_CONTENT_WHITESPACE,
+            DOMConstants.DOM_ENTITIES,
+            DOMConstants.DOM_INFOSET,
+            DOMConstants.DOM_NAMESPACES,
+            DOMConstants.DOM_NAMESPACE_DECLARATIONS,
+            //DOMConstants.DOM_NORMALIZE_CHARACTERS,
+            DOMConstants.DOM_SPLIT_CDATA,
+            DOMConstants.DOM_VALIDATE,
+            DOMConstants.DOM_VALIDATE_IF_SCHEMA,
+            DOMConstants.DOM_WELLFORMED,
+            DOMConstants.DOM_DISCARD_DEFAULT_CONTENT,
+            DOMConstants.DOM_FORMAT_PRETTY_PRINT,
+            DOMConstants.DOM_IGNORE_UNKNOWN_CHARACTER_DENORMALIZATIONS,
+            DOMConstants.DOM_XMLDECL,
+            DOMConstants.DOM_ERROR_HANDLER
+    };
+
+
+    /**
+     * Constructor:  Creates a LSSerializerImpl object.  The underlying
+     * XML 1.0 or XML 1.1 org.apache.xml.serializer.Serializer object is
+     * created and initialized the first time any of the write methods are
+     * invoked to serialize the Node.  Subsequent write methods on the same
+     * LSSerializerImpl object will use the previously created Serializer object.
+     */
+    public LSSerializerImpl () {
+        // set default parameters
+        fFeatures |= CDATA;
+        fFeatures |= COMMENTS;
+        fFeatures |= ELEM_CONTENT_WHITESPACE;
+        fFeatures |= ENTITIES;
+        fFeatures |= NAMESPACES;
+        fFeatures |= NAMESPACEDECLS;
+        fFeatures |= SPLITCDATA;
+        fFeatures |= WELLFORMED;
+        fFeatures |= DISCARDDEFAULT;
+        fFeatures |= XMLDECL;
+
+        // New OutputFormat properties
+        fDOMConfigProperties = new Properties();
+
+        // Initialize properties to be passed on the underlying serializer
+        initializeSerializerProps();
+
+        // Read output_xml.properties and System Properties to initialize properties
+        Properties  configProps = OutputPropertiesFactory.getDefaultMethodProperties("xml");
+
+        // change xml version from 1.0 to 1.1
+        //configProps.setProperty("version", "1.1");
+
+        // Get a serializer that seriailizes according to the properties,
+        // which in this case is to xml
+        fXMLSerializer = SerializerFactory.getSerializer(configProps);
+
+        // Initialize Serializer
+        fXMLSerializer.setOutputFormat(fDOMConfigProperties);
+    }
+
+    /**
+     * Initializes the underlying serializer's configuration depending on the
+     * default DOMConfiguration parameters. This method must be called before a
+     * node is to be serialized.
+     *
+     * @xsl.usage internal
+     */
+    public void initializeSerializerProps () {
+        // canonical-form
+        fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                + DOMConstants.DOM_CANONICAL_FORM, DOMConstants.DOM3_DEFAULT_FALSE);
+
+        // cdata-sections
+        fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                + DOMConstants.DOM_CDATA_SECTIONS, DOMConstants.DOM3_DEFAULT_TRUE);
+
+        // "check-character-normalization"
+        fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                + DOMConstants.DOM_CHECK_CHAR_NORMALIZATION,
+                DOMConstants.DOM3_DEFAULT_FALSE);
+
+        // comments
+        fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                + DOMConstants.DOM_COMMENTS, DOMConstants.DOM3_DEFAULT_TRUE);
+
+        // datatype-normalization
+        fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                + DOMConstants.DOM_DATATYPE_NORMALIZATION,
+                DOMConstants.DOM3_DEFAULT_FALSE);
+
+        // element-content-whitespace
+        fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                + DOMConstants.DOM_ELEMENT_CONTENT_WHITESPACE,
+                DOMConstants.DOM3_DEFAULT_TRUE);
+
+        // entities
+        fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                + DOMConstants.DOM_ENTITIES, DOMConstants.DOM3_DEFAULT_TRUE);
+        // preserve entities
+        fDOMConfigProperties.setProperty(
+                OutputPropertiesFactory.S_KEY_ENTITIES, DOMConstants.S_XSL_VALUE_ENTITIES);
+
+        // error-handler
+        // Should we set our default ErrorHandler
+        /*
+         * if (fDOMConfig.getParameter(Constants.DOM_ERROR_HANDLER) != null) {
+         * fDOMErrorHandler =
+         * (DOMErrorHandler)fDOMConfig.getParameter(Constants.DOM_ERROR_HANDLER); }
+         */
+
+        // infoset
+        if ((fFeatures & INFOSET) != 0) {
+            fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                    + DOMConstants.DOM_NAMESPACES, DOMConstants.DOM3_DEFAULT_TRUE);
+            fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                    + DOMConstants.DOM_NAMESPACE_DECLARATIONS,
+                    DOMConstants.DOM3_DEFAULT_TRUE);
+            fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                    + DOMConstants.DOM_COMMENTS, DOMConstants.DOM3_DEFAULT_TRUE);
+            fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                    + DOMConstants.DOM_ELEMENT_CONTENT_WHITESPACE,
+                    DOMConstants.DOM3_DEFAULT_TRUE);
+            fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                    + DOMConstants.DOM_WELLFORMED, DOMConstants.DOM3_DEFAULT_TRUE);
+            fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                    + DOMConstants.DOM_ENTITIES, DOMConstants.DOM3_DEFAULT_FALSE);
+            // preserve entities
+            fDOMConfigProperties.setProperty(
+                    OutputPropertiesFactory.S_KEY_ENTITIES, "");
+            fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                    + DOMConstants.DOM_CDATA_SECTIONS,
+                    DOMConstants.DOM3_DEFAULT_FALSE);
+            fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                    + DOMConstants.DOM_VALIDATE_IF_SCHEMA,
+                    DOMConstants.DOM3_DEFAULT_FALSE);
+            fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                    + DOMConstants.DOM_DATATYPE_NORMALIZATION,
+                    DOMConstants.DOM3_DEFAULT_FALSE);
+        }
+
+        // namespaces
+        fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                + DOMConstants.DOM_NAMESPACES, DOMConstants.DOM3_DEFAULT_TRUE);
+
+        // namespace-declarations
+        fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                + DOMConstants.DOM_NAMESPACE_DECLARATIONS,
+                DOMConstants.DOM3_DEFAULT_TRUE);
+
+        // normalize-characters
+        /*
+        fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                + DOMConstants.DOM_NORMALIZE_CHARACTERS,
+                DOMConstants.DOM3_DEFAULT_FALSE);
+        */
+
+        // split-cdata-sections
+        fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                + DOMConstants.DOM_SPLIT_CDATA, DOMConstants.DOM3_DEFAULT_TRUE);
+
+        // validate
+        fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                + DOMConstants.DOM_VALIDATE, DOMConstants.DOM3_DEFAULT_FALSE);
+
+        // validate-if-schema
+        fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                + DOMConstants.DOM_VALIDATE_IF_SCHEMA,
+                DOMConstants.DOM3_DEFAULT_FALSE);
+
+        // well-formed
+        fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                + DOMConstants.DOM_WELLFORMED, DOMConstants.DOM3_DEFAULT_TRUE);
+
+        // pretty-print
+        fDOMConfigProperties.setProperty(
+                DOMConstants.S_XSL_OUTPUT_INDENT,
+                DOMConstants.DOM3_DEFAULT_FALSE);
+        fDOMConfigProperties.setProperty(
+                OutputPropertiesFactory.S_KEY_INDENT_AMOUNT, Integer.toString(4));
+
+        //
+
+        // discard-default-content
+        fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                + DOMConstants.DOM_DISCARD_DEFAULT_CONTENT,
+                DOMConstants.DOM3_DEFAULT_TRUE);
+
+        // xml-declaration
+        fDOMConfigProperties.setProperty(DOMConstants.S_XSL_OUTPUT_OMIT_XML_DECL, "no");
+
+    }
+
+    // ************************************************************************
+    // DOMConfiguraiton implementation
+    // ************************************************************************
+
+    /**
+     * Checks if setting a parameter to a specific value is supported.
+     *
+     * @see org.w3c.dom.DOMConfiguration#canSetParameter(java.lang.String, java.lang.Object)
+     * @since DOM Level 3
+     * @param name A String containing the DOMConfiguration parameter name.
+     * @param value An Object specifying the value of the corresponding parameter.
+     */
+    public boolean canSetParameter(String name, Object value) {
+        if (value instanceof Boolean){
+            if ( name.equalsIgnoreCase(DOMConstants.DOM_CDATA_SECTIONS)
+                    || name.equalsIgnoreCase(DOMConstants.DOM_COMMENTS)
+                    || name.equalsIgnoreCase(DOMConstants.DOM_ENTITIES)
+                    || name.equalsIgnoreCase(DOMConstants.DOM_INFOSET)
+                    || name.equalsIgnoreCase(DOMConstants.DOM_ELEMENT_CONTENT_WHITESPACE)
+                    || name.equalsIgnoreCase(DOMConstants.DOM_NAMESPACES)
+                    || name.equalsIgnoreCase(DOMConstants.DOM_NAMESPACE_DECLARATIONS)
+                    || name.equalsIgnoreCase(DOMConstants.DOM_SPLIT_CDATA)
+                    || name.equalsIgnoreCase(DOMConstants.DOM_WELLFORMED)
+                    || name.equalsIgnoreCase(DOMConstants.DOM_DISCARD_DEFAULT_CONTENT)
+                    || name.equalsIgnoreCase(DOMConstants.DOM_FORMAT_PRETTY_PRINT)
+                    || name.equalsIgnoreCase(DOMConstants.DOM_XMLDECL)){
+                // both values supported
+                return true;
+            }
+            else if (name.equalsIgnoreCase(DOMConstants.DOM_CANONICAL_FORM)
+                    || name.equalsIgnoreCase(DOMConstants.DOM_CHECK_CHAR_NORMALIZATION)
+                    || name.equalsIgnoreCase(DOMConstants.DOM_DATATYPE_NORMALIZATION)
+                    || name.equalsIgnoreCase(DOMConstants.DOM_VALIDATE_IF_SCHEMA)
+                    || name.equalsIgnoreCase(DOMConstants.DOM_VALIDATE)
+                    // || name.equalsIgnoreCase(DOMConstants.DOM_NORMALIZE_CHARACTERS)
+                    ) {
+                // true is not supported
+                return !((Boolean)value).booleanValue();
+            }
+            else if (name.equalsIgnoreCase(DOMConstants.DOM_IGNORE_UNKNOWN_CHARACTER_DENORMALIZATIONS)) {
+                // false is not supported
+                return ((Boolean)value).booleanValue();
+            }
+        }
+        else if (name.equalsIgnoreCase(DOMConstants.DOM_ERROR_HANDLER) &&
+                value == null || value instanceof DOMErrorHandler){
+            return true;
+        }
+        return false;
+    }
+    /**
+     * This method returns the value of a parameter if known.
+     *
+     * @see org.w3c.dom.DOMConfiguration#getParameter(java.lang.String)
+     *
+     * @param name A String containing the DOMConfiguration parameter name
+     *             whose value is to be returned.
+     * @return Object The value of the parameter if known.
+     */
+    public Object getParameter(String name) throws DOMException {
+
+        if(name.equalsIgnoreCase(DOMConstants.DOM_NORMALIZE_CHARACTERS)){
+                      return null;
+        } else if (name.equalsIgnoreCase(DOMConstants.DOM_COMMENTS)) {
+            return ((fFeatures & COMMENTS) != 0) ? Boolean.TRUE : Boolean.FALSE;
+        } else if (name.equalsIgnoreCase(DOMConstants.DOM_CDATA_SECTIONS)) {
+            return ((fFeatures & CDATA) != 0) ? Boolean.TRUE : Boolean.FALSE;
+        } else if (name.equalsIgnoreCase(DOMConstants.DOM_ENTITIES)) {
+            return ((fFeatures & ENTITIES) != 0) ? Boolean.TRUE : Boolean.FALSE;
+        } else if (name.equalsIgnoreCase(DOMConstants.DOM_NAMESPACES)) {
+            return ((fFeatures & NAMESPACES) != 0) ? Boolean.TRUE : Boolean.FALSE;
+        } else if (name.equalsIgnoreCase(DOMConstants.DOM_NAMESPACE_DECLARATIONS)) {
+            return ((fFeatures & NAMESPACEDECLS) != 0) ? Boolean.TRUE : Boolean.FALSE;
+        } else if (name.equalsIgnoreCase(DOMConstants.DOM_SPLIT_CDATA)) {
+            return ((fFeatures & SPLITCDATA) != 0) ? Boolean.TRUE : Boolean.FALSE;
+        } else if (name.equalsIgnoreCase(DOMConstants.DOM_WELLFORMED)) {
+            return ((fFeatures & WELLFORMED) != 0) ? Boolean.TRUE : Boolean.FALSE;
+        }  else if (name.equalsIgnoreCase(DOMConstants.DOM_DISCARD_DEFAULT_CONTENT)) {
+            return ((fFeatures & DISCARDDEFAULT) != 0) ? Boolean.TRUE : Boolean.FALSE;
+        } else if (name.equalsIgnoreCase(DOMConstants.DOM_FORMAT_PRETTY_PRINT)) {
+            return ((fFeatures & PRETTY_PRINT) != 0) ? Boolean.TRUE : Boolean.FALSE;
+        } else if (name.equalsIgnoreCase(DOMConstants.DOM_XMLDECL)) {
+            return ((fFeatures & XMLDECL) != 0) ? Boolean.TRUE : Boolean.FALSE;
+        } else if (name.equalsIgnoreCase(DOMConstants.DOM_ELEMENT_CONTENT_WHITESPACE)) {
+            return ((fFeatures & ELEM_CONTENT_WHITESPACE) != 0) ? Boolean.TRUE : Boolean.FALSE;
+        } else if (name.equalsIgnoreCase(DOMConstants.DOM_IGNORE_UNKNOWN_CHARACTER_DENORMALIZATIONS)) {
+            return Boolean.TRUE;
+        } else if (name.equalsIgnoreCase(DOMConstants.DOM_CANONICAL_FORM)
+                || name.equalsIgnoreCase(DOMConstants.DOM_CHECK_CHAR_NORMALIZATION)
+                || name.equalsIgnoreCase(DOMConstants.DOM_DATATYPE_NORMALIZATION)
+                // || name.equalsIgnoreCase(DOMConstants.DOM_NORMALIZE_CHARACTERS)
+                || name.equalsIgnoreCase(DOMConstants.DOM_VALIDATE)
+                || name.equalsIgnoreCase(DOMConstants.DOM_VALIDATE_IF_SCHEMA)) {
+            return Boolean.FALSE;
+        } else if (name.equalsIgnoreCase(DOMConstants.DOM_INFOSET)){
+            if ((fFeatures & ENTITIES) == 0 &&
+                    (fFeatures & CDATA) == 0 &&
+                    (fFeatures & ELEM_CONTENT_WHITESPACE) != 0 &&
+                    (fFeatures & NAMESPACES) != 0 &&
+                    (fFeatures & NAMESPACEDECLS) != 0 &&
+                    (fFeatures & WELLFORMED) != 0 &&
+                    (fFeatures & COMMENTS) != 0) {
+                return Boolean.TRUE;
+            }
+            return Boolean.FALSE;
+        } else if (name.equalsIgnoreCase(DOMConstants.DOM_ERROR_HANDLER)) {
+            return fDOMErrorHandler;
+        } else if (
+                name.equalsIgnoreCase(DOMConstants.DOM_SCHEMA_LOCATION)
+                || name.equalsIgnoreCase(DOMConstants.DOM_SCHEMA_TYPE)) {
+            return null;
+        } else {
+            // Here we have to add the Xalan specific DOM Message Formatter
+            String msg = Utils.messages.createMessage(
+                    MsgKey.ER_FEATURE_NOT_FOUND,
+                    new Object[] { name });
+            throw new DOMException(DOMException.NOT_FOUND_ERR, msg);
+        }
+    }
+
+    /**
+     * This method returns a of the parameters supported by this DOMConfiguration object
+     * and for which at least one value can be set by the application
+     *
+     * @see org.w3c.dom.DOMConfiguration#getParameterNames()
+     *
+     * @return DOMStringList A list of DOMConfiguration parameters recognized
+     *                       by the serializer
+     */
+    public DOMStringList getParameterNames() {
+        return new DOMStringListImpl(fRecognizedParameters);
+    }
+
+    /**
+     * This method sets the value of the named parameter.
+     *
+     * @see org.w3c.dom.DOMConfiguration#setParameter(java.lang.String, java.lang.Object)
+     *
+     * @param name A String containing the DOMConfiguration parameter name.
+     * @param value An Object contaiing the parameters value to set.
+     */
+    public void setParameter(String name, Object value) throws DOMException {
+        // If the value is a boolean
+        if (value instanceof Boolean) {
+            boolean state = ((Boolean) value).booleanValue();
+
+            if (name.equalsIgnoreCase(DOMConstants.DOM_COMMENTS)) {
+                fFeatures = state ? fFeatures | COMMENTS : fFeatures
+                        & ~COMMENTS;
+                // comments
+                if (state) {
+                    fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                            + DOMConstants.DOM_COMMENTS, DOMConstants.DOM3_EXPLICIT_TRUE);
+                } else {
+                    fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                            + DOMConstants.DOM_COMMENTS, DOMConstants.DOM3_EXPLICIT_FALSE);
+                }
+            } else if (name.equalsIgnoreCase(DOMConstants.DOM_CDATA_SECTIONS)) {
+                fFeatures =  state ? fFeatures | CDATA : fFeatures
+                        & ~CDATA;
+                // cdata-sections
+                if (state) {
+                    fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                            + DOMConstants.DOM_CDATA_SECTIONS, DOMConstants.DOM3_EXPLICIT_TRUE);
+                } else {
+                    fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                            + DOMConstants.DOM_CDATA_SECTIONS, DOMConstants.DOM3_EXPLICIT_FALSE);
+                }
+            } else if (name.equalsIgnoreCase(DOMConstants.DOM_ENTITIES)) {
+                fFeatures = state ? fFeatures | ENTITIES : fFeatures
+                        & ~ENTITIES;
+                // entities
+                if (state) {
+                    fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                            + DOMConstants.DOM_ENTITIES, DOMConstants.DOM3_EXPLICIT_TRUE);
+                    fDOMConfigProperties.setProperty(
+                            OutputPropertiesFactory.S_KEY_ENTITIES, DOMConstants.S_XSL_VALUE_ENTITIES);
+                } else {
+                    fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                            + DOMConstants.DOM_ENTITIES, DOMConstants.DOM3_EXPLICIT_FALSE);
+                }
+            } else if (name.equalsIgnoreCase(DOMConstants.DOM_NAMESPACES)) {
+                fFeatures = state ? fFeatures | NAMESPACES : fFeatures
+                        & ~NAMESPACES;
+                // namespaces
+                if (state) {
+                    fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                            + DOMConstants.DOM_NAMESPACES, DOMConstants.DOM3_EXPLICIT_TRUE);
+                } else {
+                    fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                            + DOMConstants.DOM_NAMESPACES, DOMConstants.DOM3_EXPLICIT_FALSE);
+                }
+            } else if (name
+                    .equalsIgnoreCase(DOMConstants.DOM_NAMESPACE_DECLARATIONS)) {
+                fFeatures = state ? fFeatures | NAMESPACEDECLS
+                        : fFeatures & ~NAMESPACEDECLS;
+                // namespace-declarations
+                if (state) {
+                    fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                            + DOMConstants.DOM_NAMESPACE_DECLARATIONS, DOMConstants.DOM3_EXPLICIT_TRUE);
+                } else {
+                    fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                            + DOMConstants.DOM_NAMESPACE_DECLARATIONS, DOMConstants.DOM3_EXPLICIT_FALSE);
+                }
+            } else if (name.equalsIgnoreCase(DOMConstants.DOM_SPLIT_CDATA)) {
+                fFeatures = state ? fFeatures | SPLITCDATA : fFeatures
+                        & ~SPLITCDATA;
+                // split-cdata-sections
+                if (state) {
+                    fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                            + DOMConstants.DOM_SPLIT_CDATA, DOMConstants.DOM3_EXPLICIT_TRUE);
+                } else {
+                    fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                            + DOMConstants.DOM_SPLIT_CDATA, DOMConstants.DOM3_EXPLICIT_FALSE);
+                }
+            } else if (name.equalsIgnoreCase(DOMConstants.DOM_WELLFORMED)) {
+                fFeatures = state ? fFeatures | WELLFORMED : fFeatures
+                        & ~WELLFORMED;
+                // well-formed
+                if (state) {
+                    fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                            + DOMConstants.DOM_WELLFORMED, DOMConstants.DOM3_EXPLICIT_TRUE);
+                } else {
+                    fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                            + DOMConstants.DOM_WELLFORMED, DOMConstants.DOM3_EXPLICIT_FALSE);
+                }
+            } else if (name
+                    .equalsIgnoreCase(DOMConstants.DOM_DISCARD_DEFAULT_CONTENT)) {
+                fFeatures = state ? fFeatures | DISCARDDEFAULT
+                        : fFeatures & ~DISCARDDEFAULT;
+                // discard-default-content
+                if (state) {
+                    fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                            + DOMConstants.DOM_DISCARD_DEFAULT_CONTENT, DOMConstants.DOM3_EXPLICIT_TRUE);
+                } else {
+                    fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                            + DOMConstants.DOM_DISCARD_DEFAULT_CONTENT, DOMConstants.DOM3_EXPLICIT_FALSE);
+                }
+            } else if (name.equalsIgnoreCase(DOMConstants.DOM_FORMAT_PRETTY_PRINT)) {
+                fFeatures = state ? fFeatures | PRETTY_PRINT : fFeatures
+                        & ~PRETTY_PRINT;
+                if (state) {
+                    fDOMConfigProperties.setProperty(DOMConstants.S_XSL_OUTPUT_INDENT,DOMConstants.DOM3_EXPLICIT_TRUE);
+                    fDOMConfigProperties.setProperty(OutputPropertiesFactory.S_KEY_INDENT_AMOUNT, Integer.toString(4));
+                } else {
+                    fDOMConfigProperties.setProperty(DOMConstants.S_XSL_OUTPUT_INDENT,DOMConstants.DOM3_EXPLICIT_FALSE);
+                }
+            } else if (name.equalsIgnoreCase(DOMConstants.DOM_XMLDECL)) {
+                fFeatures = state ? fFeatures | XMLDECL : fFeatures
+                        & ~XMLDECL;
+                if (state) {
+                    fDOMConfigProperties.setProperty(DOMConstants.S_XSL_OUTPUT_OMIT_XML_DECL, "no");
+                } else {
+                    fDOMConfigProperties.setProperty(DOMConstants.S_XSL_OUTPUT_OMIT_XML_DECL, "yes");
+                }
+            } else if (name.equalsIgnoreCase(DOMConstants.DOM_ELEMENT_CONTENT_WHITESPACE)) {
+                fFeatures = state ? fFeatures | ELEM_CONTENT_WHITESPACE : fFeatures
+                        & ~ELEM_CONTENT_WHITESPACE;
+                // element-content-whitespace
+                if (state) {
+                    fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                            + DOMConstants.DOM_ELEMENT_CONTENT_WHITESPACE, DOMConstants.DOM3_EXPLICIT_TRUE);
+                } else {
+                    fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                            + DOMConstants.DOM_ELEMENT_CONTENT_WHITESPACE, DOMConstants.DOM3_EXPLICIT_FALSE);
+                }
+            } else if (name.equalsIgnoreCase(DOMConstants.DOM_IGNORE_UNKNOWN_CHARACTER_DENORMALIZATIONS)) {
+                // false is not supported
+                if (!state) {
+                    // Here we have to add the Xalan specific DOM Message Formatter
+                    String msg = Utils.messages.createMessage(
+                            MsgKey.ER_FEATURE_NOT_SUPPORTED,
+                            new Object[] { name });
+                    throw new DOMException(DOMException.NOT_SUPPORTED_ERR, msg);
+                } else {
+                    fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                            + DOMConstants.DOM_IGNORE_UNKNOWN_CHARACTER_DENORMALIZATIONS, DOMConstants.DOM3_EXPLICIT_TRUE);
+                }
+            } else if (name.equalsIgnoreCase(DOMConstants.DOM_CANONICAL_FORM)
+                    || name.equalsIgnoreCase(DOMConstants.DOM_VALIDATE_IF_SCHEMA)
+                    || name.equalsIgnoreCase(DOMConstants.DOM_VALIDATE)
+                    || name.equalsIgnoreCase(DOMConstants.DOM_CHECK_CHAR_NORMALIZATION)
+                    || name.equalsIgnoreCase(DOMConstants.DOM_DATATYPE_NORMALIZATION)
+                    // || name.equalsIgnoreCase(DOMConstants.DOM_NORMALIZE_CHARACTERS)
+                    ) {
+                // true is not supported
+                if (state) {
+                    String msg = Utils.messages.createMessage(
+                            MsgKey.ER_FEATURE_NOT_SUPPORTED,
+                            new Object[] { name });
+                    throw new DOMException(DOMException.NOT_SUPPORTED_ERR, msg);
+                } else {
+                    if (name.equalsIgnoreCase(DOMConstants.DOM_CANONICAL_FORM)) {
+                        fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                                + DOMConstants.DOM_CANONICAL_FORM, DOMConstants.DOM3_EXPLICIT_FALSE);
+                    } else if (name.equalsIgnoreCase(DOMConstants.DOM_VALIDATE_IF_SCHEMA)) {
+                        fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                                + DOMConstants.DOM_VALIDATE_IF_SCHEMA, DOMConstants.DOM3_EXPLICIT_FALSE);
+                    } else if (name.equalsIgnoreCase(DOMConstants.DOM_VALIDATE)) {
+                        fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                                + DOMConstants.DOM_VALIDATE, DOMConstants.DOM3_EXPLICIT_FALSE);
+                    } else if (name.equalsIgnoreCase(DOMConstants.DOM_VALIDATE_IF_SCHEMA)) {
+                        fDOMConfigProperties.setProperty(DOMConstants.DOM_CHECK_CHAR_NORMALIZATION
+                                + DOMConstants.DOM_CHECK_CHAR_NORMALIZATION, DOMConstants.DOM3_EXPLICIT_FALSE);
+                    } else if (name.equalsIgnoreCase(DOMConstants.DOM_DATATYPE_NORMALIZATION)) {
+                        fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                                + DOMConstants.DOM_DATATYPE_NORMALIZATION, DOMConstants.DOM3_EXPLICIT_FALSE);
+                    } /* else if (name.equalsIgnoreCase(DOMConstants.DOM_NORMALIZE_CHARACTERS)) {
+                        fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                                + DOMConstants.DOM_NORMALIZE_CHARACTERS, DOMConstants.DOM3_EXPLICIT_FALSE);
+                    } */
+                }
+            } else if (name.equalsIgnoreCase(DOMConstants.DOM_INFOSET)) {
+                if (state) {
+                    fFeatures &= ~ENTITIES;
+                    fFeatures &= ~CDATA;
+                    fFeatures &= ~SCHEMAVALIDATE;
+                    fFeatures &= ~DTNORMALIZE;
+                    fFeatures |= NAMESPACES;
+                    fFeatures |= NAMESPACEDECLS;
+                    fFeatures |= WELLFORMED;
+                    fFeatures |= ELEM_CONTENT_WHITESPACE;
+                    fFeatures |= COMMENTS;
+                }
+
+                // infoset
+                fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                        + DOMConstants.DOM_NAMESPACES, DOMConstants.DOM3_EXPLICIT_TRUE);
+                fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                        + DOMConstants.DOM_NAMESPACE_DECLARATIONS, DOMConstants.DOM3_EXPLICIT_TRUE);
+                fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                        + DOMConstants.DOM_COMMENTS, DOMConstants.DOM3_EXPLICIT_TRUE);
+                fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                        + DOMConstants.DOM_ELEMENT_CONTENT_WHITESPACE, DOMConstants.DOM3_EXPLICIT_TRUE);
+                fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                        + DOMConstants.DOM_WELLFORMED, DOMConstants.DOM3_EXPLICIT_TRUE);
+
+                fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                        + DOMConstants.DOM_ENTITIES, DOMConstants.DOM3_EXPLICIT_FALSE);
+                fDOMConfigProperties.setProperty(
+                        OutputPropertiesFactory.S_KEY_ENTITIES, "");
+
+                fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                        + DOMConstants.DOM_CDATA_SECTIONS, DOMConstants.DOM3_EXPLICIT_FALSE);
+                fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                        + DOMConstants.DOM_VALIDATE_IF_SCHEMA, DOMConstants.DOM3_EXPLICIT_FALSE);
+                fDOMConfigProperties.setProperty(DOMConstants.S_DOM3_PROPERTIES_NS
+                        + DOMConstants.DOM_DATATYPE_NORMALIZATION, DOMConstants.DOM3_EXPLICIT_FALSE);
+            } else if (name.equalsIgnoreCase(DOMConstants.DOM_NORMALIZE_CHARACTERS)) {
+                String msg = Utils.messages.createMessage(
+                    MsgKey.ER_FEATURE_NOT_SUPPORTED,
+                    new Object[] { name });
+                throw new DOMException(DOMException.NOT_SUPPORTED_ERR, msg);
+            } else {
+                // Setting this to false has no effect
+            }
+        } // If the parameter value is not a boolean
+        else if (name.equalsIgnoreCase(DOMConstants.DOM_ERROR_HANDLER)) {
+            if (value == null || value instanceof DOMErrorHandler) {
+                fDOMErrorHandler = (DOMErrorHandler)value;
+            } else {
+                String msg = Utils.messages.createMessage(
+                        MsgKey.ER_TYPE_MISMATCH_ERR,
+                        new Object[] { name });
+                throw new DOMException(DOMException.TYPE_MISMATCH_ERR, msg);
+            }
+        } else if (
+                name.equalsIgnoreCase(DOMConstants.DOM_SCHEMA_LOCATION)
+                || name.equalsIgnoreCase(DOMConstants.DOM_SCHEMA_TYPE)
+                || name.equalsIgnoreCase(DOMConstants.DOM_NORMALIZE_CHARACTERS)
+                && value != null) {
+            String msg = Utils.messages.createMessage(
+                    MsgKey.ER_FEATURE_NOT_SUPPORTED,
+                    new Object[] { name });
+            throw new DOMException(DOMException.NOT_SUPPORTED_ERR, msg);
+        } else {
+            String msg = Utils.messages.createMessage(
+                    MsgKey.ER_FEATURE_NOT_FOUND,
+                    new Object[] { name });
+            throw new DOMException(DOMException.NOT_FOUND_ERR, msg);
+        }
+    }
+    // ************************************************************************
+
+
+    // ************************************************************************
+    // DOMConfiguraiton implementation
+    // ************************************************************************
+
+    /**
+     * Returns the DOMConfiguration of the LSSerializer.
+     *
+     * @see org.w3c.dom.ls.LSSerializer#getDomConfig()
+     * @since DOM Level 3
+     * @return A DOMConfiguration object.
+     */
+    public DOMConfiguration getDomConfig() {
+        return (DOMConfiguration)this;
+    }
+
+    /**
+     * Returns the DOMConfiguration of the LSSerializer.
+     *
+     * @see org.w3c.dom.ls.LSSerializer#getFilter()
+     * @since DOM Level 3
+     * @return A LSSerializerFilter object.
+     */
+    public LSSerializerFilter getFilter() {
+        return fSerializerFilter;
+    }
+
+    /**
+     * Returns the End-Of-Line sequence of characters to be used in the XML
+     * being serialized.  If none is set a default "\n" is returned.
+     *
+     * @see org.w3c.dom.ls.LSSerializer#getNewLine()
+     * @since DOM Level 3
+     * @return A String containing the end-of-line character sequence  used in
+     * serialization.
+     */
+    public String getNewLine() {
+        return fEndOfLine;
+    }
+
+    /**
+     * Set a LSSerilizerFilter on the LSSerializer.  When set, the filter is
+     * called before each node is serialized which depending on its implemention
+     * determines if the node is to be serialized or not.
+     *
+     * @see org.w3c.dom.ls.LSSerializer#setFilter
+     * @since DOM Level 3
+     * @param filter A LSSerializerFilter to be applied to the stream to serialize.
+     */
+    public void setFilter(LSSerializerFilter filter) {
+        fSerializerFilter = filter;
+    }
+
+    /**
+     * Sets the End-Of-Line sequence of characters to be used in the XML
+     * being serialized.  Setting this attribute to null will reset its
+     * value to the default value i.e. "\n".
+     *
+     * @see org.w3c.dom.ls.LSSerializer#setNewLine
+     * @since DOM Level 3
+     * @param newLine a String that is the end-of-line character sequence to be used in
+     * serialization.
+     */
+    public void setNewLine(String newLine) {
+        fEndOfLine = newLine !=null? newLine: fEndOfLine;
+    }
+
+    /**
+     * Serializes the specified node to the specified LSOutput and returns true if the Node
+     * was successfully serialized.
+     *
+     * @see org.w3c.dom.ls.LSSerializer#write(org.w3c.dom.Node, org.w3c.dom.ls.LSOutput)
+     * @since DOM Level 3
+     * @param nodeArg The Node to serialize.
+     * @throws org.w3c.dom.ls.LSException SERIALIZE_ERR: Raised if the
+     * LSSerializer was unable to serialize the node.
+     *
+     */
+    public boolean write(Node nodeArg, LSOutput destination) throws LSException {
+        // If the destination is null
+        if (destination == null) {
+            String msg = Utils.messages
+            .createMessage(
+                    MsgKey.ER_NO_OUTPUT_SPECIFIED,
+                    null);
+            if (fDOMErrorHandler != null) {
+                fDOMErrorHandler.handleError(new DOMErrorImpl(
+                        DOMError.SEVERITY_FATAL_ERROR, msg,
+                        MsgKey.ER_NO_OUTPUT_SPECIFIED));
+            }
+            throw new LSException(LSException.SERIALIZE_ERR, msg);
+        }
+
+        // If nodeArg is null, return false.  Should we throw and LSException instead?
+        if (nodeArg == null ) {
+            return false;
+        }
+
+        // Obtain a reference to the serializer to use
+        // Serializer serializer = getXMLSerializer(xmlVersion);
+        Serializer serializer = fXMLSerializer;
+        serializer.reset();
+
+        // If the node has not been seen
+        if ( nodeArg != fVisitedNode) {
+            // Determine the XML Document version of the Node
+            String xmlVersion = getXMLVersion(nodeArg);
+
+            // Determine the encoding: 1.LSOutput.encoding, 2.Document.inputEncoding, 3.Document.xmlEncoding.
+            fEncoding = destination.getEncoding();
+            if (fEncoding == null ) {
+                fEncoding = getInputEncoding(nodeArg);
+                fEncoding = fEncoding != null ? fEncoding : getXMLEncoding(nodeArg) == null? "UTF-8": getXMLEncoding(nodeArg);
+            }
+
+            // If the encoding is not recognized throw an exception.
+            // Note: The serializer defaults to UTF-8 when created
+            if (!Encodings.isRecognizedEncoding(fEncoding)) {
+                String msg = Utils.messages
+                .createMessage(
+                        MsgKey.ER_UNSUPPORTED_ENCODING,
+                        null);
+                if (fDOMErrorHandler != null) {
+                    fDOMErrorHandler.handleError(new DOMErrorImpl(
+                            DOMError.SEVERITY_FATAL_ERROR, msg,
+                            MsgKey.ER_UNSUPPORTED_ENCODING));
+                }
+                throw new LSException(LSException.SERIALIZE_ERR, msg);
+            }
+
+            serializer.getOutputFormat().setProperty("version", xmlVersion);
+
+            // Set the output encoding and xml version properties
+            fDOMConfigProperties.setProperty(DOMConstants.S_XERCES_PROPERTIES_NS + DOMConstants.S_XML_VERSION, xmlVersion);
+            fDOMConfigProperties.setProperty(DOMConstants.S_XSL_OUTPUT_ENCODING, fEncoding);
+
+            // If the node to be serialized is not a Document, Element, or Entity
+            // node
+            // then the XML declaration, or text declaration, should be never be
+            // serialized.
+            if ( (nodeArg.getNodeType() != Node.DOCUMENT_NODE
+                    || nodeArg.getNodeType() != Node.ELEMENT_NODE
+                    || nodeArg.getNodeType() != Node.ENTITY_NODE)
+                    && ((fFeatures & XMLDECL) != 0)) {
+                fDOMConfigProperties.setProperty(
+                        DOMConstants.S_XSL_OUTPUT_OMIT_XML_DECL,
+                        DOMConstants.DOM3_DEFAULT_FALSE);
+            }
+
+            fVisitedNode = nodeArg;
+        }
+
+        // Update the serializer properties
+        fXMLSerializer.setOutputFormat(fDOMConfigProperties);
+
+        //
+        try {
+
+            // The LSSerializer will use the LSOutput object to determine
+            // where to serialize the output to in the following order the
+            // first one that is not null and not an empty string will be
+            // used: 1.LSOutput.characterStream, 2.LSOutput.byteStream,
+            // 3. LSOutput.systemId
+            // 1.LSOutput.characterStream
+            Writer writer = destination.getCharacterStream();
+            if (writer == null ) {
+
+                // 2.LSOutput.byteStream
+                OutputStream outputStream = destination.getByteStream();
+                if ( outputStream == null) {
+
+                    // 3. LSOutput.systemId
+                    String uri = destination.getSystemId();
+                    if (uri == null) {
+                        String msg = Utils.messages
+                        .createMessage(
+                                MsgKey.ER_NO_OUTPUT_SPECIFIED,
+                                null);
+                        if (fDOMErrorHandler != null) {
+                            fDOMErrorHandler.handleError(new DOMErrorImpl(
+                                    DOMError.SEVERITY_FATAL_ERROR, msg,
+                                    MsgKey.ER_NO_OUTPUT_SPECIFIED));
+                        }
+                        throw new LSException(LSException.SERIALIZE_ERR, msg);
+
+                    } else {
+                        // Expand the System Id and obtain an absolute URI for it.
+                        String absoluteURI = SystemIDResolver.getAbsoluteURI(uri);
+
+                        URL url = new URL(absoluteURI);
+                        OutputStream urlOutStream = null;
+                        String protocol = url.getProtocol();
+                        String host = url.getHost();
+
+                        // For file protocols, there is no need to use a URL to get its
+                        // corresponding OutputStream
+
+                        // Scheme names consist of a sequence of characters. The lower case
+                        // letters "a"--"z", digits, and the characters plus ("+"), period
+                        // ("."), and hyphen ("-") are allowed. For resiliency, programs
+                        // interpreting URLs should treat upper case letters as equivalent to
+                        // lower case in scheme names (e.g., allow "HTTP" as well as "http").
+                        if (protocol.equalsIgnoreCase("file")
+                                && (host == null || host.length() == 0 || host.equals("localhost"))) {
+                            // do we also need to check for host.equals(hostname)
+                            urlOutStream = new FileOutputStream(new File(url.getPath()));
+
+                        } else {
+                            // This should support URL's whose schemes are mentioned in
+                            // RFC1738 other than file
+
+                            URLConnection urlCon = url.openConnection();
+                            urlCon.setDoInput(false);
+                            urlCon.setDoOutput(true);
+                            urlCon.setUseCaches(false);
+                            urlCon.setAllowUserInteraction(false);
+
+                            // When writing to a HTTP URI, a HTTP PUT is performed.
+                            if (urlCon instanceof HttpURLConnection) {
+                                HttpURLConnection httpCon = (HttpURLConnection) urlCon;
+                                httpCon.setRequestMethod("PUT");
+                            }
+                            urlOutStream = urlCon.getOutputStream();
+                        }
+                        // set the OutputStream to that obtained from the systemId
+                        serializer.setWriter(new OutputStreamWriter(urlOutStream));
+                    }
+                } else {
+                    // 2.LSOutput.byteStream
+                    serializer.setWriter(new OutputStreamWriter(outputStream, fEncoding));
+                }
+            } else {
+                // 1.LSOutput.characterStream
+                serializer.setWriter(writer);
+            }
+
+            // The associated media type by default is set to text/xml on
+            // org.apache.xml.serializer.SerializerBase.
+
+            // Get a reference to the serializer then lets you serilize a DOM
+            // Use this hack till Xalan support JAXP1.3
+            if (fDOMSerializer == null) {
+               fDOMSerializer = (DOM3Serializer)serializer.asDOM3Serializer();
+            }
+
+            // Set the error handler on the DOM3Serializer interface implementation
+            if (fDOMErrorHandler != null) {
+                fDOMSerializer.setErrorHandler(fDOMErrorHandler);
+            }
+
+            // Set the filter on the DOM3Serializer interface implementation
+            if (fSerializerFilter != null) {
+                fDOMSerializer.setNodeFilter(fSerializerFilter);
+            }
+
+            // Set the NewLine character to be used
+            fDOMSerializer.setNewLine(fEndOfLine);
+
+            // Serializer your DOM, where node is an org.w3c.dom.Node
+            // Assuming that Xalan's serializer can serialize any type of DOM node
+            fDOMSerializer.serializeDOM3(nodeArg);
+
+        } catch( UnsupportedEncodingException ue) {
+
+            String msg = Utils.messages
+            .createMessage(
+                    MsgKey.ER_UNSUPPORTED_ENCODING,
+                    null);
+            if (fDOMErrorHandler != null) {
+                fDOMErrorHandler.handleError(new DOMErrorImpl(
+                        DOMError.SEVERITY_FATAL_ERROR, msg,
+                        MsgKey.ER_UNSUPPORTED_ENCODING, ue));
+            }
+            throw new LSException(LSException.SERIALIZE_ERR, ue.getMessage());
+        } catch (LSException lse) {
+            // Rethrow LSException.
+            throw lse;
+        } catch (RuntimeException e) {
+            e.printStackTrace();
+            throw new LSException(LSException.SERIALIZE_ERR, e!=null?e.getMessage():"NULL Exception") ;
+        }  catch (Exception e) {
+            if (fDOMErrorHandler != null) {
+                fDOMErrorHandler.handleError(new DOMErrorImpl(
+                        DOMError.SEVERITY_FATAL_ERROR, e.getMessage(),
+                        null, e));
+            }
+            e.printStackTrace();
+            throw new LSException(LSException.SERIALIZE_ERR, e.toString());
+        }
+        return true;
+    }
+
+    /**
+     * Serializes the specified node and returns a String with the serialized
+     * data to the caller.
+     *
+     * @see org.w3c.dom.ls.LSSerializer#writeToString(org.w3c.dom.Node)
+     * @since DOM Level 3
+     * @param nodeArg The Node to serialize.
+     * @throws org.w3c.dom.ls.LSException SERIALIZE_ERR: Raised if the
+     * LSSerializer was unable to serialize the node.
+     *
+     */
+    public String writeToString(Node nodeArg) throws DOMException, LSException {
+        // return null is nodeArg is null.  Should an Exception be thrown instead?
+        if (nodeArg == null) {
+            return null;
+        }
+
+        // Should we reset the serializer configuration before each write operation?
+        // Obtain a reference to the serializer to use
+        Serializer serializer = fXMLSerializer;
+        serializer.reset();
+
+        if (nodeArg != fVisitedNode){
+            // Determine the XML Document version of the Node
+            String xmlVersion = getXMLVersion(nodeArg);
+
+            serializer.getOutputFormat().setProperty("version", xmlVersion);
+
+            // Set the output encoding and xml version properties
+            fDOMConfigProperties.setProperty(DOMConstants.S_XERCES_PROPERTIES_NS + DOMConstants.S_XML_VERSION, xmlVersion);
+            fDOMConfigProperties.setProperty(DOMConstants.S_XSL_OUTPUT_ENCODING, "UTF-16");
+
+            // If the node to be serialized is not a Document, Element, or Entity
+            // node
+            // then the XML declaration, or text declaration, should be never be
+            // serialized.
+            if  ((nodeArg.getNodeType() != Node.DOCUMENT_NODE
+                    || nodeArg.getNodeType() != Node.ELEMENT_NODE
+                    || nodeArg.getNodeType() != Node.ENTITY_NODE)
+                    && ((fFeatures & XMLDECL) != 0)) {
+                fDOMConfigProperties.setProperty(
+                        DOMConstants.S_XSL_OUTPUT_OMIT_XML_DECL,
+                        DOMConstants.DOM3_DEFAULT_FALSE);
+            }
+
+            fVisitedNode = nodeArg;
+        }
+        // Update the serializer properties
+        fXMLSerializer.setOutputFormat(fDOMConfigProperties);
+
+        // StringWriter to Output to
+        StringWriter output = new StringWriter();
+
+        //
+        try {
+
+            // Set the Serializer's Writer to a StringWriter
+            serializer.setWriter(output);
+
+            // Get a reference to the serializer then lets you serilize a DOM
+            // Use this hack till Xalan support JAXP1.3
+            if (fDOMSerializer == null) {
+                fDOMSerializer = (DOM3Serializer)serializer.asDOM3Serializer();
+            }
+
+            // Set the error handler on the DOM3Serializer interface implementation
+            if (fDOMErrorHandler != null) {
+                fDOMSerializer.setErrorHandler(fDOMErrorHandler);
+            }
+
+            // Set the filter on the DOM3Serializer interface implementation
+            if (fSerializerFilter != null) {
+                fDOMSerializer.setNodeFilter(fSerializerFilter);
+            }
+
+            // Set the NewLine character to be used
+            fDOMSerializer.setNewLine(fEndOfLine);
+
+            // Serializer your DOM, where node is an org.w3c.dom.Node
+            fDOMSerializer.serializeDOM3(nodeArg);
+        } catch (LSException lse) {
+            // Rethrow LSException.
+            throw lse;
+        } catch (RuntimeException e) {
+            e.printStackTrace();
+            throw new LSException(LSException.SERIALIZE_ERR, e.toString());
+        }  catch (Exception e) {
+            if (fDOMErrorHandler != null) {
+                fDOMErrorHandler.handleError(new DOMErrorImpl(
+                        DOMError.SEVERITY_FATAL_ERROR, e.getMessage(),
+                        null, e));
+            }
+            e.printStackTrace();
+            throw new LSException(LSException.SERIALIZE_ERR, e.toString());
+        }
+
+        // return the serialized string
+        return output.toString();
+    }
+
+    /**
+     * Serializes the specified node to the specified URI and returns true if the Node
+     * was successfully serialized.
+     *
+     * @see org.w3c.dom.ls.LSSerializer#writeToURI(org.w3c.dom.Node, String)
+     * @since DOM Level 3
+     * @param nodeArg The Node to serialize.
+     * @throws org.w3c.dom.ls.LSException SERIALIZE_ERR: Raised if the
+     * LSSerializer was unable to serialize the node.
+     *
+     */
+    public boolean writeToURI(Node nodeArg, String uri) throws LSException {
+        // If nodeArg is null, return false.  Should we throw and LSException instead?
+        if (nodeArg == null ) {
+            return false;
+        }
+
+        // Obtain a reference to the serializer to use
+        Serializer serializer = fXMLSerializer;
+        serializer.reset();
+
+        if (nodeArg != fVisitedNode) {
+            // Determine the XML Document version of the Node
+            String xmlVersion = getXMLVersion(nodeArg);
+
+            // Determine the encoding: 1.LSOutput.encoding,
+            // 2.Document.inputEncoding, 3.Document.xmlEncoding.
+            fEncoding = getInputEncoding(nodeArg);
+            if (fEncoding == null ) {
+                fEncoding = fEncoding != null ? fEncoding : getXMLEncoding(nodeArg) == null? "UTF-8": getXMLEncoding(nodeArg);
+            }
+
+            serializer.getOutputFormat().setProperty("version", xmlVersion);
+
+            // Set the output encoding and xml version properties
+            fDOMConfigProperties.setProperty(DOMConstants.S_XERCES_PROPERTIES_NS + DOMConstants.S_XML_VERSION, xmlVersion);
+            fDOMConfigProperties.setProperty(DOMConstants.S_XSL_OUTPUT_ENCODING, fEncoding);
+
+            // If the node to be serialized is not a Document, Element, or Entity
+            // node
+            // then the XML declaration, or text declaration, should be never be
+            // serialized.
+            if ( (nodeArg.getNodeType() != Node.DOCUMENT_NODE
+                    || nodeArg.getNodeType() != Node.ELEMENT_NODE
+                    || nodeArg.getNodeType() != Node.ENTITY_NODE)
+                    && ((fFeatures & XMLDECL) != 0))  {
+                fDOMConfigProperties.setProperty(
+                        DOMConstants.S_XSL_OUTPUT_OMIT_XML_DECL,
+                        DOMConstants.DOM3_DEFAULT_FALSE);
+            }
+
+            fVisitedNode = nodeArg;
+        }
+
+        // Update the serializer properties
+        fXMLSerializer.setOutputFormat(fDOMConfigProperties);
+
+        //
+        try {
+            // If the specified encoding is not supported an
+            // "unsupported-encoding" fatal error is raised. ??
+            if (uri == null) {
+                String msg = Utils.messages.createMessage(
+                        MsgKey.ER_NO_OUTPUT_SPECIFIED, null);
+                if (fDOMErrorHandler != null) {
+                    fDOMErrorHandler.handleError(new DOMErrorImpl(
+                            DOMError.SEVERITY_FATAL_ERROR, msg,
+                            MsgKey.ER_NO_OUTPUT_SPECIFIED));
+                }
+                throw new LSException(LSException.SERIALIZE_ERR, msg);
+
+            } else {
+                // REVISIT: Can this be used to get an absolute expanded URI
+                String absoluteURI = SystemIDResolver.getAbsoluteURI(uri);
+
+                URL url = new URL(absoluteURI);
+                OutputStream urlOutStream = null;
+                String protocol = url.getProtocol();
+                String host = url.getHost();
+
+                // For file protocols, there is no need to use a URL to get its
+                // corresponding OutputStream
+
+                // Scheme names consist of a sequence of characters. The lower
+                // case letters "a"--"z", digits, and the characters plus ("+"),
+                // period ("."), and hyphen ("-") are allowed. For resiliency,
+                // programs interpreting URLs should treat upper case letters as
+                // equivalent to lower case in scheme names
+                // (e.g., allow "HTTP" as well as "http").
+                if (protocol.equalsIgnoreCase("file")
+                        && (host == null || host.length() == 0 || host
+                                .equals("localhost"))) {
+                    // do we also need to check for host.equals(hostname)
+                    urlOutStream = new FileOutputStream(new File(url.getPath()));
+
+                } else {
+                    // This should support URL's whose schemes are mentioned in
+                    // RFC1738 other than file
+
+                    URLConnection urlCon = url.openConnection();
+                    urlCon.setDoInput(false);
+                    urlCon.setDoOutput(true);
+                    urlCon.setUseCaches(false);
+                    urlCon.setAllowUserInteraction(false);
+
+                    // When writing to a HTTP URI, a HTTP PUT is performed.
+                    if (urlCon instanceof HttpURLConnection) {
+                        HttpURLConnection httpCon = (HttpURLConnection) urlCon;
+                        httpCon.setRequestMethod("PUT");
+                    }
+                    urlOutStream = urlCon.getOutputStream();
+                }
+                // set the OutputStream to that obtained from the systemId
+                serializer.setWriter(new OutputStreamWriter(urlOutStream, fEncoding));
+            }
+
+            // Get a reference to the serializer then lets you serilize a DOM
+            // Use this hack till Xalan support JAXP1.3
+            if (fDOMSerializer == null) {
+                fDOMSerializer = (DOM3Serializer)serializer.asDOM3Serializer();
+            }
+
+            // Set the error handler on the DOM3Serializer interface implementation
+            if (fDOMErrorHandler != null) {
+                fDOMSerializer.setErrorHandler(fDOMErrorHandler);
+            }
+
+            // Set the filter on the DOM3Serializer interface implementation
+            if (fSerializerFilter != null) {
+                fDOMSerializer.setNodeFilter(fSerializerFilter);
+            }
+
+            // Set the NewLine character to be used
+            fDOMSerializer.setNewLine(fEndOfLine);
+
+            // Serializer your DOM, where node is an org.w3c.dom.Node
+            // Assuming that Xalan's serializer can serialize any type of DOM
+            // node
+            fDOMSerializer.serializeDOM3(nodeArg);
+
+        } catch (LSException lse) {
+            // Rethrow LSException.
+            throw lse;
+        } catch (RuntimeException e) {
+            e.printStackTrace();
+            throw new LSException(LSException.SERIALIZE_ERR, e.toString());
+        }  catch (Exception e) {
+            if (fDOMErrorHandler != null) {
+                fDOMErrorHandler.handleError(new DOMErrorImpl(
+                        DOMError.SEVERITY_FATAL_ERROR, e.getMessage(),
+                        null, e));
+            }
+            e.printStackTrace();
+            throw new LSException(LSException.SERIALIZE_ERR, e.toString());
+        }
+
+        return true;
+    }
+    // ************************************************************************
+
+
+    // ************************************************************************
+    // Implementaion methods
+    // ************************************************************************
+
+    /**
+     * Determines the XML Version of the Document Node to serialize.  If the Document Node
+     * is not a DOM Level 3 Node, then the default version returned is 1.0.
+     *
+     * @param  nodeArg The Node to serialize
+     * @return A String containing the version pseudo-attribute of the XMLDecl.
+     * @throws Throwable if the DOM implementation does not implement Document.getXmlVersion()
+     */
+    //protected String getXMLVersion(Node nodeArg) throws Throwable {
+    protected String getXMLVersion(Node nodeArg) {
+        Document doc = null;
+
+        // Determine the XML Version of the document
+        if (nodeArg != null) {
+            if (nodeArg.getNodeType() == Node.DOCUMENT_NODE) {
+                // The Document node is the Node argument
+                doc = (Document)nodeArg;
+            } else {
+                // The Document node is the Node argument's ownerDocument
+                doc = nodeArg.getOwnerDocument();
+            }
+
+            // Determine the DOM Version.
+            if (doc != null && doc.getImplementation().hasFeature("Core","3.0")) {
+                try {
+                    return doc.getXmlVersion();
+                } catch (AbstractMethodError e) {
+                    //ignore, impl does not support the method
+                }
+            }
+        }
+        // The version will be treated as "1.0" which may result in
+        // an ill-formed document being serialized.
+        // If nodeArg does not have an ownerDocument, treat this as XML 1.0
+        return "1.0";
+    }
+
+    /**
+     * Determines the XML Encoding of the Document Node to serialize.  If the Document Node
+     * is not a DOM Level 3 Node, then the default encoding "UTF-8" is returned.
+     *
+     * @param  nodeArg The Node to serialize
+     * @return A String containing the encoding pseudo-attribute of the XMLDecl.
+     * @throws Throwable if the DOM implementation does not implement Document.getXmlEncoding()
+     */
+    protected String getXMLEncoding(Node nodeArg) {
+        Document doc = null;
+
+        // Determine the XML Encoding of the document
+        if (nodeArg != null) {
+            if (nodeArg.getNodeType() == Node.DOCUMENT_NODE) {
+                // The Document node is the Node argument
+                doc = (Document)nodeArg;
+            } else {
+                // The Document node is the Node argument's ownerDocument
+                doc = nodeArg.getOwnerDocument();
+            }
+
+            // Determine the XML Version.
+            if (doc != null && doc.getImplementation().hasFeature("Core","3.0")) {
+                return doc.getXmlEncoding();
+            }
+        }
+        // The default encoding is UTF-8 except for the writeToString method
+        return "UTF-8";
+    }
+
+    /**
+     * Determines the Input Encoding of the Document Node to serialize.  If the Document Node
+     * is not a DOM Level 3 Node, then null is returned.
+     *
+     * @param  nodeArg The Node to serialize
+     * @return A String containing the input encoding.
+     */
+    protected String getInputEncoding(Node nodeArg)  {
+        Document doc = null;
+
+        // Determine the Input Encoding of the document
+        if (nodeArg != null) {
+            if (nodeArg.getNodeType() == Node.DOCUMENT_NODE) {
+                // The Document node is the Node argument
+                doc = (Document)nodeArg;
+            } else {
+                // The Document node is the Node argument's ownerDocument
+                doc = nodeArg.getOwnerDocument();
+            }
+
+            // Determine the DOM Version.
+            if (doc != null && doc.getImplementation().hasFeature("Core","3.0")) {
+                return doc.getInputEncoding();
+            }
+        }
+        // The default encoding returned is null
+        return null;
+    }
+
+    /**
+     * This method returns the LSSerializer's error handler.
+     *
+     * @return Returns the fDOMErrorHandler.
+     */
+    public DOMErrorHandler getErrorHandler() {
+        return fDOMErrorHandler;
+    }
+
+}

--- a/jaxp/src/com/sun/org/apache/xml/internal/serializer/dom3/NamespaceSupport.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serializer/dom3/NamespaceSupport.java
@@ -1,0 +1,315 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the  "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * $Id:  $
+ */
+
+package com.sun.org.apache.xml.internal.serializer.dom3;
+
+import java.util.Enumeration;
+import java.util.NoSuchElementException;
+
+/**
+ * Namespace support for XML document handlers. This class doesn't
+ * perform any error checking and assumes that all strings passed
+ * as arguments to methods are unique symbols. The SymbolTable class
+ * can be used for this purpose.
+ *
+ * Derived from org.apache.xerces.util.NamespaceSupport
+ *
+ * @author Andy Clark, IBM
+ *
+ * @version $Id: Exp $
+ */
+public class NamespaceSupport {
+
+        static final String PREFIX_XML = "xml".intern();
+
+        static final String PREFIX_XMLNS = "xmlns".intern();
+
+    /**
+     * The XML Namespace ("http://www.w3.org/XML/1998/namespace"). This is
+     * the Namespace URI that is automatically mapped to the "xml" prefix.
+     */
+    public final static String XML_URI = "http://www.w3.org/XML/1998/namespace".intern();
+
+    /**
+     * XML Information Set REC
+     * all namespace attributes (including those named xmlns,
+     * whose [prefix] property has no value) have a namespace URI of http://www.w3.org/2000/xmlns/
+     */
+    public final static String XMLNS_URI = "http://www.w3.org/2000/xmlns/".intern();
+
+        //
+    // Data
+    //
+
+    /**
+     * Namespace binding information. This array is composed of a
+     * series of tuples containing the namespace binding information:
+     * &lt;prefix, uri&gt;. The default size can be set to anything
+     * as long as it is a power of 2 greater than 1.
+     *
+     * @see #fNamespaceSize
+     * @see #fContext
+     */
+    protected String[] fNamespace = new String[16 * 2];
+
+    /** The top of the namespace information array. */
+    protected int fNamespaceSize;
+
+    // NOTE: The constructor depends on the initial context size
+    //       being at least 1. -Ac
+
+    /**
+     * Context indexes. This array contains indexes into the namespace
+     * information array. The index at the current context is the start
+     * index of declared namespace bindings and runs to the size of the
+     * namespace information array.
+     *
+     * @see #fNamespaceSize
+     */
+    protected int[] fContext = new int[8];
+
+    /** The current context. */
+    protected int fCurrentContext;
+
+    protected String[] fPrefixes = new String[16];
+
+    //
+    // Constructors
+    //
+
+    /** Default constructor. */
+    public NamespaceSupport() {
+    } // <init>()
+
+    //
+    // Public methods
+    //
+
+        /**
+         * @see org.apache.xerces.xni.NamespaceContext#reset()
+         */
+    public void reset() {
+
+        // reset namespace and context info
+        fNamespaceSize = 0;
+        fCurrentContext = 0;
+        fContext[fCurrentContext] = fNamespaceSize;
+
+        // bind "xml" prefix to the XML uri
+        fNamespace[fNamespaceSize++] = PREFIX_XML;
+        fNamespace[fNamespaceSize++] = XML_URI;
+        // bind "xmlns" prefix to the XMLNS uri
+        fNamespace[fNamespaceSize++] = PREFIX_XMLNS;
+        fNamespace[fNamespaceSize++] = XMLNS_URI;
+        ++fCurrentContext;
+
+    } // reset(SymbolTable)
+
+
+        /**
+         * @see org.apache.xerces.xni.NamespaceContext#pushContext()
+         */
+    public void pushContext() {
+
+        // extend the array, if necessary
+        if (fCurrentContext + 1 == fContext.length) {
+            int[] contextarray = new int[fContext.length * 2];
+            System.arraycopy(fContext, 0, contextarray, 0, fContext.length);
+            fContext = contextarray;
+        }
+
+        // push context
+        fContext[++fCurrentContext] = fNamespaceSize;
+
+    } // pushContext()
+
+
+        /**
+         * @see org.apache.xerces.xni.NamespaceContext#popContext()
+         */
+    public void popContext() {
+        fNamespaceSize = fContext[fCurrentContext--];
+    } // popContext()
+
+        /**
+         * @see org.apache.xerces.xni.NamespaceContext#declarePrefix(String, String)
+         */
+    public boolean declarePrefix(String prefix, String uri) {
+        // ignore "xml" and "xmlns" prefixes
+        if (prefix == PREFIX_XML || prefix == PREFIX_XMLNS) {
+            return false;
+        }
+
+        // see if prefix already exists in current context
+        for (int i = fNamespaceSize; i > fContext[fCurrentContext]; i -= 2) {
+            //if (fNamespace[i - 2] == prefix) {
+                if (fNamespace[i - 2].equals(prefix) )  {
+                // REVISIT: [Q] Should the new binding override the
+                //          previously declared binding or should it
+                //          it be ignored? -Ac
+                // NOTE:    The SAX2 "NamespaceSupport" helper allows
+                //          re-bindings with the new binding overwriting
+                //          the previous binding. -Ac
+                fNamespace[i - 1] = uri;
+                return true;
+            }
+        }
+
+        // resize array, if needed
+        if (fNamespaceSize == fNamespace.length) {
+            String[] namespacearray = new String[fNamespaceSize * 2];
+            System.arraycopy(fNamespace, 0, namespacearray, 0, fNamespaceSize);
+            fNamespace = namespacearray;
+        }
+
+        // bind prefix to uri in current context
+        fNamespace[fNamespaceSize++] = prefix;
+        fNamespace[fNamespaceSize++] = uri;
+
+        return true;
+
+    } // declarePrefix(String,String):boolean
+
+        /**
+         * @see org.apache.xerces.xni.NamespaceContext#getURI(String)
+         */
+    public String getURI(String prefix) {
+
+        // find prefix in current context
+        for (int i = fNamespaceSize; i > 0; i -= 2) {
+            //if (fNamespace[i - 2] == prefix) {
+                if (fNamespace[i - 2].equals(prefix) ) {
+                return fNamespace[i - 1];
+            }
+        }
+
+        // prefix not found
+        return null;
+
+    } // getURI(String):String
+
+
+        /**
+         * @see org.apache.xerces.xni.NamespaceContext#getPrefix(String)
+         */
+    public String getPrefix(String uri) {
+
+        // find uri in current context
+        for (int i = fNamespaceSize; i > 0; i -= 2) {
+            //if (fNamespace[i - 1] == uri) {
+                if (fNamespace[i - 1].equals(uri) ) {
+                //if (getURI(fNamespace[i - 2]) == uri)
+                        if (getURI(fNamespace[i - 2]).equals(uri) )
+                    return fNamespace[i - 2];
+            }
+        }
+
+        // uri not found
+        return null;
+
+    } // getPrefix(String):String
+
+
+        /**
+         * @see org.apache.xerces.xni.NamespaceContext#getDeclaredPrefixCount()
+         */
+    public int getDeclaredPrefixCount() {
+        return (fNamespaceSize - fContext[fCurrentContext]) / 2;
+    } // getDeclaredPrefixCount():int
+
+        /**
+         * @see org.apache.xerces.xni.NamespaceContext#getDeclaredPrefixAt(int)
+         */
+    public String getDeclaredPrefixAt(int index) {
+        return fNamespace[fContext[fCurrentContext] + index * 2];
+    } // getDeclaredPrefixAt(int):String
+
+        /**
+         * @see org.apache.xerces.xni.NamespaceContext#getAllPrefixes()
+         */
+        public Enumeration getAllPrefixes() {
+        int count = 0;
+        if (fPrefixes.length < (fNamespace.length/2)) {
+            // resize prefix array
+            String[] prefixes = new String[fNamespaceSize];
+            fPrefixes = prefixes;
+        }
+        String prefix = null;
+        boolean unique = true;
+        for (int i = 2; i < (fNamespaceSize-2); i += 2) {
+            prefix = fNamespace[i + 2];
+            for (int k=0;k<count;k++){
+                if (fPrefixes[k]==prefix){
+                    unique = false;
+                    break;
+                }
+            }
+            if (unique){
+                fPrefixes[count++] = prefix;
+            }
+            unique = true;
+        }
+                return new Prefixes(fPrefixes, count);
+        }
+
+    protected final class Prefixes implements Enumeration {
+        private String[] prefixes;
+        private int counter = 0;
+        private int size = 0;
+
+                /**
+                 * Constructor for Prefixes.
+                 */
+                public Prefixes(String [] prefixes, int size) {
+                        this.prefixes = prefixes;
+            this.size = size;
+                }
+
+       /**
+                 * @see java.util.Enumeration#hasMoreElements()
+                 */
+                public boolean hasMoreElements() {
+                        return (counter< size);
+                }
+
+                /**
+                 * @see java.util.Enumeration#nextElement()
+                 */
+                public Object nextElement() {
+            if (counter< size){
+                return fPrefixes[counter++];
+            }
+                        throw new NoSuchElementException("Illegal access to Namespace prefixes enumeration.");
+                }
+
+        public String toString(){
+            StringBuffer buf = new StringBuffer();
+            for (int i=0;i<size;i++){
+                buf.append(prefixes[i]);
+                buf.append(" ");
+            }
+
+            return buf.toString();
+        }
+
+}
+
+} // class NamespaceSupport

--- a/jaxp/src/com/sun/org/apache/xml/internal/serializer/utils/MsgKey.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serializer/utils/MsgKey.java
@@ -3,9 +3,11 @@
  * DO NOT REMOVE OR ALTER!
  */
 /*
- * Copyright 2004 The Apache Software Foundation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the  "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -98,5 +100,37 @@ public class MsgKey {
     public static final String ER_XML_VERSION_NOT_SUPPORTED = "ER_XML_VERSION_NOT_SUPPORTED";
     public static final String ER_FACTORY_PROPERTY_MISSING = "ER_FACTORY_PROPERTY_MISSING";
     public static final String ER_ENCODING_NOT_SUPPORTED = "ER_ENCODING_NOT_SUPPORTED";
+
+    // DOM Exceptions
+    public static final String ER_FEATURE_NOT_FOUND = "FEATURE_NOT_FOUND";
+    public static final String ER_FEATURE_NOT_SUPPORTED = "FEATURE_NOT_SUPPORTED";
+    public static final String ER_STRING_TOO_LONG = "DOMSTRING_SIZE_ERR";
+    public static final String ER_TYPE_MISMATCH_ERR = "TYPE_MISMATCH_ERR";
+
+    // DOM Level 3 load and save messages
+    public static final String ER_NO_OUTPUT_SPECIFIED = "no-output-specified";
+    public static final String ER_UNSUPPORTED_ENCODING = "unsupported-encoding";
+    public static final String ER_ELEM_UNBOUND_PREFIX_IN_ENTREF = "unbound-prefix-in-entity-reference";
+    public static final String ER_ATTR_UNBOUND_PREFIX_IN_ENTREF = "unbound-prefix-in-entity-reference";
+    public static final String ER_CDATA_SECTIONS_SPLIT = "cdata-sections-splitted";
+    public static final String ER_WF_INVALID_CHARACTER = "wf-invalid-character";
+    public static final String ER_WF_INVALID_CHARACTER_IN_NODE_NAME = "wf-invalid-character-in-node-name";
+
+    // DOM Level 3 Implementation specific Exceptions
+    public static final String ER_UNABLE_TO_SERIALIZE_NODE = "ER_UNABLE_TO_SERIALIZE_NODE";
+    public static final String ER_WARNING_WF_NOT_CHECKED = "ER_WARNING_WF_NOT_CHECKED";
+
+    public static final String ER_WF_INVALID_CHARACTER_IN_COMMENT = "ER_WF_INVALID_CHARACTER_IN_COMMENT";
+    public static final String ER_WF_INVALID_CHARACTER_IN_PI = "ER_WF_INVALID_CHARACTER_IN_PI";
+    public static final String ER_WF_INVALID_CHARACTER_IN_CDATA = "ER_WF_INVALID_CHARACTER_IN_CDATA";
+    public static final String ER_WF_INVALID_CHARACTER_IN_TEXT = "ER_WF_INVALID_CHARACTER_IN_TEXT";
+    public static final String ER_WF_DASH_IN_COMMENT = "ER_WF_DASH_IN_COMMENT";
+    public static final String ER_WF_LT_IN_ATTVAL = "ER_WF_LT_IN_ATTVAL";
+    public static final String ER_WF_REF_TO_UNPARSED_ENT = "ER_WF_REF_TO_UNPARSED_ENT";
+    public static final String ER_WF_REF_TO_EXTERNAL_ENT =  "ER_WF_REF_TO_EXTERNAL_ENT";
+    public static final String ER_NS_PREFIX_CANNOT_BE_BOUND =  "ER_NS_PREFIX_CANNOT_BE_BOUND";
+    public static final String ER_NULL_LOCAL_ELEMENT_NAME = "ER_NULL_LOCAL_ELEMENT_NAME";
+    public static final String ER_NULL_LOCAL_ATTR_NAME = "ER_NULL_LOCAL_ATTR_NAME";
+    public static final String ER_WRITING_INTERNAL_SUBSET = "ER_WRITING_INTERNAL_SUBSET";
 
 }

--- a/jaxp/src/com/sun/org/apache/xml/internal/serializer/utils/SerializerMessages.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serializer/utils/SerializerMessages.java
@@ -3,9 +3,11 @@
  * DO NOT REMOVE OR ALTER!
  */
 /*
- * Copyright 2004 The Apache Software Foundation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the  "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -197,6 +199,97 @@ public class SerializerMessages extends ListResourceBundle {
             {   MsgKey.ER_ENCODING_NOT_SUPPORTED,
                 "Warning:  The encoding ''{0}'' is not supported by the Java runtime." },
 
+             {MsgKey.ER_FEATURE_NOT_FOUND,
+             "The parameter ''{0}'' is not recognized."},
+
+             {MsgKey.ER_FEATURE_NOT_SUPPORTED,
+             "The parameter ''{0}'' is recognized but the requested value cannot be set."},
+
+             {MsgKey.ER_STRING_TOO_LONG,
+             "The resulting string is too long to fit in a DOMString: ''{0}''."},
+
+             {MsgKey.ER_TYPE_MISMATCH_ERR,
+             "The value type for this parameter name is incompatible with the expected value type."},
+
+             {MsgKey.ER_NO_OUTPUT_SPECIFIED,
+             "The output destination for data to be written to was null."},
+
+             {MsgKey.ER_UNSUPPORTED_ENCODING,
+             "An unsupported encoding is encountered."},
+
+             {MsgKey.ER_UNABLE_TO_SERIALIZE_NODE,
+             "The node could not be serialized."},
+
+             {MsgKey.ER_CDATA_SECTIONS_SPLIT,
+             "The CDATA Section contains one or more termination markers ']]>'."},
+
+             {MsgKey.ER_WARNING_WF_NOT_CHECKED,
+                 "An instance of the Well-Formedness checker could not be created.  The well-formed parameter was set to true but well-formedness checking can not be performed."
+             },
+
+             {MsgKey.ER_WF_INVALID_CHARACTER,
+                 "The node ''{0}'' contains invalid XML characters."
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_COMMENT,
+                 "An invalid XML character (Unicode: 0x{0}) was found in the comment."
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_PI,
+                 "An invalid XML character (Unicode: 0x{0}) was found in the processing instructiondata."
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_CDATA,
+                 "An invalid XML character (Unicode: 0x{0}) was found in the contents of the CDATASection."
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_TEXT,
+                 "An invalid XML character (Unicode: 0x{0}) was found in the node''s character data content."
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_NODE_NAME,
+                 "An invalid XML character(s) was found in the {0} node named ''{1}''."
+             },
+
+             { MsgKey.ER_WF_DASH_IN_COMMENT,
+                 "The string \"--\" is not permitted within comments."
+             },
+
+             {MsgKey.ER_WF_LT_IN_ATTVAL,
+                 "The value of attribute \"{1}\" associated with an element type \"{0}\" must not contain the ''<'' character."
+             },
+
+             {MsgKey.ER_WF_REF_TO_UNPARSED_ENT,
+                 "The unparsed entity reference \"&{0};\" is not permitted."
+             },
+
+             {MsgKey.ER_WF_REF_TO_EXTERNAL_ENT,
+                 "The external entity reference \"&{0};\" is not permitted in an attribute value."
+             },
+
+             {MsgKey.ER_NS_PREFIX_CANNOT_BE_BOUND,
+                 "The prefix \"{0}\" can not be bound to namespace \"{1}\"."
+             },
+
+             {MsgKey.ER_NULL_LOCAL_ELEMENT_NAME,
+                 "The local name of element \"{0}\" is null."
+             },
+
+             {MsgKey.ER_NULL_LOCAL_ATTR_NAME,
+                 "The local name of attr \"{0}\" is null."
+             },
+
+             { MsgKey.ER_ELEM_UNBOUND_PREFIX_IN_ENTREF,
+                 "The replacement text of the entity node \"{0}\" contains an element node \"{1}\" with an unbound prefix \"{2}\"."
+             },
+
+             { MsgKey.ER_ATTR_UNBOUND_PREFIX_IN_ENTREF,
+                 "The replacement text of the entity node \"{0}\" contains an attribute node \"{1}\" with an unbound prefix \"{2}\"."
+             },
+
+             { MsgKey.ER_WRITING_INTERNAL_SUBSET,
+                 "An error occured while writing the internal subset."
+             },
 
         };
 

--- a/jaxp/src/com/sun/org/apache/xml/internal/serializer/utils/SerializerMessages_ca.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serializer/utils/SerializerMessages_ca.java
@@ -3,9 +3,11 @@
  * DO NOT REMOVE OR ALTER!
  */
 /*
- * Copyright 1999-2004 The Apache Software Foundation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the  "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -122,7 +124,106 @@ public class SerializerMessages_ca extends ListResourceBundle {
         "Userinfo may not be specified if host is not specified"},
 
       { MsgKey.ER_SCHEME_REQUIRED,
-        "Scheme is required!"}
+        "Scheme is required!"},
+
+      /*
+       * Note to translators:  The words 'Properties' and
+       * 'SerializerFactory' in this message are Java class names
+       * and should not be translated.
+       */
+      {   MsgKey.ER_FACTORY_PROPERTY_MISSING,
+          "L''objecte de propietats passat a SerializerFactory no t\u00e9 cap propietat ''{0}''." },
+
+      {   MsgKey.ER_ENCODING_NOT_SUPPORTED,
+          "Av\u00eds: el temps d''execuci\u00f3 de Java no d\u00f3na suport a la codificaci\u00f3 ''{0}''." },
+
+       {MsgKey.ER_FEATURE_NOT_FOUND,
+       "El par\u00e0metre ''{0}'' no es reconeix."},
+
+       {MsgKey.ER_FEATURE_NOT_SUPPORTED,
+       "El par\u00e0metre ''{0}'' es reconeix per\u00f2 el valor sol\u00b7licitat no es pot establir."},
+
+       {MsgKey.ER_STRING_TOO_LONG,
+       "La cadena resultant \u00e9s massa llarga per cabre en una DOMString: ''{0}''."},
+
+       {MsgKey.ER_TYPE_MISMATCH_ERR,
+       "El tipus de valor per a aquest nom de par\u00e0metre \u00e9s incompatible amb el tipus de valor esperat."},
+
+       {MsgKey.ER_NO_OUTPUT_SPECIFIED,
+       "La destinaci\u00f3 de sortida per a les dades que s'ha d'escriure era nul\u00b7la."},
+
+       {MsgKey.ER_UNSUPPORTED_ENCODING,
+       "S'ha trobat una codificaci\u00f3 no suportada."},
+
+       {MsgKey.ER_UNABLE_TO_SERIALIZE_NODE,
+       "El node no s'ha pogut serialitzat."},
+
+       {MsgKey.ER_CDATA_SECTIONS_SPLIT,
+       "La secci\u00f3 CDATA cont\u00e9 un o m\u00e9s marcadors d'acabament ']]>'."},
+
+       {MsgKey.ER_WARNING_WF_NOT_CHECKED,
+           "No s'ha pogut crear cap inst\u00e0ncia per comprovar si t\u00e9 un format correcte o no. El par\u00e0metre del tipus ben format es va establir en cert, per\u00f2 la comprovaci\u00f3 de format no s'ha pogut realitzar."
+       },
+
+       {MsgKey.ER_WF_INVALID_CHARACTER,
+           "El node ''{0}'' cont\u00e9 car\u00e0cters XML no v\u00e0lids."
+       },
+
+       { MsgKey.ER_WF_INVALID_CHARACTER_IN_COMMENT,
+           "S''ha trobat un car\u00e0cter XML no v\u00e0lid (Unicode: 0x{0}) en el comentari."
+       },
+
+       { MsgKey.ER_WF_INVALID_CHARACTER_IN_PI,
+           "S''ha trobat un car\u00e0cter XML no v\u00e0lid (Unicode: 0x{0}) en les dades d''instrucci\u00f3 de proc\u00e9s."
+       },
+
+       { MsgKey.ER_WF_INVALID_CHARACTER_IN_CDATA,
+           "S''ha trobat un car\u00e0cter XML no v\u00e0lid (Unicode: 0x''{0})'' en els continguts de la CDATASection."
+       },
+
+       { MsgKey.ER_WF_INVALID_CHARACTER_IN_TEXT,
+           "S''ha trobat un car\u00e0cter XML no v\u00e0lid (Unicode: 0x''{0})'' en el contingut de dades de car\u00e0cter del node."
+       },
+
+       { MsgKey.ER_WF_INVALID_CHARACTER_IN_NODE_NAME,
+           "S''han trobat car\u00e0cters XML no v\u00e0lids al node {0} anomenat ''{1}''."
+       },
+
+       { MsgKey.ER_WF_DASH_IN_COMMENT,
+           "La cadena \"--\" no est\u00e0 permesa dins dels comentaris."
+       },
+
+       {MsgKey.ER_WF_LT_IN_ATTVAL,
+           "El valor d''atribut \"{1}\" associat amb un tipus d''element \"{0}\" no pot contenir el car\u00e0cter ''<''."
+       },
+
+       {MsgKey.ER_WF_REF_TO_UNPARSED_ENT,
+           "La refer\u00e8ncia de l''entitat no analitzada \"&{0};\" no est\u00e0 permesa."
+       },
+
+       {MsgKey.ER_WF_REF_TO_EXTERNAL_ENT,
+           "La refer\u00e8ncia externa de l''entitat \"&{0};\" no est\u00e0 permesa en un valor d''atribut."
+       },
+
+       {MsgKey.ER_NS_PREFIX_CANNOT_BE_BOUND,
+           "El prefix \"{0}\" no es pot vincular a l''espai de noms \"{1}\"."
+       },
+
+       {MsgKey.ER_NULL_LOCAL_ELEMENT_NAME,
+           "El nom local de l''element \"{0}\" \u00e9s nul."
+       },
+
+       {MsgKey.ER_NULL_LOCAL_ATTR_NAME,
+           "El nom local d''atr \"{0}\" \u00e9s nul."
+       },
+
+       { MsgKey.ER_ELEM_UNBOUND_PREFIX_IN_ENTREF,
+           "El text de recanvi del node de l''entitat \"{0}\" cont\u00e9 un node d''element \"{1}\" amb un prefix de no enlla\u00e7at \"{2}\"."
+       },
+
+       { MsgKey.ER_ATTR_UNBOUND_PREFIX_IN_ENTREF,
+           "El text de recanvi del node de l''entitat \"{0}\" cont\u00e9 un node d''atribut \"{1}\" amb un prefix de no enlla\u00e7at \"{2}\"."
+       },
 
     };
     return contents;

--- a/jaxp/src/com/sun/org/apache/xml/internal/serializer/utils/SerializerMessages_cs.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serializer/utils/SerializerMessages_cs.java
@@ -3,9 +3,11 @@
  * DO NOT REMOVE OR ALTER!
  */
 /*
- * Copyright 1999-2004 The Apache Software Foundation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the  "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -114,7 +116,106 @@ public class SerializerMessages_cs extends ListResourceBundle {
         "Nen\u00ed-li ur\u010den hostitel, nelze zadat \u00fadaje o u\u017eivateli."},
 
       { MsgKey.ER_SCHEME_REQUIRED,
-        "Je vy\u017eadov\u00e1no sch\u00e9ma!"}
+        "Je vy\u017eadov\u00e1no sch\u00e9ma!"},
+
+      /*
+       * Note to translators:  The words 'Properties' and
+       * 'SerializerFactory' in this message are Java class names
+       * and should not be translated.
+       */
+      {   MsgKey.ER_FACTORY_PROPERTY_MISSING,
+          "Objekt vlastnost\u00ed p\u0159edan\u00fd faktorii SerializerFactory neobsahuje vlastnost ''{0}''. " },
+
+      {   MsgKey.ER_ENCODING_NOT_SUPPORTED,
+          "Varov\u00e1n\u00ed: K\u00f3dov\u00e1n\u00ed ''{0}'' nen\u00ed v b\u011bhov\u00e9m prost\u0159ed\u00ed Java podporov\u00e1no." },
+
+       {MsgKey.ER_FEATURE_NOT_FOUND,
+       "Parametr ''{0}'' nebyl rozpozn\u00e1n."},
+
+       {MsgKey.ER_FEATURE_NOT_SUPPORTED,
+       "Parametr ''{0}'' byl rozpozn\u00e1n, ale nelze nastavit po\u017eadovanou hodnotu."},
+
+       {MsgKey.ER_STRING_TOO_LONG,
+       "V\u00fdsledn\u00fd \u0159et\u011bzec je p\u0159\u00edli\u0161 dlouh\u00fd pro \u0159et\u011bzec DOMString: ''{0}''."},
+
+       {MsgKey.ER_TYPE_MISMATCH_ERR,
+       "Typ hodnoty pro tento n\u00e1zev parametru nen\u00ed kompatibiln\u00ed s o\u010dek\u00e1van\u00fdm typem hodnoty."},
+
+       {MsgKey.ER_NO_OUTPUT_SPECIFIED,
+       "C\u00edlov\u00e9 um\u00edst\u011bn\u00ed v\u00fdstupu pro data ur\u010den\u00e1 k z\u00e1pisu je rovno hodnot\u011b Null. "},
+
+       {MsgKey.ER_UNSUPPORTED_ENCODING,
+       "Bylo nalezeno nepodporovan\u00e9 k\u00f3dov\u00e1n\u00ed."},
+
+       {MsgKey.ER_UNABLE_TO_SERIALIZE_NODE,
+       "Nelze prov\u00e9st serializaci uzlu. "},
+
+       {MsgKey.ER_CDATA_SECTIONS_SPLIT,
+       "Sekce CDATA obsahuje jednu nebo v\u00edce ukon\u010dovac\u00edch zna\u010dek ']]>'."},
+
+       {MsgKey.ER_WARNING_WF_NOT_CHECKED,
+           "Nelze vytvo\u0159it instanci modulu pro kontrolu spr\u00e1vn\u00e9ho utvo\u0159en\u00ed. Parametr spr\u00e1vn\u00e9ho utvo\u0159en\u00ed byl nastaven na hodnotu true, nepoda\u0159ilo se v\u0161ak zkontrolovat spr\u00e1vnost utvo\u0159en\u00ed. "
+       },
+
+       {MsgKey.ER_WF_INVALID_CHARACTER,
+           "Uzel ''{0}'' obsahuje neplatn\u00e9 znaky XML. "
+       },
+
+       { MsgKey.ER_WF_INVALID_CHARACTER_IN_COMMENT,
+           "V pozn\u00e1mce byl zji\u0161t\u011bn neplatn\u00fd znak XML (Unicode: 0x{0})."
+       },
+
+       { MsgKey.ER_WF_INVALID_CHARACTER_IN_PI,
+           "V datech instrukce zpracov\u00e1n\u00ed byl nalezen neplatn\u00fd znak XML (Unicode: 0x{0})."
+       },
+
+       { MsgKey.ER_WF_INVALID_CHARACTER_IN_CDATA,
+           "V odd\u00edlu CDATASection byl nalezen neplatn\u00fd znak XML (Unicode: 0x{0})."
+       },
+
+       { MsgKey.ER_WF_INVALID_CHARACTER_IN_TEXT,
+           "V obsahu znakov\u00fdch dat uzlu byl nalezen neplatn\u00fd znak XML (Unicode: 0x{0})."
+       },
+
+       { MsgKey.ER_WF_INVALID_CHARACTER_IN_NODE_NAME,
+           "V objektu {0} s n\u00e1zvem ''{1}'' byl nalezen neplatn\u00fd znak XML. "
+       },
+
+       { MsgKey.ER_WF_DASH_IN_COMMENT,
+           "V pozn\u00e1mk\u00e1ch nen\u00ed povolen \u0159et\u011bzec \"--\"."
+       },
+
+       {MsgKey.ER_WF_LT_IN_ATTVAL,
+           "Hodnota atributu \"{1}\" souvisej\u00edc\u00edho s typem prvku \"{0}\" nesm\u00ed obsahovat znak ''<''."
+       },
+
+       {MsgKey.ER_WF_REF_TO_UNPARSED_ENT,
+           "Odkaz na neanalyzovanou entitu \"&{0};\" nen\u00ed povolen."
+       },
+
+       {MsgKey.ER_WF_REF_TO_EXTERNAL_ENT,
+           "Extern\u00ed odkaz na entitu \"&{0};\" nen\u00ed v hodnot\u011b atributu povolen."
+       },
+
+       {MsgKey.ER_NS_PREFIX_CANNOT_BE_BOUND,
+           "P\u0159edpona \"{0}\" nesm\u00ed b\u00fdt v\u00e1zan\u00e1 k oboru n\u00e1zv\u016f \"{1}\"."
+       },
+
+       {MsgKey.ER_NULL_LOCAL_ELEMENT_NAME,
+           "Lok\u00e1ln\u00ed n\u00e1zev prvku \"{0}\" m\u00e1 hodnotu Null. "
+       },
+
+       {MsgKey.ER_NULL_LOCAL_ATTR_NAME,
+           "Lok\u00e1ln\u00ed n\u00e1zev atributu \"{0}\" m\u00e1 hodnotu Null. "
+       },
+
+       { MsgKey.ER_ELEM_UNBOUND_PREFIX_IN_ENTREF,
+           "Nov\u00fd text uzlu entity \"{0}\" obsahuje uzel prvku \"{1}\" s nesv\u00e1zanou p\u0159edponou \"{2}\"."
+       },
+
+       { MsgKey.ER_ATTR_UNBOUND_PREFIX_IN_ENTREF,
+           "Nov\u00fd text uzlu entity \"{0}\" obsahuje uzel atributu \"{1}\" s nesv\u00e1zanou p\u0159edponou \"{2}\". "
+       },
 
     };
     return contents;

--- a/jaxp/src/com/sun/org/apache/xml/internal/serializer/utils/SerializerMessages_de.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serializer/utils/SerializerMessages_de.java
@@ -3,9 +3,11 @@
  * DO NOT REMOVE OR ALTER!
  */
 /*
- * Copyright 2004 The Apache Software Foundation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the  "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -197,6 +199,93 @@ public class SerializerMessages_de extends ListResourceBundle {
             {   MsgKey.ER_ENCODING_NOT_SUPPORTED,
                 "Warnung: Die Codierung \"{0}\" wird nicht von der Java-Laufzeit unterst\u00FCtzt." },
 
+             {MsgKey.ER_FEATURE_NOT_FOUND,
+             "Der Parameter ''{0}'' wird nicht erkannt."},
+
+             {MsgKey.ER_FEATURE_NOT_SUPPORTED,
+             "Der Parameter ''{0}'' wird erkannt, der angeforderte Wert kann jedoch nicht festgelegt werden."},
+
+             {MsgKey.ER_STRING_TOO_LONG,
+             "Die Ergebniszeichenfolge ist zu lang f\u00fcr eine DOM-Zeichenfolge: ''{0}''."},
+
+             {MsgKey.ER_TYPE_MISMATCH_ERR,
+             "Der Werttyp f\u00fcr diesen Parameternamen ist nicht kompatibel mit dem erwarteten Werttyp."},
+
+             {MsgKey.ER_NO_OUTPUT_SPECIFIED,
+             "Das Ausgabeziel f\u00fcr die zu schreibenden Daten war leer."},
+
+             {MsgKey.ER_UNSUPPORTED_ENCODING,
+             "Eine nicht unterst\u00fctzte Codierung wurde festgestellt."},
+
+             {MsgKey.ER_UNABLE_TO_SERIALIZE_NODE,
+             "Der Knoten konnte nicht serialisiert werden."},
+
+             {MsgKey.ER_CDATA_SECTIONS_SPLIT,
+             "Der Abschnitt CDATA enth\u00e4lt mindestens eine Beendigungsmarkierung ']]>'."},
+
+             {MsgKey.ER_WARNING_WF_NOT_CHECKED,
+                 "Eine Instanz des Pr\u00fcfprogramms f\u00fcr korrekte Formatierung konnte nicht erstellt werden.  F\u00fcr den korrekt formatierten Parameter wurde der Wert 'True' festgelegt, die Pr\u00fcfung auf korrekte Formatierung kann jedoch nicht durchgef\u00fchrt werden."
+             },
+
+             {MsgKey.ER_WF_INVALID_CHARACTER,
+                 "Der Knoten ''{0}'' enth\u00e4lt ung\u00fcltige XML-Zeichen."
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_COMMENT,
+                 "Im Kommentar wurde ein ung\u00fcltiges XML-Zeichen (Unicode: 0x{0}) gefunden."
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_PI,
+                 "In der Verarbeitungsanweisung wurde ein ung\u00fcltiges XML-Zeichen (Unicode: 0x{0}) gefunden."
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_CDATA,
+                 "Im Inhalt von CDATASection wurde ein ung\u00fcltiges XML-Zeichen (Unicode: 0x{0}) gefunden."
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_TEXT,
+                 "Ein ung\u00fcltiges XML-Zeichen  (Unicode: 0x{0}) wurde im Inhalt der Zeichendaten des Knotens gefunden."
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_NODE_NAME,
+                 "Ung\u00fcltige XML-Zeichen wurden gefunden in {0} im Knoten ''{1}''."
+             },
+
+             { MsgKey.ER_WF_DASH_IN_COMMENT,
+                 "Die Zeichenfolge \"--\" ist innerhalb von Kommentaren nicht zul\u00e4ssig."
+             },
+
+             {MsgKey.ER_WF_LT_IN_ATTVAL,
+                 "Der Wert des Attributs \"{1}\" mit einem Elementtyp \"{0}\" darf nicht das Zeichen ''<'' enthalten."
+             },
+
+             {MsgKey.ER_WF_REF_TO_UNPARSED_ENT,
+                 "Der syntaktisch nicht analysierte Entit\u00e4tenverweis \"&{0};\" ist nicht zul\u00e4ssig."
+             },
+
+             {MsgKey.ER_WF_REF_TO_EXTERNAL_ENT,
+                 "Der externe Entit\u00e4tenverweis \"&{0};\" ist in einem Attributwert nicht zul\u00e4ssig."
+             },
+
+             {MsgKey.ER_NS_PREFIX_CANNOT_BE_BOUND,
+                 "Das Pr\u00e4fix \"{0}\" kann nicht an den Namensbereich \"{1}\" gebunden werden."
+             },
+
+             {MsgKey.ER_NULL_LOCAL_ELEMENT_NAME,
+                 "Der lokale Name von Element \"{0}\" ist nicht angegeben."
+             },
+
+             {MsgKey.ER_NULL_LOCAL_ATTR_NAME,
+                 "Der lokale Name des Attributs \"{0}\" ist nicht angegeben."
+             },
+
+             { MsgKey.ER_ELEM_UNBOUND_PREFIX_IN_ENTREF,
+                 "Der Ersatztext des Entit\u00e4tenknotens \"{0}\" enth\u00e4lt einen Elementknoten \"{1}\" mit einem nicht gebundenen Pr\u00e4fix \"{2}\"."
+             },
+
+             { MsgKey.ER_ATTR_UNBOUND_PREFIX_IN_ENTREF,
+                 "Der Ersatztext des Entit\u00e4tenknotens \"{0}\" enth\u00e4lt einen Attributknoten \"{1}\" mit einem nicht gebundenen Pr\u00e4fix \"{2}\"."
+             },
 
         };
 

--- a/jaxp/src/com/sun/org/apache/xml/internal/serializer/utils/SerializerMessages_es.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serializer/utils/SerializerMessages_es.java
@@ -3,9 +3,11 @@
  * DO NOT REMOVE OR ALTER!
  */
 /*
- * Copyright 2004 The Apache Software Foundation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the  "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -195,8 +197,95 @@ public class SerializerMessages_es extends ListResourceBundle {
                 "El objeto de propiedades transferido a SerializerFactory no tiene una propiedad ''{0}''." },
 
             {   MsgKey.ER_ENCODING_NOT_SUPPORTED,
-                "Advertencia: el tiempo de ejecuci\u00F3n de Java no soporta la codificaci\u00F3n ''{0}''." },
+                "Aviso: La codificaci\u00f3n ''{0}'' no est\u00e1 soportada por Java Runtime." },
 
+             {MsgKey.ER_FEATURE_NOT_FOUND,
+             "El par\u00e1metro ''{0}'' no se reconoce."},
+
+             {MsgKey.ER_FEATURE_NOT_SUPPORTED,
+             "Se reconoce el par\u00e1metro ''{0}'' pero no puede establecerse el valor solicitado."},
+
+             {MsgKey.ER_STRING_TOO_LONG,
+             "La serie producida es demasiado larga para ajustarse a DOMString: ''{0}''."},
+
+             {MsgKey.ER_TYPE_MISMATCH_ERR,
+             "El tipo de valor para este nombre de par\u00e1metro es incompatible con el tipo de valor esperado."},
+
+             {MsgKey.ER_NO_OUTPUT_SPECIFIED,
+             "El destino de salida de escritura de los datos es nulo."},
+
+             {MsgKey.ER_UNSUPPORTED_ENCODING,
+             "Se ha encontrado una codificaci\u00f3n no soportada."},
+
+             {MsgKey.ER_UNABLE_TO_SERIALIZE_NODE,
+             "No se ha podido serializar el nodo."},
+
+             {MsgKey.ER_CDATA_SECTIONS_SPLIT,
+             "La secci\u00f3n CDATA contiene uno o m\u00e1s marcadores ']]>' de terminaci\u00f3n."},
+
+             {MsgKey.ER_WARNING_WF_NOT_CHECKED,
+                 "No se ha podido crear una instancia del comprobador de gram\u00e1tica correcta.  El par\u00e1metro well-formed se ha establecido en true pero no se puede realizar la comprobaci\u00f3n de gram\u00e1tica correcta."
+             },
+
+             {MsgKey.ER_WF_INVALID_CHARACTER,
+                 "El nodo ''{0}'' contiene caracteres XML no v\u00e1lidos."
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_COMMENT,
+                 "Se ha encontrado un car\u00e1cter XML no v\u00e1lido (Unicode: 0x{0}) en el comentario."
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_PI,
+                 "Se ha encontrado un car\u00e1cter XML no v\u00e1lido (Unicode: 0x{0}) en los datos de la instrucci\u00f3n de proceso."
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_CDATA,
+                 "Se ha encontrado un car\u00e1cter XML no v\u00e1lido (Unicode: 0x{0}) en el contenido de CDATASection."
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_TEXT,
+                 "Se ha encontrado un car\u00e1cter XML no v\u00e1lido (Unicode: 0x{0}) en el contenido de datos de caracteres del nodo."
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_NODE_NAME,
+                 "Se ha encontrado un car\u00e1cter o caracteres XML no v\u00e1lidos en el nodo {0} denominado ''{1}''."
+             },
+
+             { MsgKey.ER_WF_DASH_IN_COMMENT,
+                 "No se permite la serie \"--\" dentro de los comentarios."
+             },
+
+             {MsgKey.ER_WF_LT_IN_ATTVAL,
+                 "El valor del atributo \"{1}\" asociado a un tipo de elemento \"{0}\" no debe contener el car\u00e1cter ''''<''''."
+             },
+
+             {MsgKey.ER_WF_REF_TO_UNPARSED_ENT,
+                 "No se permite la referencia de entidad no analizada \"&{0};\"."
+             },
+
+             {MsgKey.ER_WF_REF_TO_EXTERNAL_ENT,
+                 "La referencia de entidad externa \"&{0};\" no est\u00e1 permitida en un valor de atributo."
+             },
+
+             {MsgKey.ER_NS_PREFIX_CANNOT_BE_BOUND,
+                 "No se puede encontrar el prefijo \"{0}\" en el espacio de nombres \"{1}\"."
+             },
+
+             {MsgKey.ER_NULL_LOCAL_ELEMENT_NAME,
+                 "El nombre local del elemento \"{0}\" es null."
+             },
+
+             {MsgKey.ER_NULL_LOCAL_ATTR_NAME,
+                 "El nombre local del atributo \"{0}\" es null."
+             },
+
+             { MsgKey.ER_ELEM_UNBOUND_PREFIX_IN_ENTREF,
+                 "El texto de sustituci\u00f3n del nodo de entidad \"{0}\" contiene un nodo de elemento \"{1}\" con un prefijo no enlazado \"{2}\"."
+             },
+
+             { MsgKey.ER_ATTR_UNBOUND_PREFIX_IN_ENTREF,
+                 "El texto de sustituci\u00f3n del nodo de entidad \"{0}\" contiene un nodo de atributo \"{1}\" con un prefijo no enlazado \"{2}\"."
+             },
 
         };
 

--- a/jaxp/src/com/sun/org/apache/xml/internal/serializer/utils/SerializerMessages_fr.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serializer/utils/SerializerMessages_fr.java
@@ -3,9 +3,11 @@
  * DO NOT REMOVE OR ALTER!
  */
 /*
- * Copyright 2004 The Apache Software Foundation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the  "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -197,6 +199,93 @@ public class SerializerMessages_fr extends ListResourceBundle {
             {   MsgKey.ER_ENCODING_NOT_SUPPORTED,
                 "Avertissement : l''encodage ''{0}'' n''est pas pris en charge par l''ex\u00E9cution Java." },
 
+             {MsgKey.ER_FEATURE_NOT_FOUND,
+             "Le param\u00e8tre ''{0}'' n''est pas reconnu."},
+
+             {MsgKey.ER_FEATURE_NOT_SUPPORTED,
+             "Le param\u00e8tre ''{0}'' est reconnu mas la valeur demand\u00e9e ne peut pas \u00eatre d\u00e9finie."},
+
+             {MsgKey.ER_STRING_TOO_LONG,
+             "La cha\u00eene obtenue est trop longue pour un DOMString : ''{0}''."},
+
+             {MsgKey.ER_TYPE_MISMATCH_ERR,
+             "Le type de valeur de ce param\u00e8tre est incompatible avec le type de valeur attendu."},
+
+             {MsgKey.ER_NO_OUTPUT_SPECIFIED,
+             "La sortie de destination des donn\u00e9es \u00e0 \u00e9crire \u00e9tait vide."},
+
+             {MsgKey.ER_UNSUPPORTED_ENCODING,
+             "Codage non pris en charge."},
+
+             {MsgKey.ER_UNABLE_TO_SERIALIZE_NODE,
+             "Le noeud ne peut pas \u00eatre s\u00e9rialis\u00e9."},
+
+             {MsgKey.ER_CDATA_SECTIONS_SPLIT,
+             "La section CDATA contient un ou plusieurs marqueurs de fin ']]>'."},
+
+             {MsgKey.ER_WARNING_WF_NOT_CHECKED,
+                 "Aucune instance du programme de v\u00e9rification de la formation n'a pu \u00eatre cr\u00e9\u00e9e.  La valeur true a \u00e9t\u00e9 attribu\u00e9e au param\u00e8tre well-formed mais la v\u00e9rification de la formation n'a pas pu \u00eatre effectu\u00e9e."
+             },
+
+             {MsgKey.ER_WF_INVALID_CHARACTER,
+                 "Le noeud ''{0}'' contient des caract\u00e8res XML non valides."
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_COMMENT,
+                 "Un caract\u00e8re XML non valide (Unicode : 0x{0}) a \u00e9t\u00e9 trouv\u00e9 dans le commentaire."
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_PI,
+                 "Un caract\u00e8re XML non valide (Unicode : 0x{0}) a \u00e9t\u00e9 trouv\u00e9 dans les donn\u00e9es de l''instruction de traitement."
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_CDATA,
+                 "Un caract\u00e8re XML non valide (Unicode: 0x{0}) a \u00e9t\u00e9 trouv\u00e9 dans le contenu de la CDATASection"
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_TEXT,
+                 "Un caract\u00e8re XML non valide (Unicode : 0x{0}) a \u00e9t\u00e9 trouv\u00e9 dans le contenu des donn\u00e9es de type caract\u00e8res du noeud."
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_NODE_NAME,
+                 "Un ou plusieurs caract\u00e8res non valides ont \u00e9t\u00e9 trouv\u00e9s dans le noeud {0} nomm\u00e9 ''{1}''."
+             },
+
+             { MsgKey.ER_WF_DASH_IN_COMMENT,
+                 "La cha\u00eene \"--\" est interdite dans des commentaires."
+             },
+
+             {MsgKey.ER_WF_LT_IN_ATTVAL,
+                 "La valeur de l''attribut \"{1}\" associ\u00e9 \u00e0 un type d''\u00e9l\u00e9ment \"{0}\" ne doit pas contenir le caract\u00e8re ''<''."
+             },
+
+             {MsgKey.ER_WF_REF_TO_UNPARSED_ENT,
+                 "La r\u00e9f\u00e9rence d''entit\u00e9 non analys\u00e9e \"&{0};\" n''est pas admise."
+             },
+
+             {MsgKey.ER_WF_REF_TO_EXTERNAL_ENT,
+                 "La r\u00e9f\u00e9rence d''entit\u00e9 externe \"&{0};\" n''est pas admise dans une valeur d''attribut."
+             },
+
+             {MsgKey.ER_NS_PREFIX_CANNOT_BE_BOUND,
+                 "Le pr\u00e9fixe \"{0}\" ne peut pas \u00eatre li\u00e9 \u00e0 l''espace de noms \"{1}\"."
+             },
+
+             {MsgKey.ER_NULL_LOCAL_ELEMENT_NAME,
+                 "Le nom local de l''\u00e9l\u00e9ment \"{0}\" a une valeur null."
+             },
+
+             {MsgKey.ER_NULL_LOCAL_ATTR_NAME,
+                 "Le nom local de l''attribut \"{0}\" a une valeur null."
+             },
+
+             { MsgKey.ER_ELEM_UNBOUND_PREFIX_IN_ENTREF,
+                 "le texte de remplacement du noeud de l''entit\u00e9 \"{0}\" contaient un noeud d''\u00e9l\u00e9ment \"{1}\" avec un pr\u00e9fixe non li\u00e9 \"{2}\"."
+             },
+
+             { MsgKey.ER_ATTR_UNBOUND_PREFIX_IN_ENTREF,
+                 "Le texte de remplacement du noeud de l''entit\u00e9 \"{0}\" contient un noeud d''attribut \"{1}\" avec un pr\u00e9fixe non li\u00e9 \"{2}\"."
+             },
 
         };
 

--- a/jaxp/src/com/sun/org/apache/xml/internal/serializer/utils/SerializerMessages_it.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serializer/utils/SerializerMessages_it.java
@@ -3,9 +3,11 @@
  * DO NOT REMOVE OR ALTER!
  */
 /*
- * Copyright 2004 The Apache Software Foundation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the  "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -197,6 +199,93 @@ public class SerializerMessages_it extends ListResourceBundle {
             {   MsgKey.ER_ENCODING_NOT_SUPPORTED,
                 "Avvertenza: la codifica ''{0}'' non \u00E8 supportata da Java Runtime." },
 
+             {MsgKey.ER_FEATURE_NOT_FOUND,
+             "Il parametro ''{0}'' non \u00e8 riconosciuto."},
+
+             {MsgKey.ER_FEATURE_NOT_SUPPORTED,
+             "Il parametro ''{0}'' \u00e8 riconosciuto ma non \u00e8 possibile impostare il valore richiesto."},
+
+             {MsgKey.ER_STRING_TOO_LONG,
+             "La stringa risultante \u00e8 troppo lunga per essere inserita in DOMString: ''{0}''."},
+
+             {MsgKey.ER_TYPE_MISMATCH_ERR,
+             "Il tipo di valore per questo nome di parametro non \u00e8 compatibile con il tipo di valore previsto."},
+
+             {MsgKey.ER_NO_OUTPUT_SPECIFIED,
+             "La destinazione di output in cui scrivere i dati era nulla."},
+
+             {MsgKey.ER_UNSUPPORTED_ENCODING,
+             "\u00c8 stata rilevata una codifica non supportata."},
+
+             {MsgKey.ER_UNABLE_TO_SERIALIZE_NODE,
+             "Impossibile serializzare il nodo."},
+
+             {MsgKey.ER_CDATA_SECTIONS_SPLIT,
+             "La Sezione CDATA contiene uno o pi\u00f9 markers di termine ']]>'."},
+
+             {MsgKey.ER_WARNING_WF_NOT_CHECKED,
+                 "Impossibile creare un'istanza del controllore Well-Formedness.  Il parametro well-formed \u00e8 stato impostato su true ma non \u00e8 possibile eseguire i controlli well-formedness."
+             },
+
+             {MsgKey.ER_WF_INVALID_CHARACTER,
+                 "Il nodo ''{0}'' contiene caratteri XML non validi."
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_COMMENT,
+                 "Trovato un carattere XML non valido (Unicode: 0x{0}) nel commento."
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_PI,
+                 "Carattere XML non valido (Unicode: 0x{0}) rilevato nell''elaborazione di instructiondata."
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_CDATA,
+                 "Carattere XML non valido (Unicode: 0x{0}) rilevato nel contenuto di CDATASection."
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_TEXT,
+                 "Carattere XML non valido (Unicode: 0x{0}) rilevato nel contenuto dati di caratteri del nodo. "
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_NODE_NAME,
+                 "Carattere XML non valido rilevato nel nodo {0} denominato ''{1}''."
+             },
+
+             { MsgKey.ER_WF_DASH_IN_COMMENT,
+                 "La stringa \"--\" non \u00e8 consentita nei commenti."
+             },
+
+             {MsgKey.ER_WF_LT_IN_ATTVAL,
+                 "Il valore dell''''attributo \"{1}\" associato con un tipo di elemento \"{0}\" non deve contenere il carattere ''<''."
+             },
+
+             {MsgKey.ER_WF_REF_TO_UNPARSED_ENT,
+                 "Il riferimento entit\u00e0 non analizzata \"&{0};\" non \u00e8 permesso."
+             },
+
+             {MsgKey.ER_WF_REF_TO_EXTERNAL_ENT,
+                 "Il riferimento all''''entit\u00e0 esterna \"&{0};\" non \u00e8 permesso in un valore attributo."
+             },
+
+             {MsgKey.ER_NS_PREFIX_CANNOT_BE_BOUND,
+                 "Il prefisso \"{0}\" non pu\u00f2 essere associato allo spazio nome \"{1}\"."
+             },
+
+             {MsgKey.ER_NULL_LOCAL_ELEMENT_NAME,
+                 "Il nome locale dell''''elemento \"{0}\" \u00e8 null."
+             },
+
+             {MsgKey.ER_NULL_LOCAL_ATTR_NAME,
+                 "Il nome locale dell''''attributo \"{0}\" \u00e8  null."
+             },
+
+             { MsgKey.ER_ELEM_UNBOUND_PREFIX_IN_ENTREF,
+                 "Il testo di sostituzione del nodo di entit\u00e0 \"{0}\" contiene un nodo di elemento \"{1}\" con un prefisso non associato \"{2}\"."
+             },
+
+             { MsgKey.ER_ATTR_UNBOUND_PREFIX_IN_ENTREF,
+                 "Il testo di sostituzione del nodo di entit\u00e0 \"{0}\" contiene un nodo di attributo \"{1}\" con un prefisso non associato \"{2}\"."
+             },
 
         };
 

--- a/jaxp/src/com/sun/org/apache/xml/internal/serializer/utils/SerializerMessages_ja.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serializer/utils/SerializerMessages_ja.java
@@ -3,9 +3,11 @@
  * DO NOT REMOVE OR ALTER!
  */
 /*
- * Copyright 2004 The Apache Software Foundation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the  "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -197,6 +199,93 @@ public class SerializerMessages_ja extends ListResourceBundle {
             {   MsgKey.ER_ENCODING_NOT_SUPPORTED,
                 "\u8B66\u544A:  \u30A8\u30F3\u30B3\u30FC\u30C7\u30A3\u30F3\u30B0''{0}''\u306F\u3001Java\u30E9\u30F3\u30BF\u30A4\u30E0\u3067\u30B5\u30DD\u30FC\u30C8\u3055\u308C\u3066\u3044\u307E\u305B\u3093\u3002" },
 
+             {MsgKey.ER_FEATURE_NOT_FOUND,
+             "\u30d1\u30e9\u30e1\u30fc\u30bf\u30fc ''{0}'' \u306f\u8a8d\u8b58\u3055\u308c\u307e\u305b\u3093\u3002"},
+
+             {MsgKey.ER_FEATURE_NOT_SUPPORTED,
+             "\u30d1\u30e9\u30e1\u30fc\u30bf\u30fc ''{0}'' \u306f\u8a8d\u8b58\u3055\u308c\u307e\u3059\u304c\u3001\u8981\u6c42\u3055\u308c\u305f\u5024\u306f\u8a2d\u5b9a\u3067\u304d\u307e\u305b\u3093\u3002"},
+
+             {MsgKey.ER_STRING_TOO_LONG,
+             "\u7d50\u679c\u306e\u30b9\u30c8\u30ea\u30f3\u30b0\u304c\u9577\u3059\u304e\u308b\u305f\u3081\u3001DOMString \u5185\u306b\u53ce\u307e\u308a\u307e\u305b\u3093: ''{0}''\u3002"},
+
+             {MsgKey.ER_TYPE_MISMATCH_ERR,
+             "\u3053\u306e\u30d1\u30e9\u30e1\u30fc\u30bf\u30fc\u540d\u306e\u5024\u306e\u578b\u306f\u3001\u671f\u5f85\u3055\u308c\u308b\u5024\u306e\u578b\u3068\u4e0d\u9069\u5408\u3067\u3059\u3002"},
+
+             {MsgKey.ER_NO_OUTPUT_SPECIFIED,
+             "\u66f8\u304d\u8fbc\u307e\u308c\u308b\u30c7\u30fc\u30bf\u306e\u51fa\u529b\u5b9b\u5148\u304c\u30cc\u30eb\u3067\u3059\u3002"},
+
+             {MsgKey.ER_UNSUPPORTED_ENCODING,
+             "\u30b5\u30dd\u30fc\u30c8\u3055\u308c\u306a\u3044\u30a8\u30f3\u30b3\u30fc\u30c9\u304c\u691c\u51fa\u3055\u308c\u307e\u3057\u305f\u3002"},
+
+             {MsgKey.ER_UNABLE_TO_SERIALIZE_NODE,
+             "\u30ce\u30fc\u30c9\u3092\u76f4\u5217\u5316\u3067\u304d\u307e\u305b\u3093\u3067\u3057\u305f\u3002"},
+
+             {MsgKey.ER_CDATA_SECTIONS_SPLIT,
+             "CDATA \u30bb\u30af\u30b7\u30e7\u30f3\u306b 1 \u3064\u4ee5\u4e0a\u306e\u7d42\u4e86\u30de\u30fc\u30ab\u30fc ']]>' \u304c\u542b\u307e\u308c\u3066\u3044\u307e\u3059\u3002"},
+
+             {MsgKey.ER_WARNING_WF_NOT_CHECKED,
+                 "\u6574\u5f62\u5f0f\u6027\u30c1\u30a7\u30c3\u30ab\u30fc\u306e\u30a4\u30f3\u30b9\u30bf\u30f3\u30b9\u3092\u4f5c\u6210\u3067\u304d\u307e\u305b\u3093\u3067\u3057\u305f\u3002  well-formed \u30d1\u30e9\u30e1\u30fc\u30bf\u30fc\u306e\u8a2d\u5b9a\u306f true \u3067\u3057\u305f\u304c\u3001\u6574\u5f62\u5f0f\u6027\u306e\u691c\u67fb\u306f\u5b9f\u884c\u3067\u304d\u307e\u305b\u3093\u3002"
+             },
+
+             {MsgKey.ER_WF_INVALID_CHARACTER,
+                 "\u30ce\u30fc\u30c9 ''{0}'' \u306b\u7121\u52b9\u306a XML \u6587\u5b57\u304c\u3042\u308a\u307e\u3059\u3002"
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_COMMENT,
+                 "\u30b3\u30e1\u30f3\u30c8\u306e\u4e2d\u306b\u7121\u52b9\u306a XML \u6587\u5b57 (Unicode: 0x{0}) \u304c\u898b\u3064\u304b\u308a\u307e\u3057\u305f\u3002"
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_PI,
+                 "\u51e6\u7406\u547d\u4ee4\u30c7\u30fc\u30bf\u306e\u4e2d\u306b\u7121\u52b9\u306a XML \u6587\u5b57 (Unicode: 0x{0}) \u304c\u898b\u3064\u304b\u308a\u307e\u3057\u305f\u3002"
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_CDATA,
+                 "CDATA \u30bb\u30af\u30b7\u30e7\u30f3\u306e\u4e2d\u306b\u7121\u52b9\u306a XML \u6587\u5b57 (Unicode: 0x{0}) \u304c\u898b\u3064\u304b\u308a\u307e\u3057\u305f\u3002"
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_TEXT,
+                 "\u30ce\u30fc\u30c9\u306e\u6587\u5b57\u30c7\u30fc\u30bf\u306e\u5185\u5bb9\u306b\u7121\u52b9\u306a XML \u6587\u5b57 (Unicode: 0x{0}) \u304c\u898b\u3064\u304b\u308a\u307e\u3057\u305f\u3002"
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_NODE_NAME,
+                 "''{1}'' \u3068\u3044\u3046\u540d\u524d\u306e {0} \u30ce\u30fc\u30c9\u306e\u4e2d\u306b\u7121\u52b9\u306a XML \u6587\u5b57\u304c\u898b\u3064\u304b\u308a\u307e\u3057\u305f\u3002"
+             },
+
+             { MsgKey.ER_WF_DASH_IN_COMMENT,
+                 "\u30b9\u30c8\u30ea\u30f3\u30b0 \"--\" \u306f\u30b3\u30e1\u30f3\u30c8\u5185\u3067\u306f\u4f7f\u7528\u3067\u304d\u307e\u305b\u3093\u3002"
+             },
+
+             {MsgKey.ER_WF_LT_IN_ATTVAL,
+                 "\u8981\u7d20\u578b \"{0}\" \u306b\u95a2\u9023\u3057\u305f\u5c5e\u6027 \"{1}\" \u306e\u5024\u306b\u306f ''<'' \u6587\u5b57\u3092\u542b\u3081\u3066\u306f\u3044\u3051\u307e\u305b\u3093\u3002"
+             },
+
+             {MsgKey.ER_WF_REF_TO_UNPARSED_ENT,
+                 "\u89e3\u6790\u5bfe\u8c61\u5916\u5b9f\u4f53\u53c2\u7167 \"&{0};\" \u306f\u8a31\u53ef\u3055\u308c\u307e\u305b\u3093\u3002"
+             },
+
+             {MsgKey.ER_WF_REF_TO_EXTERNAL_ENT,
+                 "\u5c5e\u6027\u5024\u3067\u306e\u5916\u90e8\u5b9f\u4f53\u53c2\u7167 \"&{0};\" \u306f\u8a31\u53ef\u3055\u308c\u307e\u305b\u3093\u3002"
+             },
+
+             {MsgKey.ER_NS_PREFIX_CANNOT_BE_BOUND,
+                 "\u63a5\u982d\u90e8 \"{0}\" \u306f\u540d\u524d\u7a7a\u9593 \"{1}\" \u306b\u7d50\u5408\u3067\u304d\u307e\u305b\u3093\u3002"
+             },
+
+             {MsgKey.ER_NULL_LOCAL_ELEMENT_NAME,
+                 "\u8981\u7d20 \"{0}\" \u306e\u30ed\u30fc\u30ab\u30eb\u540d\u304c\u30cc\u30eb\u3067\u3059\u3002"
+             },
+
+             {MsgKey.ER_NULL_LOCAL_ATTR_NAME,
+                 "\u5c5e\u6027 \"{0}\" \u306e\u30ed\u30fc\u30ab\u30eb\u540d\u304c\u30cc\u30eb\u3067\u3059\u3002"
+             },
+
+             { MsgKey.ER_ELEM_UNBOUND_PREFIX_IN_ENTREF,
+                 "\u5b9f\u4f53\u30ce\u30fc\u30c9 \"{0}\" \u306e\u7f6e\u63db\u30c6\u30ad\u30b9\u30c8\u306b\u3001\u672a\u7d50\u5408\u306e\u63a5\u982d\u90e8 \"{2}\" \u3092\u6301\u3064\u8981\u7d20\u30ce\u30fc\u30c9 \"{1}\" \u304c\u542b\u307e\u308c\u3066\u3044\u307e\u3059\u3002"
+             },
+
+             { MsgKey.ER_ATTR_UNBOUND_PREFIX_IN_ENTREF,
+                 "\u5b9f\u4f53\u30ce\u30fc\u30c9 \"{0}\" \u306e\u7f6e\u63db\u30c6\u30ad\u30b9\u30c8\u306b\u3001\u672a\u7d50\u5408\u306e\u63a5\u982d\u90e8 \"{2}\" \u3092\u6301\u3064\u5c5e\u6027\u30ce\u30fc\u30c9 \"{1}\" \u304c\u542b\u307e\u308c\u3066\u3044\u307e\u3059\u3002"
+             },
 
         };
 

--- a/jaxp/src/com/sun/org/apache/xml/internal/serializer/utils/SerializerMessages_ko.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serializer/utils/SerializerMessages_ko.java
@@ -3,9 +3,11 @@
  * DO NOT REMOVE OR ALTER!
  */
 /*
- * Copyright 2004 The Apache Software Foundation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the  "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -197,6 +199,93 @@ public class SerializerMessages_ko extends ListResourceBundle {
             {   MsgKey.ER_ENCODING_NOT_SUPPORTED,
                 "\uACBD\uACE0: \uC778\uCF54\uB529 ''{0}''\uC740(\uB294) Java \uB7F0\uD0C0\uC784\uC5D0 \uC9C0\uC6D0\uB418\uC9C0 \uC54A\uC2B5\uB2C8\uB2E4." },
 
+             {MsgKey.ER_FEATURE_NOT_FOUND,
+             "''{0}'' \ub9e4\uac1c\ubcc0\uc218\ub97c \uc778\uc2dd\ud560 \uc218 \uc5c6\uc2b5\ub2c8\ub2e4."},
+
+             {MsgKey.ER_FEATURE_NOT_SUPPORTED,
+             "''{0}'' \ub9e4\uac1c\ubcc0\uc218\ub294 \uc778\uc2dd\ud560 \uc218 \uc788\uc73c\ub098 \uc694\uccad\ub41c \uac12\uc744 \uc124\uc815\ud560 \uc218 \uc5c6\uc2b5\ub2c8\ub2e4."},
+
+             {MsgKey.ER_STRING_TOO_LONG,
+             "\uacb0\uacfc \ubb38\uc790\uc5f4\uc774 \ub108\ubb34 \uae38\uc5b4 DOMString\uc5d0 \ub9de\uc9c0 \uc54a\uc2b5\ub2c8\ub2e4: ''{0}'' "},
+
+             {MsgKey.ER_TYPE_MISMATCH_ERR,
+             "\uc774 \ub9e4\uac1c\ubcc0\uc218 \uc774\ub984\uc5d0 \ub300\ud55c \uac12 \uc720\ud615\uc774 \uc608\uc0c1 \uac12 \uc720\ud615\uacfc \ud638\ud658\ub418\uc9c0 \uc54a\uc2b5\ub2c8\ub2e4."},
+
+             {MsgKey.ER_NO_OUTPUT_SPECIFIED,
+             "\ub370\uc774\ud130\ub97c \uae30\ub85d\ud560 \ucd9c\ub825 \ub300\uc0c1\uc774 \ub110(null)\uc785\ub2c8\ub2e4."},
+
+             {MsgKey.ER_UNSUPPORTED_ENCODING,
+             "\uc9c0\uc6d0\ub418\uc9c0 \uc54a\ub294 \uc778\ucf54\ub529\uc774 \ubc1c\uacac\ub418\uc5c8\uc2b5\ub2c8\ub2e4."},
+
+             {MsgKey.ER_UNABLE_TO_SERIALIZE_NODE,
+             "\ub178\ub4dc\ub97c \uc9c1\ub82c\ud654\ud560 \uc218 \uc5c6\uc2b5\ub2c8\ub2e4."},
+
+             {MsgKey.ER_CDATA_SECTIONS_SPLIT,
+             "CDATA \uc139\uc158\uc5d0 \uc885\ub8cc \ud45c\uc2dc \ubb38\uc790\uc778 ']]>'\uac00 \ud558\ub098 \uc774\uc0c1 \ud3ec\ud568\ub418\uc5b4 \uc788\uc2b5\ub2c8\ub2e4."},
+
+             {MsgKey.ER_WARNING_WF_NOT_CHECKED,
+                 "Well-Formedness \uac80\uc0ac\uae30\uc758 \uc778\uc2a4\ud134\uc2a4\ub97c \uc791\uc131\ud560 \uc218 \uc5c6\uc2b5\ub2c8\ub2e4. Well-Formed \ub9e4\uac1c\ubcc0\uc218\uac00 true\ub85c \uc124\uc815\ub418\uc5c8\uc9c0\ub9cc Well-Formedness \uac80\uc0ac\ub97c \uc218\ud589\ud560 \uc218 \uc5c6\uc2b5\ub2c8\ub2e4."
+             },
+
+             {MsgKey.ER_WF_INVALID_CHARACTER,
+                 "''{0}'' \ub178\ub4dc\uc5d0 \uc720\ud6a8\ud558\uc9c0 \uc54a\uc740 XML \ubb38\uc790\uac00 \uc788\uc2b5\ub2c8\ub2e4."
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_COMMENT,
+                 "\uc124\uba85\uc5d0 \uc720\ud6a8\ud558\uc9c0 \uc54a\uc740 XML \ubb38\uc790(Unicode: 0x{0})\uac00 \uc788\uc2b5\ub2c8\ub2e4. "
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_PI,
+                 "\ucc98\ub9ac \uba85\ub839\uc5b4 \ub370\uc774\ud130\uc5d0 \uc720\ud6a8\ud558\uc9c0 \uc54a\uc740 XML \ubb38\uc790(Unicode: 0x{0})\uac00 \uc788\uc2b5\ub2c8\ub2e4 "
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_CDATA,
+                 "CDATASection\uc758 \ub0b4\uc6a9\uc5d0 \uc720\ud6a8\ud558\uc9c0 \uc54a\uc740 XML \ubb38\uc790(Unicode: 0x{0})\uac00 \uc788\uc2b5\ub2c8\ub2e4. "
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_TEXT,
+                 "\ub178\ub4dc\uc758 \ubb38\uc790 \ub370\uc774\ud130 \ub0b4\uc6a9\uc5d0 \uc720\ud6a8\ud558\uc9c0 \uc54a\uc740 XML \ubb38\uc790(Unicode: 0x{0})\uac00 \uc788\uc2b5\ub2c8\ub2e4. "
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_NODE_NAME,
+                 "\uc774\ub984\uc774 ''{1}''\uc778 {0} \ub178\ub4dc\uc5d0 \uc720\ud6a8\ud558\uc9c0 \uc54a\uc740 XML \ubb38\uc790\uac00 \uc788\uc2b5\ub2c8\ub2e4. "
+             },
+
+             { MsgKey.ER_WF_DASH_IN_COMMENT,
+                 "\uc124\uba85 \ub0b4\uc5d0\uc11c\ub294 \"--\" \ubb38\uc790\uc5f4\uc774 \ud5c8\uc6a9\ub418\uc9c0 \uc54a\uc2b5\ub2c8\ub2e4."
+             },
+
+             {MsgKey.ER_WF_LT_IN_ATTVAL,
+                 "\"{0}\" \uc694\uc18c \uc720\ud615\uacfc \uc5f0\uad00\ub41c \"{1}\" \uc18d\uc131\uac12\uc5d0 ''<'' \ubb38\uc790\uac00 \ud3ec\ud568\ub418\uba74 \uc548\ub429\ub2c8\ub2e4."
+             },
+
+             {MsgKey.ER_WF_REF_TO_UNPARSED_ENT,
+                 "\"&{0};\"\uc758 \uad6c\ubd84 \ubd84\uc11d\ub418\uc9c0 \uc54a\uc740 \uc5d4\ud2f0\ud2f0 \ucc38\uc870\ub294 \ud5c8\uc6a9\ub418\uc9c0 \uc54a\uc2b5\ub2c8\ub2e4. "
+             },
+
+             {MsgKey.ER_WF_REF_TO_EXTERNAL_ENT,
+                 "\uc18d\uc131\uac12\uc5d0\ub294 \"&{0};\" \uc678\ubd80 \uc5d4\ud2f0\ud2f0 \ucc38\uc870\uac00 \ud5c8\uc6a9\ub418\uc9c0 \uc54a\uc2b5\ub2c8\ub2e4. "
+             },
+
+             {MsgKey.ER_NS_PREFIX_CANNOT_BE_BOUND,
+                 "\"{0}\" \uc811\ub450\ubd80\ub97c \"{1}\" \uc774\ub984 \uacf5\uac04\uc5d0 \ubc14\uc778\ub4dc\ud560 \uc218 \uc5c6\uc2b5\ub2c8\ub2e4."
+             },
+
+             {MsgKey.ER_NULL_LOCAL_ELEMENT_NAME,
+                 "\"{0}\" \uc694\uc18c\uc758 \ub85c\uceec \uc774\ub984\uc774 \ub110(null)\uc785\ub2c8\ub2e4."
+             },
+
+             {MsgKey.ER_NULL_LOCAL_ATTR_NAME,
+                 "\"{0}\" \uc18d\uc131\uc758 \ub85c\uceec \uc774\ub984\uc774 \ub110(null)\uc785\ub2c8\ub2e4."
+             },
+
+             { MsgKey.ER_ELEM_UNBOUND_PREFIX_IN_ENTREF,
+                 "\"{0}\" \uc5d4\ud2f0\ud2f0 \ub178\ub4dc\uc758 \ub300\uccb4 \ud14d\uc2a4\ud2b8\uc5d0 \ubc14\uc778\ub4dc\ub418\uc9c0 \uc54a\uc740 \uc811\ub450\ubd80 \"{2}\"\uc744(\ub97c) \uac16\ub294 \"{1}\" \uc694\uc18c \ub178\ub4dc\uac00 \uc788\uc2b5\ub2c8\ub2e4."
+             },
+
+             { MsgKey.ER_ATTR_UNBOUND_PREFIX_IN_ENTREF,
+                 "\"{0}\" \uc5d4\ud2f0\ud2f0 \ub178\ub4dc\uc758 \ub300\uccb4 \ud14d\uc2a4\ud2b8\uc5d0 \ubc14\uc778\ub4dc\ub418\uc9c0 \uc54a\uc740 \uc811\ub450\ubd80 \"{2}\"\uc744(\ub97c) \uac16\ub294 \"{1}\" \uc18d\uc131 \ub178\ub4dc\uac00 \uc788\uc2b5\ub2c8\ub2e4."
+             },
 
         };
 

--- a/jaxp/src/com/sun/org/apache/xml/internal/serializer/utils/SerializerMessages_pt_BR.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serializer/utils/SerializerMessages_pt_BR.java
@@ -3,9 +3,11 @@
  * DO NOT REMOVE OR ALTER!
  */
 /*
- * Copyright 2004 The Apache Software Foundation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the  "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -197,6 +199,93 @@ public class SerializerMessages_pt_BR extends ListResourceBundle {
             {   MsgKey.ER_ENCODING_NOT_SUPPORTED,
                 "Advert\u00EAncia: a codifica\u00E7\u00E3o ''{0}'' n\u00E3o \u00E9 suportada pelo Java runtime." },
 
+             {MsgKey.ER_FEATURE_NOT_FOUND,
+             "O par\u00e2metro ''{0}'' n\u00e3o \u00e9 reconhecido."},
+
+             {MsgKey.ER_FEATURE_NOT_SUPPORTED,
+             "O par\u00e2metro ''{0}'' \u00e9 reconhecido, mas o valor pedido n\u00e3o pode ser definido. "},
+
+             {MsgKey.ER_STRING_TOO_LONG,
+             "A cadeia resultante \u00e9 muito longa para caber em uma DOMString: ''{0}''. "},
+
+             {MsgKey.ER_TYPE_MISMATCH_ERR,
+             "O tipo de valor para este nome de par\u00e2metro \u00e9 incompat\u00edvel com o tipo de valor esperado. "},
+
+             {MsgKey.ER_NO_OUTPUT_SPECIFIED,
+             "O destino de sa\u00edda para os dados a serem gravados era nulo. "},
+
+             {MsgKey.ER_UNSUPPORTED_ENCODING,
+             "Uma codifica\u00e7\u00e3o n\u00e3o suportada foi encontrada. "},
+
+             {MsgKey.ER_UNABLE_TO_SERIALIZE_NODE,
+             "O n\u00f3 n\u00e3o p\u00f4de ser serializado."},
+
+             {MsgKey.ER_CDATA_SECTIONS_SPLIT,
+             "A Se\u00e7\u00e3o CDATA cont\u00e9m um ou mais marcadores de t\u00e9rmino ']]>'."},
+
+             {MsgKey.ER_WARNING_WF_NOT_CHECKED,
+                 "Uma inst\u00e2ncia do verificador Well-Formedness n\u00e3o p\u00f4de ser criada. O par\u00e2metro well-formed foi definido como true, mas a verifica\u00e7\u00e3o well-formedness n\u00e3o pode ser executada."
+             },
+
+             {MsgKey.ER_WF_INVALID_CHARACTER,
+                 "O n\u00f3 ''{0}'' cont\u00e9m caracteres XML inv\u00e1lidos. "
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_COMMENT,
+                 "Um caractere XML inv\u00e1lido (Unicode: 0x{0}) foi encontrado no coment\u00e1rio. "
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_PI,
+                 "Um caractere XML inv\u00e1lido (Unicode: 0x{0}) foi encontrado no processo instructiondata."
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_CDATA,
+                 "Um caractere XML inv\u00e1lido (Unicode: 0x{0}) foi encontrado nos conte\u00fados do CDATASection. "
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_TEXT,
+                 "Um caractere XML inv\u00e1lido (Unicode: 0x{0}) foi encontrado no conte\u00fado dos dados de caractere dos n\u00f3s. "
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_NODE_NAME,
+                 "Um caractere inv\u00e1lido foi encontrado no {0} do n\u00f3 denominado ''{1}''."
+             },
+
+             { MsgKey.ER_WF_DASH_IN_COMMENT,
+                 "A cadeia \"--\" n\u00e3o \u00e9 permitida dentro dos coment\u00e1rios. "
+             },
+
+             {MsgKey.ER_WF_LT_IN_ATTVAL,
+                 "O valor do atributo \"{1}\" associado a um tipo de elemento \"{0}\" n\u00e3o deve conter o caractere ''<''. "
+             },
+
+             {MsgKey.ER_WF_REF_TO_UNPARSED_ENT,
+                 "A refer\u00eancia de entidade n\u00e3o analisada \"&{0};\" n\u00e3o \u00e9 permitida. "
+             },
+
+             {MsgKey.ER_WF_REF_TO_EXTERNAL_ENT,
+                 "A refer\u00eancia de entidade externa \"&{0};\" n\u00e3o \u00e9 permitida em um valor de atributo. "
+             },
+
+             {MsgKey.ER_NS_PREFIX_CANNOT_BE_BOUND,
+                 "O prefixo \"{0}\" n\u00e3o pode ser vinculado ao espa\u00e7o de nomes \"{1}\"."
+             },
+
+             {MsgKey.ER_NULL_LOCAL_ELEMENT_NAME,
+                 "O nome local do elemento \"{0}\" \u00e9 nulo."
+             },
+
+             {MsgKey.ER_NULL_LOCAL_ATTR_NAME,
+                 "O nome local do atributo \"{0}\" \u00e9 nulo."
+             },
+
+             { MsgKey.ER_ELEM_UNBOUND_PREFIX_IN_ENTREF,
+                 "O texto de substitui\u00e7\u00e3o do n\u00f3 de entidade \"{0}\" cont\u00e9m um n\u00f3 de elemento \"{1}\" com um prefixo n\u00e3o vinculado \"{2}\"."
+             },
+
+             { MsgKey.ER_ATTR_UNBOUND_PREFIX_IN_ENTREF,
+                 "O texto de substitui\u00e7\u00e3o do n\u00f3 de entidade \"{0}\" cont\u00e9m um n\u00f3 de atributo \"{1}\" com um prefixo n\u00e3o vinculado \"{2}\"."
+             },
 
         };
 

--- a/jaxp/src/com/sun/org/apache/xml/internal/serializer/utils/SerializerMessages_zh_TW.java
+++ b/jaxp/src/com/sun/org/apache/xml/internal/serializer/utils/SerializerMessages_zh_TW.java
@@ -3,9 +3,11 @@
  * DO NOT REMOVE OR ALTER!
  */
 /*
- * Copyright 2004 The Apache Software Foundation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the  "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -197,6 +199,93 @@ public class SerializerMessages_zh_TW extends ListResourceBundle {
             {   MsgKey.ER_ENCODING_NOT_SUPPORTED,
                 "\u8B66\u544A:  Java Runtime \u4E0D\u652F\u63F4\u7DE8\u78BC ''{0}''\u3002" },
 
+             {MsgKey.ER_FEATURE_NOT_FOUND,
+             "\u7121\u6cd5\u8fa8\u8b58\u53c3\u6578 ''{0}''\u3002"},
+
+             {MsgKey.ER_FEATURE_NOT_SUPPORTED,
+             "\u53ef\u8fa8\u8b58 ''{0}'' \u53c3\u6578\uff0c\u4f46\u6240\u8981\u6c42\u7684\u503c\u7121\u6cd5\u8a2d\u5b9a\u3002"},
+
+             {MsgKey.ER_STRING_TOO_LONG,
+             "\u7d50\u679c\u5b57\u4e32\u904e\u9577\uff0c\u7121\u6cd5\u7f6e\u5165 DOMString: ''{0}'' \u4e2d\u3002"},
+
+             {MsgKey.ER_TYPE_MISMATCH_ERR,
+             "\u9019\u500b\u53c3\u6578\u540d\u7a31\u7684\u503c\u985e\u578b\u8207\u671f\u671b\u503c\u985e\u578b\u4e0d\u76f8\u5bb9\u3002"},
+
+             {MsgKey.ER_NO_OUTPUT_SPECIFIED,
+             "\u8cc7\u6599\u8981\u5beb\u5165\u7684\u8f38\u51fa\u76ee\u7684\u5730\u70ba\u7a7a\u503c\u3002"},
+
+             {MsgKey.ER_UNSUPPORTED_ENCODING,
+             "\u767c\u73fe\u4e0d\u652f\u63f4\u7684\u7de8\u78bc\u3002"},
+
+             {MsgKey.ER_UNABLE_TO_SERIALIZE_NODE,
+             "\u7bc0\u9ede\u7121\u6cd5\u5e8f\u5217\u5316\u3002"},
+
+             {MsgKey.ER_CDATA_SECTIONS_SPLIT,
+             "CDATA \u5340\u6bb5\u5305\u542b\u4e00\u6216\u591a\u500b\u7d42\u6b62\u6a19\u8a18 ']]>'\u3002"},
+
+             {MsgKey.ER_WARNING_WF_NOT_CHECKED,
+                 "\u7121\u6cd5\u5efa\u7acb\u300c\u5f62\u5f0f\u5b8c\u6574\u300d\u6aa2\u67e5\u7a0b\u5f0f\u7684\u5be6\u4f8b\u3002Well-formed \u53c3\u6578\u96d6\u8a2d\u70ba true\uff0c\u4f46\u7121\u6cd5\u57f7\u884c\u5f62\u5f0f\u5b8c\u6574\u6aa2\u67e5\u3002"
+             },
+
+             {MsgKey.ER_WF_INVALID_CHARACTER,
+                 "\u7bc0\u9ede ''{0}'' \u5305\u542b\u7121\u6548\u7684 XML \u5b57\u5143\u3002"
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_COMMENT,
+                 "\u5728\u8a3b\u89e3\u4e2d\u767c\u73fe\u7121\u6548\u7684 XML \u5b57\u5143 (Unicode: 0x{0})\u3002"
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_PI,
+                 "\u5728\u8655\u7406\u7a0b\u5e8f instructiondata \u4e2d\u767c\u73fe\u7121\u6548\u7684 XML \u5b57\u5143 (Unicode: 0x{0})\u3002"
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_CDATA,
+                 "\u5728 CDATASection \u7684\u5167\u5bb9\u4e2d\u767c\u73fe\u7121\u6548\u7684 XML \u5b57\u5143 (Unicode: 0x{0})\u3002"
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_TEXT,
+                 "\u5728\u7bc0\u9ede\u7684\u5b57\u5143\u8cc7\u6599\u5167\u5bb9\u4e2d\u767c\u73fe\u7121\u6548\u7684 XML \u5b57\u5143 (Unicode: 0x{0})\u3002"
+             },
+
+             { MsgKey.ER_WF_INVALID_CHARACTER_IN_NODE_NAME,
+                 "\u5728\u540d\u70ba ''{1}'' \u7684 ''{0}'' \u4e2d\u767c\u73fe\u7121\u6548\u7684 XML \u5b57\u5143\u3002"
+             },
+
+             { MsgKey.ER_WF_DASH_IN_COMMENT,
+                 "\u8a3b\u89e3\u4e2d\u4e0d\u5141\u8a31\u4f7f\u7528\u5b57\u4e32 \"--\"\u3002"
+             },
+
+             {MsgKey.ER_WF_LT_IN_ATTVAL,
+                 "\u8207\u5143\u7d20\u985e\u578b \"{0}\" \u76f8\u95dc\u806f\u7684\u5c6c\u6027 \"{1}\" \u503c\u4e0d\u53ef\u5305\u542b ''<'' \u5b57\u5143\u3002"
+             },
+
+             {MsgKey.ER_WF_REF_TO_UNPARSED_ENT,
+                 "\u4e0d\u5141\u8a31\u4f7f\u7528\u672a\u5256\u6790\u7684\u5be6\u9ad4\u53c3\u7167 \"&{0};\"\u3002"
+             },
+
+             {MsgKey.ER_WF_REF_TO_EXTERNAL_ENT,
+                 "\u5c6c\u6027\u503c\u4e2d\u4e0d\u5141\u8a31\u4f7f\u7528\u5916\u90e8\u5be6\u9ad4\u53c3\u7167 \"&{0};\"\u3002"
+             },
+
+             {MsgKey.ER_NS_PREFIX_CANNOT_BE_BOUND,
+                 "\u5b57\u9996 \"{0}\" \u7121\u6cd5\u9023\u7d50\u5230\u540d\u7a31\u7a7a\u9593 \"{1}\"\u3002"
+             },
+
+             {MsgKey.ER_NULL_LOCAL_ELEMENT_NAME,
+                 "\u5143\u7d20 \"{0}\" \u7684\u672c\u7aef\u540d\u7a31\u662f\u7a7a\u503c\u3002"
+             },
+
+             {MsgKey.ER_NULL_LOCAL_ATTR_NAME,
+                 "\u5c6c\u6027 \"{0}\" \u7684\u672c\u7aef\u540d\u7a31\u662f\u7a7a\u503c\u3002"
+             },
+
+             { MsgKey.ER_ELEM_UNBOUND_PREFIX_IN_ENTREF,
+                 "\u5be6\u9ad4\u7bc0\u9ede \"{0}\" \u7684\u53d6\u4ee3\u6587\u5b57\u5305\u542b\u9644\u6709\u5df2\u5207\u65b7\u9023\u7d50\u5b57\u9996 \"{2}\" \u7684\u5143\u7d20\u7bc0\u9ede \"{1}\"\u3002"
+             },
+
+             { MsgKey.ER_ATTR_UNBOUND_PREFIX_IN_ENTREF,
+                 "\u5be6\u9ad4\u7bc0\u9ede \"{0}\" \u7684\u53d6\u4ee3\u6587\u5b57\u5305\u542b\u9644\u6709\u5df2\u5207\u65b7\u9023\u7d50\u5b57\u9996 \"{2}\" \u7684\u5c6c\u6027\u7bc0\u9ede \"{1}\"\u3002"
+             },
 
         };
 


### PR DESCRIPTION
This backport is part of the effort to update Xerces in 8u to 2.12 ([JDK-8238164](https://bugs.openjdk.org/browse/JDK-8238164).

The JDK 9 commit does not apply cleanly, but only required cosmetic changes. These are due to differences in some copyright headers, and not having a `@version` Javadoc tag in the 8u version of these files.

I am concerned over deprecating the Xerces serializer. As noted in [JDK-8219692](https://bugs.openjdk.org/browse/JDK-8219692), there are behavioural changes caused by this new serializer.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8035467](https://bugs.openjdk.org/browse/JDK-8035467): Xerces Update: Move to Xalan based DOM L3 serializer. Deprecate Xerces' native serializer.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/89/head:pull/89` \
`$ git checkout pull/89`

Update a local copy of the PR: \
`$ git checkout pull/89` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/89/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 89`

View PR using the GUI difftool: \
`$ git pr show -t 89`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/89.diff">https://git.openjdk.org/jdk8u-dev/pull/89.diff</a>

</details>
