### PR TITLE
8195607: sun/security/pkcs11/Secmod/TestNssDbSqlite.java failed with "NSS initialization failed" on NSS 3.34.1

### DIFF
--- a/jdk/src/share/classes/sun/security/pkcs11/Secmod.java
+++ b/jdk/src/share/classes/sun/security/pkcs11/Secmod.java
@@ -206,7 +206,7 @@ public final class Secmod {
 
         if (configDir != null) {
             String configDirPath = null;
-            String sqlPrefix = "sql:/";
+            String sqlPrefix = "sql:";
             if (!configDir.startsWith(sqlPrefix)) {
                 configDirPath = configDir;
             } else {

--- a/jdk/src/solaris/native/sun/security/pkcs11/j2secmod_md.h
+++ b/jdk/src/solaris/native/sun/security/pkcs11/j2secmod_md.h
@@ -34,6 +34,10 @@ typedef int (*FPTR_Initialize)(const char *configdir,
         const char *certPrefix, const char *keyPrefix,
         const char *secmodName, unsigned int flags);
 
+#ifdef SECMOD_DEBUG
+typedef int (*FPTR_GetError)(void);
+#endif //SECMOD_DEBUG
+
 // in secmod.h
 //extern SECMODModule *SECMOD_LoadModule(char *moduleSpec,SECMODModule *parent,
 //                                                      PRBool recurse);

--- a/jdk/test/sun/security/pkcs11/Secmod/pkcs11.txt
+++ b/jdk/test/sun/security/pkcs11/Secmod/pkcs11.txt
@@ -1,0 +1,4 @@
+library=
+name=NSS Internal PKCS #11 Module
+parameters=configdir='sql:./tmpdb' certPrefix='' keyPrefix='' secmod='' flags= updatedir='' updateCertPrefix='' updateKeyPrefix='' updateid='' updateTokenDescription='' 
+NSS=Flags=internal,critical trustOrder=75 cipherOrder=100 slotParams=(1={slotFlags=[RSA,DSA,DH,RC2,RC4,DES,RANDOM,SHA1,MD5,MD2,SSL,TLS,AES,Camellia,SEED,SHA256,SHA512] askpw=any timeout=30})

--- a/jdk/test/sun/security/pkcs11/SecmodTest.java
+++ b/jdk/test/sun/security/pkcs11/SecmodTest.java
@@ -26,11 +26,6 @@
 
 import java.io.*;
 
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.security.Provider;
 
 public class SecmodTest extends PKCS11Test {
@@ -65,10 +60,9 @@ public class SecmodTest extends PKCS11Test {
             System.setProperty("pkcs11test.nss.db", DBDIR);
         }
         File dbdirFile = new File(DBDIR);
-        if (dbdirFile.exists()) {
-            deleteDir(dbdirFile.toPath());
+        if (dbdirFile.exists() == false) {
+            dbdirFile.mkdir();
         }
-        dbdirFile.mkdir();
 
         if (useSqlite) {
             copyFile("key4.db", BASE, DBDIR);
@@ -95,25 +89,6 @@ public class SecmodTest extends PKCS11Test {
         }
         in.close();
         out.close();
-    }
-
-    private static void deleteDir(final Path directory) throws IOException {
-        Files.walkFileTree(directory, new SimpleFileVisitor<Path>() {
-
-            @Override
-            public FileVisitResult visitFile(Path file,
-                    BasicFileAttributes attrs) throws IOException {
-                Files.delete(file);
-                return FileVisitResult.CONTINUE;
-            }
-
-            @Override
-            public FileVisitResult postVisitDirectory(Path dir, IOException exc)
-                    throws IOException {
-                Files.delete(dir);
-                return FileVisitResult.CONTINUE;
-            }
-        });
     }
 
     public void main(Provider p) throws Exception {

--- a/jdk/test/sun/security/pkcs11/SecmodTest.java
+++ b/jdk/test/sun/security/pkcs11/SecmodTest.java
@@ -26,6 +26,11 @@
 
 import java.io.*;
 
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.security.Provider;
 
 public class SecmodTest extends PKCS11Test {
@@ -60,9 +65,10 @@ public class SecmodTest extends PKCS11Test {
             System.setProperty("pkcs11test.nss.db", DBDIR);
         }
         File dbdirFile = new File(DBDIR);
-        if (dbdirFile.exists() == false) {
-            dbdirFile.mkdir();
+        if (dbdirFile.exists()) {
+            deleteDir(dbdirFile.toPath());
         }
+        dbdirFile.mkdir();
 
         if (useSqlite) {
             copyFile("key4.db", BASE, DBDIR);
@@ -89,6 +95,25 @@ public class SecmodTest extends PKCS11Test {
         }
         in.close();
         out.close();
+    }
+
+    private static void deleteDir(final Path directory) throws IOException {
+        Files.walkFileTree(directory, new SimpleFileVisitor<Path>() {
+
+            @Override
+            public FileVisitResult visitFile(Path file,
+                    BasicFileAttributes attrs) throws IOException {
+                Files.delete(file);
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory(Path dir, IOException exc)
+                    throws IOException {
+                Files.delete(dir);
+                return FileVisitResult.CONTINUE;
+            }
+        });
     }
 
     public void main(Provider p) throws Exception {

--- a/jdk/test/sun/security/pkcs11/SecmodTest.java
+++ b/jdk/test/sun/security/pkcs11/SecmodTest.java
@@ -55,7 +55,7 @@ public class SecmodTest extends PKCS11Test {
 
         DBDIR = System.getProperty("test.classes", ".") + SEP + "tmpdb";
         if (useSqlite) {
-            System.setProperty("pkcs11test.nss.db", "sql:/" + DBDIR);
+            System.setProperty("pkcs11test.nss.db", "sql:" + DBDIR);
         } else {
             System.setProperty("pkcs11test.nss.db", DBDIR);
         }
@@ -67,6 +67,7 @@ public class SecmodTest extends PKCS11Test {
         if (useSqlite) {
             copyFile("key4.db", BASE, DBDIR);
             copyFile("cert9.db", BASE, DBDIR);
+            copyFile("pkcs11.txt", BASE, DBDIR);
         } else {
             copyFile("secmod.db", BASE, DBDIR);
             copyFile("key3.db", BASE, DBDIR);


### PR DESCRIPTION
Hi,

I'd like to propose the backport of the JDK-8195607 fix to 8u because this release is affected by this issue. Given that the legacy NSS DB has been deprecated for a long time and it's increasingly replaced by SQLite DBs, the chances that JDK-8 builds hit this problem are now higher.

The 11u backport applies cleanly, once paths are fixed.

To minimize risks, I manually debugged the OpenJDK code that connected to an NSS DB using the sql: prefix and everything was as expected.

I also run all the tests under the jdk/sun/security/pkcs11 category and noticed no-regressions strictly related to this fix. The test 'jdk/sun/security/pkcs11/Secmod/TrustAnchors.java' requires a special note, though. This test passes if run standalone but fails when run as part of a group. The reason is because when run as part of a group, other tests copy the file 'pkcs11.txt' to the temporary nssdb directory which is shared between all of them. This DB does not register the trust anchors module called 'Builtin Roots Module', which was available in the old secmod.db and is required by the test (which expects to see a Secmod$Module of TRUSTANCHOR type). While the test leaves the sun.security.pkcs11.SecmodTest::useSqlite field set to false and tries to access the legacy DB (also contained in the shared temporary nssdb directory), NSS realizes that there is a new SQLite DB in the same directory and reads the configuration from pkcs11.txt. Otherwise, if pkcs11.txt does not exist (as when the test is run standalone), it creates one with the information in secmod.db and it registers the 'Builtin Roots Module' module. All these findings have been verified with the 'modutil -list' command. While the issue is unrelated to what JDK-8195607 fixes, it has been uncovered by the existence of the pkcs11.txt file introduced with this change.

Why newer releases are not affected? Because jtreg runs tests (including TrustAnchors.java) in separated directories, so they don't share the nssdb temporary directory. In newer releases, TEST.ROOT has a requiredVersion attribute [1] indicating to jtreg that this can be done [2].

I've analyzed several ways to fix this issue but the one that I'd like to propose is to clean up the temporary nssdb directory for every test and avoid conflicts, giving every test the isolation that jtreg does when it sets test.classes uniquely per test in newer JDK releases.

Thanks,
Martin.-

--
[1] - https://github.com/openjdk/jdk11u/blob/master/test/jdk/TEST.ROOT#L61
[2] - https://github.com/openjdk/jtreg/blob/jtreg-6.2%2B1/src/share/classes/com/sun/javatest/regtest/config/Locations.java#L174

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8195607](https://bugs.openjdk.org/browse/JDK-8195607): sun/security/pkcs11/Secmod/TestNssDbSqlite.java failed with "NSS initialization failed" on NSS 3.34.1


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/106/head:pull/106` \
`$ git checkout pull/106`

Update a local copy of the PR: \
`$ git checkout pull/106` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/106/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 106`

View PR using the GUI difftool: \
`$ git pr show -t 106`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/106.diff">https://git.openjdk.org/jdk8u-dev/pull/106.diff</a>

</details>
