### PR TITLE
Update FLAGS_CXX_COMPILER_CHECK_ARGUMENTS in flags.m4

### DIFF
--- a/common/autoconf/flags.m4
+++ b/common/autoconf/flags.m4
@@ -857,7 +857,7 @@ AC_DEFUN([FLAGS_CXX_COMPILER_CHECK_ARGUMENTS],
   supports=yes
 
   saved_cxxflags="$CXXFLAGS"
-  CXXFLAGS="$CXXFLAG $1"
+  CXXFLAGS="$CXXFLAGS $1"
   AC_LANG_PUSH([C++])
   AC_COMPILE_IFELSE([AC_LANG_SOURCE([[int i;]])], [], 
       [supports=no])


### PR DESCRIPTION
In FLAGS_CXX_COMPILER_CHECK_ARGUMENTS, CXXFLAG is used instead of CXXFLAGS, so the options are not properly passed. For example, when building 32-bit JDK on a 64-bit system, "-m32" is not passed as a C++ option in some tests, so configure fails.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/90/head:pull/90` \
`$ git checkout pull/90`

Update a local copy of the PR: \
`$ git checkout pull/90` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/90/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 90`

View PR using the GUI difftool: \
`$ git pr show -t 90`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/90.diff">https://git.openjdk.org/jdk8u-dev/pull/90.diff</a>

</details>
