### PR TITLE
8148005: One byte may be corrupted by get_datetime_string()

### DIFF
--- a/hotspot/src/share/vm/utilities/ostream.cpp
+++ b/hotspot/src/share/vm/utilities/ostream.cpp
@@ -385,7 +385,7 @@ extern Mutex* tty_lock;
 char* get_datetime_string(char *buf, size_t len) {
   os::local_time_string(buf, len);
   int i = (int)strlen(buf);
-  while (i-- >= 0) {
+  while (--i >= 0) {
     if (buf[i] == ' ') buf[i] = '_';
     else if (buf[i] == ':') buf[i] = '-';
   }


### PR DESCRIPTION
The bug has been fixed in jdk9, but it wasn't backported to jdk8u.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8148005](https://bugs.openjdk.org/browse/JDK-8148005): One byte may be corrupted by get_datetime_string()


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/97/head:pull/97` \
`$ git checkout pull/97`

Update a local copy of the PR: \
`$ git checkout pull/97` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/97/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 97`

View PR using the GUI difftool: \
`$ git pr show -t 97`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/97.diff">https://git.openjdk.org/jdk8u-dev/pull/97.diff</a>

</details>
