### PR TITLE
8039955: [TESTBUG] jdk/lambda/LambdaTranslationTest1 - java.lang.AssertionError: expected [d:1234.000000] but found [d:1234,000000]

### DIFF
--- a/jdk/test/jdk/lambda/LambdaTranslationTest1.java
+++ b/jdk/test/jdk/lambda/LambdaTranslationTest1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -137,7 +137,7 @@ public class LambdaTranslationTest1 extends LT1Sub {
 
         LT1IA da = LambdaTranslationTest1::deye;
         da.doit(1234);
-        assertResult("d:1234.000000");
+        assertResult(String.format("d:%f", 1234.0));
 
         LT1SA a = LambdaTranslationTest1::count;
         assertEquals((Integer) 5, a.doit("howdy"));

--- a/jdk/test/jdk/lambda/LambdaTranslationTest2.java
+++ b/jdk/test/jdk/lambda/LambdaTranslationTest2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -200,7 +200,7 @@ public class LambdaTranslationTest2 {
         assertEquals("b1 s2", ws1.m((byte) 1, (short) 2));
 
         WidenD wd1 = LambdaTranslationTest2::pwD1;
-        assertEquals("f1.000000 d2.000000", wd1.m(1.0f, 2.0));
+        assertEquals(String.format("f%f d%f", 1.0f, 2.0), wd1.m(1.0f, 2.0));
 
         WidenI wi1 = LambdaTranslationTest2::pwI1;
         assertEquals("b1 s2 c3 i4", wi1.m((byte) 1, (short) 2, (char) 3, 4));
@@ -221,12 +221,16 @@ public class LambdaTranslationTest2 {
 
     public void testUnboxing() {
         Unbox u = LambdaTranslationTest2::pu;
-        assertEquals("b1 s2 cA i4 j5 ztrue f6.000000 d7.000000", u.m((byte)1, (short) 2, 'A', 4, 5L, true, 6.0f, 7.0));
+        String expected = String.format("b%d s%d c%c i%d j%d z%b f%f d%f",
+                                    (byte)1, (short) 2, 'A', 4, 5L, true, 6.0f, 7.0);
+        assertEquals(expected, u.m((byte)1, (short) 2, 'A', 4, 5L, true, 6.0f, 7.0));
     }
 
     public void testBoxing() {
         Box b = LambdaTranslationTest2::pb;
-        assertEquals("b1 s2 cA i4 j5 ztrue f6.000000 d7.000000", b.m((byte) 1, (short) 2, 'A', 4, 5L, true, 6.0f, 7.0));
+        String expected = String.format("b%d s%d c%c i%d j%d z%b f%f d%f",
+                                    (byte) 1, (short) 2, 'A', 4, 5L, true,  6.0f, 7.0);
+        assertEquals(expected, b.m((byte) 1, (short) 2, 'A', 4, 5L, true, 6.0f, 7.0));
     }
 
     static boolean cc(Object o) {


### PR DESCRIPTION
This is backport of JDK-8039955 [1]. 

Two tests from jdk_tier1 are sensitive to locale of test machine (expect "." as decimal separator), which causes failures when running on some locales, such as czech (which uses "," as decimal separator ). This backport fixes this issue.

Patch with changes applies cleanly:
```
git apply 0001-8039955-TESTBUG-jdk-lambda-LambdaTranslationTest1-ja.patch
```

Tested locally using czech locale, 2 tests in jdk_tier1 get fixed, no regressions.

[1] https://bugs.openjdk.org/browse/JDK-8039955

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8039955](https://bugs.openjdk.org/browse/JDK-8039955): [TESTBUG] jdk/lambda/LambdaTranslationTest1 - java.lang.AssertionError: expected [d:1234.000000] but found [d:1234,000000]


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/112/head:pull/112` \
`$ git checkout pull/112`

Update a local copy of the PR: \
`$ git checkout pull/112` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/112/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 112`

View PR using the GUI difftool: \
`$ git pr show -t 112`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/112.diff">https://git.openjdk.org/jdk8u-dev/pull/112.diff</a>

</details>
