### PR TITLE
8245263: Enable TLSv1.3 by default on JDK 8u for Client roles

### DIFF
--- a/jdk/src/share/classes/sun/security/ssl/SSLContextImpl.java
+++ b/jdk/src/share/classes/sun/security/ssl/SSLContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -940,12 +940,14 @@ public abstract class SSLContextImpl extends SSLContextSpi {
         static ProtocolVersion[] getProtocols() {
             if (SunJSSE.isFIPS()) {
                 return new ProtocolVersion[]{
+                        ProtocolVersion.TLS13,
                         ProtocolVersion.TLS12,
                         ProtocolVersion.TLS11,
                         ProtocolVersion.TLS10
                 };
             } else {
                 return new ProtocolVersion[]{
+                        ProtocolVersion.TLS13,
                         ProtocolVersion.TLS12,
                         ProtocolVersion.TLS11,
                         ProtocolVersion.TLS10,

--- a/jdk/test/javax/net/ssl/SSLSession/ResumeTLS13withSNI.java
+++ b/jdk/test/javax/net/ssl/SSLSession/ResumeTLS13withSNI.java
@@ -28,7 +28,7 @@
  * @test
  * @bug 8211806
  * @summary TLS 1.3 handshake server name indication is missing on a session resume
- * @run main/othervm -Djdk.tls.client.protocols="TLSv1.3,TLSv1.2,TLSv1.1,TLSv1,SSLv3" ResumeTLS13withSNI
+ * @run main/othervm ResumeTLS13withSNI
  */
 
 import javax.net.ssl.*;

--- a/jdk/test/javax/net/ssl/SSLSocket/Tls13PacketSize.java
+++ b/jdk/test/javax/net/ssl/SSLSocket/Tls13PacketSize.java
@@ -31,7 +31,7 @@
  * @bug 8221253
  * @summary TLSv1.3 may generate TLSInnerPlainText longer than 2^14+1 bytes
  * @library /javax/net/ssl/templates
- * @run main/othervm -Djdk.tls.client.protocols="TLSv1.3,TLSv1.2,TLSv1.1,TLSv1,SSLv3" Tls13PacketSize
+ * @run main/othervm Tls13PacketSize
  */
 import java.io.InputStream;
 import java.io.OutputStream;

--- a/jdk/test/javax/net/ssl/Stapling/HttpsUrlConnClient.java
+++ b/jdk/test/javax/net/ssl/Stapling/HttpsUrlConnClient.java
@@ -30,7 +30,7 @@
  * @summary OCSP Stapling for TLS
  * @library ../../../../java/security/testlibrary
  * @build CertificateBuilder SimpleOCSPServer
- * @run main/othervm -Djdk.tls.client.protocols="TLSv1.3,TLSv1.2,TLSv1.1,TLSv1,SSLv3" HttpsUrlConnClient
+ * @run main/othervm HttpsUrlConnClient
  */
 
 import java.io.*;

--- a/jdk/test/javax/net/ssl/Stapling/SSLEngineWithStapling.java
+++ b/jdk/test/javax/net/ssl/Stapling/SSLEngineWithStapling.java
@@ -30,7 +30,7 @@
  * @summary OCSP Stapling for TLS
  * @library ../../../../java/security/testlibrary
  * @build CertificateBuilder SimpleOCSPServer
- * @run main/othervm -Djdk.tls.client.protocols="TLSv1.3,TLSv1.2,TLSv1.1,TLSv1,SSLv3" SSLEngineWithStapling
+ * @run main/othervm SSLEngineWithStapling
  */
 
 /**

--- a/jdk/test/javax/net/ssl/Stapling/SSLSocketWithStapling.java
+++ b/jdk/test/javax/net/ssl/Stapling/SSLSocketWithStapling.java
@@ -30,7 +30,7 @@
  * @summary OCSP Stapling for TLS
  * @library ../../../../java/security/testlibrary
  * @build CertificateBuilder SimpleOCSPServer
- * @run main/othervm -Djdk.tls.client.protocols="TLSv1.3,TLSv1.2,TLSv1.1,TLSv1,SSLv3" SSLSocketWithStapling
+ * @run main/othervm SSLSocketWithStapling
  */
 
 import java.io.*;

--- a/jdk/test/javax/net/ssl/Stapling/StapleEnableProps.java
+++ b/jdk/test/javax/net/ssl/Stapling/StapleEnableProps.java
@@ -30,7 +30,7 @@
  * @summary SSLContextImpl.statusResponseManager should be generated if required
  * @library ../../../../java/security/testlibrary
  * @build CertificateBuilder SimpleOCSPServer
- * @run main/othervm -Djdk.tls.client.protocols="TLSv1.3,TLSv1.2,TLSv1.1,TLSv1,SSLv3" StapleEnableProps
+ * @run main/othervm StapleEnableProps
  */
 
 import javax.net.ssl.*;

--- a/jdk/test/javax/net/ssl/TLS/TLSClientPropertyTest.java
+++ b/jdk/test/javax/net/ssl/TLS/TLSClientPropertyTest.java
@@ -71,7 +71,7 @@ public class TLSClientPropertyTest {
             }
             contextProtocol = null;
             expectedDefaultProtos = new String[] {
-                    "TLSv1.2"
+                    "TLSv1.2", "TLSv1.3"
             };
             break;
         case "SSLv3":
@@ -90,13 +90,13 @@ public class TLSClientPropertyTest {
             };
             break;
         case "TLSv12":
-        case "TLS":
             contextProtocol = "TLSv1.2";
             expectedDefaultProtos = new String[] {
                     "TLSv1.2"
             };
             break;
         case "TLSv13":
+        case "TLS":
             contextProtocol = "TLSv1.3";
             expectedDefaultProtos = new String[] {
                     "TLSv1.2", "TLSv1.3"

--- a/jdk/test/javax/net/ssl/sanity/ciphersuites/CheckCipherSuites.java
+++ b/jdk/test/javax/net/ssl/sanity/ciphersuites/CheckCipherSuites.java
@@ -25,8 +25,8 @@
  * @test
  * @bug 4750141 4895631 8217579 8163326
  * @summary Check enabled and supported ciphersuites are correct
- * @run main/othervm -Djdk.tls.client.protocols="TLSv1.3,TLSv1.2,TLSv1.1,TLSv1,SSLv3" CheckCipherSuites default
- * @run main/othervm -Djdk.tls.client.protocols="TLSv1.3,TLSv1.2,TLSv1.1,TLSv1,SSLv3" CheckCipherSuites limited
+ * @run main/othervm CheckCipherSuites default
+ * @run main/othervm CheckCipherSuites limited
  */
 
 import java.util.*;

--- a/jdk/test/sun/security/ssl/HandshakeHash/HandshakeHashCloneExhaustion.java
+++ b/jdk/test/sun/security/ssl/HandshakeHash/HandshakeHashCloneExhaustion.java
@@ -35,8 +35,8 @@
  * @library /javax/net/ssl/templates
  * @library /lib/security
  * @compile DigestBase.java
- * @run main/othervm -Djdk.tls.client.protocols="TLSv1.3,TLSv1.2,TLSv1.1,TLSv1,SSLv3"
- *     HandshakeHashCloneExhaustion TLSv1.3 TLS_AES_128_GCM_SHA256
+ * @run main/othervm HandshakeHashCloneExhaustion
+ *     TLSv1.3 TLS_AES_128_GCM_SHA256
  * @run main/othervm HandshakeHashCloneExhaustion
  *     TLSv1.2 TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
  * @run main/othervm HandshakeHashCloneExhaustion

--- a/jdk/test/sun/security/ssl/SSLContextImpl/CustomizedServerDefaultProtocols.java
+++ b/jdk/test/sun/security/ssl/SSLContextImpl/CustomizedServerDefaultProtocols.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,10 +52,10 @@ public class CustomizedServerDefaultProtocols {
     enum ContextVersion {
         TLS_CV_01("SSL",
                 new String[]{"SSLv3", "TLSv1", "TLSv1.1"},
-                new String[]{"SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2"}),
+                new String[]{"SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"}),
         TLS_CV_02("TLS",
                 new String[]{"SSLv3", "TLSv1", "TLSv1.1"},
-                new String[]{"SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2"}),
+                new String[]{"SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"}),
         TLS_CV_03("SSLv3",
                 supportedProtocols,
                 new String[]{"SSLv3", "TLSv1"}),
@@ -73,7 +73,7 @@ public class CustomizedServerDefaultProtocols {
                 new String[]{"SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"}),
         TLS_CV_08("Default",
                 new String[]{"SSLv3", "TLSv1", "TLSv1.1"},
-                new String[]{"SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2"});
+                new String[]{"SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"});
 
         final String contextVersion;
         final String[] serverEnabledProtocols;

--- a/jdk/test/sun/security/ssl/SSLContextImpl/DefaultEnabledProtocols.java
+++ b/jdk/test/sun/security/ssl/SSLContextImpl/DefaultEnabledProtocols.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,9 +49,9 @@ import javax.net.ssl.TrustManager;
 public class DefaultEnabledProtocols {
     enum ContextVersion {
         TLS_CV_01("SSL",
-                new String[] {"SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2"}),
+                new String[] {"SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"}),
         TLS_CV_02("TLS",
-                new String[] {"SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2"}),
+                new String[] {"SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"}),
         TLS_CV_03("SSLv3",
                 new String[] {"SSLv3", "TLSv1"}),
         TLS_CV_04("TLSv1",
@@ -63,7 +63,7 @@ public class DefaultEnabledProtocols {
         TLS_CV_07("TLSv1.3",
                 new String[] {"SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"}),
         TLS_CV_08("Default",
-                new String[] {"SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2"});
+                new String[] {"SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"});
 
         final String contextVersion;
         final String[] enabledProtocols;

--- a/jdk/test/sun/security/ssl/SSLSessionImpl/ResumeChecksClient.java
+++ b/jdk/test/sun/security/ssl/SSLSessionImpl/ResumeChecksClient.java
@@ -29,8 +29,8 @@
  * @run main/othervm -Djdk.tls.client.protocols=TLSv1.2 ResumeChecksClient BASIC
  * @run main/othervm -Djdk.tls.client.protocols=TLSv1.3 ResumeChecksClient BASIC
  * @run main/othervm ResumeChecksClient BASIC
- * @run main/othervm -Djdk.tls.client.protocols=TLSv1.2,TLSv1.3 ResumeChecksClient VERSION_2_TO_3
- * @run main/othervm -Djdk.tls.client.protocols=TLSv1.2,TLSv1.3 ResumeChecksClient VERSION_3_TO_2
+ * @run main/othervm ResumeChecksClient VERSION_2_TO_3
+ * @run main/othervm ResumeChecksClient VERSION_3_TO_2
  * @run main/othervm -Djdk.tls.client.protocols=TLSv1.3 ResumeChecksClient CIPHER_SUITE
  * @run main/othervm -Djdk.tls.client.protocols=TLSv1.3 ResumeChecksClient SIGNATURE_SCHEME
  *

--- a/jdk/test/sun/security/ssl/SSLSessionImpl/ResumeChecksServer.java
+++ b/jdk/test/sun/security/ssl/SSLSessionImpl/ResumeChecksServer.java
@@ -32,8 +32,8 @@
  * @run main/othervm -Djdk.tls.client.protocols=TLSv1.2 ResumeChecksServer CLIENT_AUTH
  * @run main/othervm -Djdk.tls.client.protocols=TLSv1.3 ResumeChecksServer CLIENT_AUTH
  * @run main/othervm ResumeChecksServer CLIENT_AUTH
- * @run main/othervm -Djdk.tls.client.protocols=TLSv1.2,TLSv1.3 ResumeChecksServer VERSION_2_TO_3
- * @run main/othervm -Djdk.tls.client.protocols=TLSv1.2,TLSv1.3 ResumeChecksServer VERSION_3_TO_2
+ * @run main/othervm ResumeChecksServer VERSION_2_TO_3
+ * @run main/othervm ResumeChecksServer VERSION_3_TO_2
  * @run main/othervm -Djdk.tls.client.protocols=TLSv1.3 ResumeChecksServer CIPHER_SUITE
  * @run main/othervm -Djdk.tls.client.protocols=TLSv1.3 ResumeChecksServer SIGNATURE_SCHEME
  *

--- a/jdk/test/sun/security/ssl/X509TrustManagerImpl/TooManyCAs.java
+++ b/jdk/test/sun/security/ssl/X509TrustManagerImpl/TooManyCAs.java
@@ -26,8 +26,8 @@
  * @bug 8206925
  * @library /javax/net/ssl/templates
  * @summary Support the certificate_authorities extension
- * @run main/othervm -Djdk.tls.client.protocols=TLSv1.3 TooManyCAs
- * @run main/othervm -Djdk.tls.client.protocols=TLSv1.3 -Djdk.tls.client.enableCAExtension=true TooManyCAs
+ * @run main/othervm TooManyCAs
+ * @run main/othervm -Djdk.tls.client.enableCAExtension=true TooManyCAs
  */
 import javax.net.ssl.*;
 import javax.security.auth.x500.X500Principal;


### PR DESCRIPTION
Please review a patch to enable TLSv1.3 by default on JDK 8u for Client roles
I'd like to add this functionality for parity with Oracle JavaSE8

The patch rolls back the JDK-8245476 and updates JTREG tests

All sun/security/ssl and javax/net/ssl jtreg tests are passed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8245263](https://bugs.openjdk.org/browse/JDK-8245263): Enable TLSv1.3 by default on JDK 8u for Client roles


### Reviewers
 * [Martin Balao](https://openjdk.org/census#mbalao) (@martinuy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/96/head:pull/96` \
`$ git checkout pull/96`

Update a local copy of the PR: \
`$ git checkout pull/96` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/96/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 96`

View PR using the GUI difftool: \
`$ git pr show -t 96`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/96.diff">https://git.openjdk.org/jdk8u-dev/pull/96.diff</a>

</details>
