### PR TITLE
8183107: PKCS11 regression regarding checkKeySize

### DIFF
--- a/jdk/src/share/classes/sun/security/pkcs11/P11KeyGenerator.java
+++ b/jdk/src/share/classes/sun/security/pkcs11/P11KeyGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -119,11 +119,13 @@ final class P11KeyGenerator extends KeyGeneratorSpi {
                 // RC4 which is in bits. However, some PKCS#11 impls still use
                 // bytes for all mechs, e.g. NSS. We try to detect this
                 // inconsistency if the minKeySize seems unreasonably small.
-                int minKeySize = (int)info.ulMinKeySize;
-                int maxKeySize = (int)info.ulMaxKeySize;
+                int minKeySize = info.iMinKeySize;
+                int maxKeySize = info.iMaxKeySize;
                 if (keyGenMech != CKM_RC4_KEY_GEN || minKeySize < 8) {
-                    minKeySize = (int)info.ulMinKeySize << 3;
-                    maxKeySize = (int)info.ulMaxKeySize << 3;
+                    minKeySize = Math.multiplyExact(minKeySize, 8);
+                    if (maxKeySize != Integer.MAX_VALUE) {
+                        maxKeySize = Math.multiplyExact(maxKeySize, 8);
+                    }
                 }
                 // Explicitly disallow keys shorter than 40-bits for security
                 if (minKeySize < 40) minKeySize = 40;

--- a/jdk/src/share/classes/sun/security/pkcs11/P11Signature.java
+++ b/jdk/src/share/classes/sun/security/pkcs11/P11Signature.java
@@ -370,8 +370,9 @@ final class P11Signature extends SignatureSpi {
             // skip the check if no native info available
             return;
         }
-        int minKeySize = (int) mechInfo.ulMinKeySize;
-        int maxKeySize = (int) mechInfo.ulMaxKeySize;
+        int minKeySize = mechInfo.iMinKeySize;
+        int maxKeySize = mechInfo.iMaxKeySize;
+
         // need to override the MAX keysize for SHA1withDSA
         if (md != null && mechanism == CKM_DSA && maxKeySize > 1024) {
                maxKeySize = 1024;
@@ -395,11 +396,11 @@ final class P11Signature extends SignatureSpi {
                     " key must be the right type", cce);
             }
         }
-        if ((minKeySize != -1) && (keySize < minKeySize)) {
+        if (keySize < minKeySize) {
             throw new InvalidKeyException(keyAlgo +
                 " key must be at least " + minKeySize + " bits");
         }
-        if ((maxKeySize != -1) && (keySize > maxKeySize)) {
+        if (keySize > maxKeySize) {
             throw new InvalidKeyException(keyAlgo +
                 " key must be at most " + maxKeySize + " bits");
         }

--- a/jdk/src/share/classes/sun/security/pkcs11/wrapper/CK_MECHANISM_INFO.java
+++ b/jdk/src/share/classes/sun/security/pkcs11/wrapper/CK_MECHANISM_INFO.java
@@ -1,4 +1,28 @@
 /*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
  * reserved comment block
  * DO NOT REMOVE OR ALTER!
  */
@@ -47,7 +71,7 @@
 
 package sun.security.pkcs11.wrapper;
 
-
+import java.security.ProviderException;
 
 /**
  * class CK_MECHANISM_INFO provides information about a particular mechanism.
@@ -74,6 +98,10 @@ public class CK_MECHANISM_INFO {
      */
     public long ulMinKeySize;
 
+    // the integer version of ulMinKeySize for doing the actual range
+    // check in SunPKCS11 provider, defaults to 0
+    public final int iMinKeySize;
+
     /**
      * <B>PKCS#11:</B>
      * <PRE>
@@ -81,6 +109,10 @@ public class CK_MECHANISM_INFO {
      * </PRE>
      */
     public long ulMaxKeySize;
+
+    // the integer version of ulMaxKeySize for doing the actual range
+    // check in SunPKCS11 provider, defaults to Integer.MAX_VALUE
+    public final int iMaxKeySize;
 
     /**
      * <B>PKCS#11:</B>
@@ -94,6 +126,10 @@ public class CK_MECHANISM_INFO {
                              long flags) {
         this.ulMinKeySize = minKeySize;
         this.ulMaxKeySize = maxKeySize;
+        this.iMinKeySize = ((minKeySize < Integer.MAX_VALUE && minKeySize > 0)?
+                (int)minKeySize : 0);
+        this.iMaxKeySize = ((maxKeySize < Integer.MAX_VALUE && maxKeySize > 0)?
+                (int)maxKeySize : Integer.MAX_VALUE);
         this.flags = flags;
     }
 


### PR DESCRIPTION
This is backport of JDK-8183107 [1]. When dealt with different paths on jdk8, patch extracted from jdk project applied cleanly except for copyright line P11Signature.java file, which already has newer year then what is in changest (so this change is excluded).
```
git apply -p3 --directory=jdk/src --reject 0001-8183107-PKCS11-regression-regarding-checkKeySize.patch
Checking patch jdk/src/share/classes/sun/security/pkcs11/P11KeyGenerator.java...
Checking patch jdk/src/share/classes/sun/security/pkcs11/P11KeyPairGenerator.java...
Checking patch jdk/src/share/classes/sun/security/pkcs11/P11Signature.java...
error: while searching for:
/*
 * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 *
 * This code is free software; you can redistribute it and/or modify it

error: patch failed: jdk/src/share/classes/sun/security/pkcs11/P11Signature.java:1
Hunk #2 succeeded at 370 (offset -24 lines).
Hunk #3 succeeded at 396 (offset -24 lines).
Checking patch jdk/src/share/classes/sun/security/pkcs11/wrapper/CK_MECHANISM_INFO.java...
Applied patch jdk/src/share/classes/sun/security/pkcs11/P11KeyGenerator.java cleanly.
Applied patch jdk/src/share/classes/sun/security/pkcs11/P11KeyPairGenerator.java cleanly.
Applying patch jdk/src/share/classes/sun/security/pkcs11/P11Signature.java with 1 reject...
Rejected hunk #1.
Hunk #2 applied cleanly.
Hunk #3 applied cleanly.
Applied patch jdk/src/share/classes/sun/security/pkcs11/wrapper/CK_MECHANISM_INFO.java cleanly.
```

Tested locally, no regressions seen in jdk_security tests.
This backport is done with intention of later also backporting JDK-8232950 [2], which depends on this one.

[1] https://bugs.openjdk.org/browse/JDK-8183107
[2] https://bugs.openjdk.org/browse/JDK-8232950

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8183107](https://bugs.openjdk.org/browse/JDK-8183107): PKCS11 regression regarding checkKeySize


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/98/head:pull/98` \
`$ git checkout pull/98`

Update a local copy of the PR: \
`$ git checkout pull/98` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/98/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 98`

View PR using the GUI difftool: \
`$ git pr show -t 98`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/98.diff">https://git.openjdk.org/jdk8u-dev/pull/98.diff</a>

</details>
