### PR TITLE
8232950: SUNPKCS11 Provider incorrectly check key length for PSS Signatures.

### DIFF
--- a/jdk/src/share/classes/sun/security/pkcs11/P11PSSSignature.java
+++ b/jdk/src/share/classes/sun/security/pkcs11/P11PSSSignature.java
@@ -341,9 +341,6 @@ final class P11PSSSignature extends SignatureSpi {
 
         int keySize = 0; // in bytes
         if (mechInfo != null) {
-            // check against available native info
-            int minKeySize = (int) mechInfo.ulMinKeySize;
-            int maxKeySize = (int) mechInfo.ulMaxKeySize;
             if (key instanceof P11Key) {
                 keySize = (((P11Key) key).length() + 7) >> 3;
             } else if (key instanceof RSAKey) {
@@ -351,13 +348,16 @@ final class P11PSSSignature extends SignatureSpi {
             } else {
                 throw new InvalidKeyException("Unrecognized key type " + key);
             }
-            if ((minKeySize != -1) && (keySize < minKeySize)) {
+            // check against available native info which are in bits
+            if ((mechInfo.iMinKeySize != 0) &&
+                    (keySize < (mechInfo.iMinKeySize >> 3))) {
                 throw new InvalidKeyException(KEY_ALGO +
-                    " key must be at least " + minKeySize + " bytes");
+                    " key must be at least " + mechInfo.iMinKeySize + " bits");
             }
-            if ((maxKeySize != -1) && (keySize > maxKeySize)) {
+            if ((mechInfo.iMaxKeySize != Integer.MAX_VALUE) &&
+                    (keySize > (mechInfo.iMaxKeySize >> 3))) {
                 throw new InvalidKeyException(KEY_ALGO +
-                    " key must be at most " + maxKeySize + " bytes");
+                    " key must be at most " + mechInfo.iMaxKeySize + " bits");
             }
         }
         if (this.sigParams != null) {


### PR DESCRIPTION
This is backport of JDK-8183107 [1]. When dealt with different paths on jdk8, patch extracted from jdk project applied cleanly.
```
git apply -p3 --dir=jdk/src 0001-8232950-SUNPKCS11-Provider-incorrectly-check-key-len.patch
```
Tested locally, no regressions in jdk_security tests.

[1] https://bugs.openjdk.org/browse/JDK-8232950

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8232950](https://bugs.openjdk.org/browse/JDK-8232950): SUNPKCS11 Provider incorrectly check key length for PSS Signatures.


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/109/head:pull/109` \
`$ git checkout pull/109`

Update a local copy of the PR: \
`$ git checkout pull/109` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/109/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 109`

View PR using the GUI difftool: \
`$ git pr show -t 109`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/109.diff">https://git.openjdk.org/jdk8u-dev/pull/109.diff</a>

</details>
