### PR TITLE
8285400: Add '@apiNote' to the APIs defined in Java SE 8 MR 3

### DIFF
--- a/jdk/src/share/classes/java/security/Signature.java
+++ b/jdk/src/share/classes/java/security/Signature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -591,8 +591,6 @@ public abstract class Signature extends SignatureSpi {
      * is not encoded properly or does not include required  parameter
      * information or cannot be used for digital signature purposes.
      * @exception InvalidAlgorithmParameterException if the params is invalid.
-     *
-     * @since 8
      */
     final void initVerify(Certificate certificate,
             AlgorithmParameterSpec params)

--- a/jdk/src/share/classes/java/security/interfaces/RSAKey.java
+++ b/jdk/src/share/classes/java/security/interfaces/RSAKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,6 +56,7 @@ public interface RSAKey {
      * explicitly specified or implicitly created during
      * key pair generation.
      *
+     * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
      * @implSpec
      * The default implementation returns {@code null}.
      *

--- a/jdk/src/share/classes/java/security/spec/MGF1ParameterSpec.java
+++ b/jdk/src/share/classes/java/security/spec/MGF1ParameterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -98,12 +98,18 @@ public class MGF1ParameterSpec implements AlgorithmParameterSpec {
 
     /**
      * The MGF1ParameterSpec which uses SHA-512/224 message digest
+     *
+     * @apiNote This field is defined in Java SE 8 Maintenance Release 3.
+     * @since 8
      */
     public static final MGF1ParameterSpec SHA512_224 =
         new MGF1ParameterSpec("SHA-512/224");
 
     /**
      * The MGF1ParameterSpec which uses SHA-512/256 message digest
+     *
+     * @apiNote This field is defined in Java SE 8 Maintenance Release 3.
+     * @since 8
      */
     public static final MGF1ParameterSpec SHA512_256 =
         new MGF1ParameterSpec("SHA-512/256");

--- a/jdk/src/share/classes/java/security/spec/PSSParameterSpec.java
+++ b/jdk/src/share/classes/java/security/spec/PSSParameterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -96,6 +96,7 @@ public class PSSParameterSpec implements AlgorithmParameterSpec {
     /**
      * The {@code TrailerFieldBC} constant as defined in PKCS#1
      *
+     * @apiNote This field is defined in Java SE 8 Maintenance Release 3.
      * @since 8
      */
     public static final int TRAILER_FIELD_BC = 1;

--- a/jdk/src/share/classes/java/security/spec/RSAKeyGenParameterSpec.java
+++ b/jdk/src/share/classes/java/security/spec/RSAKeyGenParameterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,6 +70,7 @@ public class RSAKeyGenParameterSpec implements AlgorithmParameterSpec {
      * Constructs a new {@code RSAKeyGenParameterSpec} object from the
      * given keysize, public-exponent value, and key parameters.
      *
+     * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
      * @param keysize the modulus size (specified in number of bits)
      * @param publicExponent the public exponent
      * @param keyParams the key parameters, may be null
@@ -103,6 +104,7 @@ public class RSAKeyGenParameterSpec implements AlgorithmParameterSpec {
     /**
      * Returns the parameters to be associated with key.
      *
+     * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
      * @return the associated parameters, may be null if
      *         not present
      * @since 8

--- a/jdk/src/share/classes/java/security/spec/RSAMultiPrimePrivateCrtKeySpec.java
+++ b/jdk/src/share/classes/java/security/spec/RSAMultiPrimePrivateCrtKeySpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -104,6 +104,7 @@ public class RSAMultiPrimePrivateCrtKeySpec extends RSAPrivateKeySpec {
     * are copied to protect against subsequent modification when
     * constructing this object.
     *
+    * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
     * @param modulus          the modulus n
     * @param publicExponent   the public exponent e
     * @param privateExponent  the private exponent d

--- a/jdk/src/share/classes/java/security/spec/RSAPrivateCrtKeySpec.java
+++ b/jdk/src/share/classes/java/security/spec/RSAPrivateCrtKeySpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,6 +81,7 @@ public class RSAPrivateCrtKeySpec extends RSAPrivateKeySpec {
     * Creates a new {@code RSAPrivateCrtKeySpec} with additional
     * key parameters.
     *
+    * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
     * @param modulus the modulus n
     * @param publicExponent the public exponent e
     * @param privateExponent the private exponent d

--- a/jdk/src/share/classes/java/security/spec/RSAPrivateKeySpec.java
+++ b/jdk/src/share/classes/java/security/spec/RSAPrivateKeySpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,6 +60,7 @@ public class RSAPrivateKeySpec implements KeySpec {
     /**
      * Creates a new RSAPrivateKeySpec with additional key parameters.
      *
+     * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
      * @param modulus the modulus
      * @param privateExponent the private exponent
      * @param params the parameters associated with this key, may be null
@@ -94,6 +95,7 @@ public class RSAPrivateKeySpec implements KeySpec {
      * Returns the parameters associated with this key, may be null if not
      * present.
      *
+     * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
      * @return the parameters associated with this key
      * @since 8
      */

--- a/jdk/src/share/classes/java/security/spec/RSAPublicKeySpec.java
+++ b/jdk/src/share/classes/java/security/spec/RSAPublicKeySpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 20220, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,6 +60,7 @@ public class RSAPublicKeySpec implements KeySpec {
     /**
      * Creates a new RSAPublicKeySpec with additional key parameters.
      *
+     * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
      * @param modulus the modulus
      * @param publicExponent the public exponent
      * @param params the parameters associated with this key, may be null
@@ -95,6 +96,7 @@ public class RSAPublicKeySpec implements KeySpec {
      * Returns the parameters associated with this key, may be null if not
      * present.
      *
+     * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
      * @return the parameters associated with this key
      * @since 8
      */

--- a/jdk/src/share/classes/java/security/spec/RSAPublicKeySpec.java
+++ b/jdk/src/share/classes/java/security/spec/RSAPublicKeySpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 20220, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/jdk/src/share/classes/javax/net/ssl/SSLEngine.java
+++ b/jdk/src/share/classes/javax/net/ssl/SSLEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1265,6 +1265,7 @@ public abstract class SSLEngine {
      * Application-Layer Protocol Negotiation (ALPN), can negotiate
      * application-level values between peers.
      *
+     * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
      * @implSpec
      * The implementation in this class throws
      * {@code UnsupportedOperationException} and performs no other action.
@@ -1290,6 +1291,7 @@ public abstract class SSLEngine {
      * a connection may be in the middle of a handshake. The
      * application protocol may or may not yet be available.
      *
+     * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
      * @implSpec
      * The implementation in this class throws
      * {@code UnsupportedOperationException} and performs no other action.
@@ -1350,7 +1352,8 @@ public abstract class SSLEngine {
      *         });
      * }</pre>
      *
-     * @apiNote
+     * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
+     * <p>
      * This method should be called by TLS server applications before the TLS
      * handshake begins. Also, this {@code SSLEngine} should be configured with
      * parameters that are compatible with the application protocol selected by
@@ -1380,6 +1383,7 @@ public abstract class SSLEngine {
      * setHandshakeApplicationProtocolSelector}
      * for the function's type parameters.
      *
+     * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
      * @implSpec
      * The implementation in this class throws
      * {@code UnsupportedOperationException} and performs no other action.

--- a/jdk/src/share/classes/javax/net/ssl/SSLParameters.java
+++ b/jdk/src/share/classes/javax/net/ssl/SSLParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -486,6 +486,7 @@ public class SSLParameters {
      * <p>
      * This method will return a new array each time it is invoked.
      *
+     * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
      * @return a non-null, possibly zero-length array of application protocol
      *         {@code String}s.  The array is ordered based on protocol
      *         preference, with {@code protocols[0]} being the most preferred.
@@ -518,6 +519,7 @@ public class SSLParameters {
      * action to take.  (For example, ALPN will send a
      * {@code "no_application_protocol"} alert and terminate the connection.)
      *
+     * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
      * @implSpec
      * This method will make a copy of the {@code protocols} array.
      *

--- a/jdk/src/share/classes/javax/net/ssl/SSLSocket.java
+++ b/jdk/src/share/classes/javax/net/ssl/SSLSocket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -674,6 +674,7 @@ public abstract class SSLSocket extends Socket
      * Application-Layer Protocol Negotiation (ALPN), can negotiate
      * application-level values between peers.
      *
+     * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
      * @implSpec
      * The implementation in this class throws
      * {@code UnsupportedOperationException} and performs no other action.
@@ -699,6 +700,7 @@ public abstract class SSLSocket extends Socket
      * a connection may be in the middle of a handshake. The
      * application protocol may or may not yet be available.
      *
+     * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
      * @implSpec
      * The implementation in this class throws
      * {@code UnsupportedOperationException} and performs no other action.
@@ -760,7 +762,8 @@ public abstract class SSLSocket extends Socket
      *         });
      * }</pre>
      *
-     * @apiNote
+     * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
+     * <p>
      * This method should be called by TLS server applications before the TLS
      * handshake begins. Also, this {@code SSLSocket} should be configured with
      * parameters that are compatible with the application protocol selected by
@@ -789,6 +792,7 @@ public abstract class SSLSocket extends Socket
      * setHandshakeApplicationProtocolSelector}
      * for the function's type parameters.
      *
+     * @apiNote This method is defined in Java SE 8 Maintenance Release 3.
      * @implSpec
      * The implementation in this class throws
      * {@code UnsupportedOperationException} and performs no other action.


### PR DESCRIPTION
This changeset is a backport of JDK-8285400 from jdk8u-ri to jdk8u-dev. It is a clean backport other than the manual update of the copyright years.

This change adds "apiNote This method is defined in Java SE 8 Maintenance Release 3." to the doc comments of the new APIs added with the following changesets in Java SE MR3 :

    https://hg.openjdk.java.net/jdk8u/jdk8u41/jdk/rev/b26b096d4c89
    https://hg.openjdk.java.net/jdk8u/jdk8u41/jdk/rev/6bada58189de

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285400](https://bugs.openjdk.org/browse/JDK-8285400): Add '@apiNote' to the APIs defined in Java SE 8 MR 3


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - Author)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/103/head:pull/103` \
`$ git checkout pull/103`

Update a local copy of the PR: \
`$ git checkout pull/103` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/103/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 103`

View PR using the GUI difftool: \
`$ git pr show -t 103`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/103.diff">https://git.openjdk.org/jdk8u-dev/pull/103.diff</a>

</details>
