### PR TITLE
8292762: Remove .jcheck directories from jdk8u subcomponents

### DIFF
--- a/corba/.jcheck/conf
+++ b/corba/.jcheck/conf
@@ -1,2 +1,0 @@
-project=jdk8
-bugids=dup

--- a/hotspot/.jcheck/conf
+++ b/hotspot/.jcheck/conf
@@ -1,2 +1,0 @@
-project=jdk8
-bugids=dup

--- a/jaxp/.jcheck/conf
+++ b/jaxp/.jcheck/conf
@@ -1,2 +1,0 @@
-project=jdk8
-bugids=dup

--- a/jaxws/.jcheck/conf
+++ b/jaxws/.jcheck/conf
@@ -1,2 +1,0 @@
-project=jdk8
-bugids=dup

--- a/jdk/.jcheck/conf
+++ b/jdk/.jcheck/conf
@@ -1,2 +1,0 @@
-project=jdk8
-bugids=dup

--- a/langtools/.jcheck/conf
+++ b/langtools/.jcheck/conf
@@ -1,2 +1,0 @@
-project=jdk8
-bugids=dup

--- a/nashorn/.jcheck/conf
+++ b/nashorn/.jcheck/conf
@@ -1,2 +1,0 @@
-project=jdk8
-bugids=dup


### PR DESCRIPTION
After the consolidation of jdk8u into a single mono-style repo there is no longer a need to have the .jcheck configuration files in each of the subcomponent directories. These can now be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292762](https://bugs.openjdk.org/browse/JDK-8292762): Remove .jcheck directories from jdk8u subcomponents


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/110/head:pull/110` \
`$ git checkout pull/110`

Update a local copy of the PR: \
`$ git checkout pull/110` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/110/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 110`

View PR using the GUI difftool: \
`$ git pr show -t 110`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/110.diff">https://git.openjdk.org/jdk8u-dev/pull/110.diff</a>

</details>
