### PR TITLE
8175797: (ref) Reference::enqueue method should clear the reference object before enqueuing

### DIFF
--- a/jdk/src/share/classes/java/lang/ref/FinalReference.java
+++ b/jdk/src/share/classes/java/lang/ref/FinalReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,5 +32,10 @@ class FinalReference<T> extends Reference<T> {
 
     public FinalReference(T referent, ReferenceQueue<? super T> q) {
         super(referent, q);
+    }
+
+    @Override
+    public boolean enqueue() {
+        throw new InternalError("should never reach here");
     }
 }

--- a/jdk/src/share/classes/java/lang/ref/Reference.java
+++ b/jdk/src/share/classes/java/lang/ref/Reference.java
@@ -265,7 +265,6 @@ public abstract class Reference<T> {
         this.referent = null;
     }
 
-
     /* -- Queue operations -- */
 
     /**
@@ -282,8 +281,8 @@ public abstract class Reference<T> {
     }
 
     /**
-     * Adds this reference object to the queue with which it is registered,
-     * if any.
+     * Clears this reference object and adds it to the queue with which
+     * it is registered, if any.
      *
      * <p> This method is invoked only by Java code; when the garbage collector
      * enqueues references it does so directly, without invoking this method.
@@ -293,9 +292,9 @@ public abstract class Reference<T> {
      *           it was not registered with a queue when it was created
      */
     public boolean enqueue() {
+        this.referent = null;
         return this.queue.enqueue(this);
     }
-
 
     /* -- Constructors -- */
 
@@ -307,5 +306,4 @@ public abstract class Reference<T> {
         this.referent = referent;
         this.queue = (queue == null) ? ReferenceQueue.NULL : queue;
     }
-
 }


### PR DESCRIPTION
These changes backport JDK-8175797 and two very closely related fixes (8178832 and 8193780) to jdk8u-dev:

    8175797: (ref) Reference::enqueue method should clear the reference object before enqueuing
    8178832: (ref) jdk.lang.ref.disableClearBeforeEnqueue property is ignored
    8193780: (ref) Remove the undocumented jdk.lang.ref.disableClearBeforeEnqueue system property

With these changes, the enqueue method clears the reference before enqueuing it to the registered queue.

It is a clean port from jdk8u-ri.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8175797](https://bugs.openjdk.org/browse/JDK-8175797): (ref) Reference::enqueue method should clear the reference object before enqueuing
 * [JDK-8178832](https://bugs.openjdk.org/browse/JDK-8178832): (ref) jdk.lang.ref.disableClearBeforeEnqueue property is ignored
 * [JDK-8193780](https://bugs.openjdk.org/browse/JDK-8193780): (ref) Remove the undocumented "jdk.lang.ref.disableClearBeforeEnqueue" system property


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - Author)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/99/head:pull/99` \
`$ git checkout pull/99`

Update a local copy of the PR: \
`$ git checkout pull/99` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/99/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 99`

View PR using the GUI difftool: \
`$ git pr show -t 99`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/99.diff">https://git.openjdk.org/jdk8u-dev/pull/99.diff</a>

</details>
