### PR TITLE
JDK-8292998: Clean Secmod temporary NSS DB directory before test execution

### DIFF
--- a/jdk/test/sun/security/pkcs11/SecmodTest.java
+++ b/jdk/test/sun/security/pkcs11/SecmodTest.java
@@ -26,6 +26,11 @@
 
 import java.io.*;
 
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.security.Provider;
 
 public class SecmodTest extends PKCS11Test {
@@ -60,9 +65,10 @@ public class SecmodTest extends PKCS11Test {
             System.setProperty("pkcs11test.nss.db", DBDIR);
         }
         File dbdirFile = new File(DBDIR);
-        if (dbdirFile.exists() == false) {
-            dbdirFile.mkdir();
+        if (dbdirFile.exists()) {
+            deleteDir(dbdirFile.toPath());
         }
+        dbdirFile.mkdir();
 
         if (useSqlite) {
             copyFile("key4.db", BASE, DBDIR);
@@ -88,6 +94,25 @@ public class SecmodTest extends PKCS11Test {
         }
         in.close();
         out.close();
+    }
+
+    private static void deleteDir(final Path directory) throws IOException {
+        Files.walkFileTree(directory, new SimpleFileVisitor<Path>() {
+
+            @Override
+            public FileVisitResult visitFile(Path file,
+                    BasicFileAttributes attrs) throws IOException {
+                Files.delete(file);
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory(Path dir, IOException exc)
+                    throws IOException {
+                Files.delete(dir);
+                return FileVisitResult.CONTINUE;
+            }
+        });
     }
 
     public void main(Provider p) throws Exception {


### PR DESCRIPTION
Hello,

I'd like to propose this fix as described in https://bugs.openjdk.org/browse/JDK-8292998

The temporary directory used by Secmod tests to copy NSS DB files is deleted (which includes all its files and, potentially, subdirectories) and created empty again before running the test. I decided to implement the recursive delete function here for 3 reasons: 1) it's a short and simple function,  2) convenience (we don't have to link every current Secmod test to a test library) and 3) increase chances of backporting future Secmod tests cleanly. Contrary to the approach of setting a minimum jtreg version required, the scope of this change are Secmod tests only and the risk should be minimal.

Thanks,
Martin.-

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8292998](https://bugs.openjdk.org/browse/JDK-8292998): Clean Secmod temporary NSS DB directory before test execution


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/115/head:pull/115` \
`$ git checkout pull/115`

Update a local copy of the PR: \
`$ git checkout pull/115` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/115/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 115`

View PR using the GUI difftool: \
`$ git pr show -t 115`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/115.diff">https://git.openjdk.org/jdk8u-dev/pull/115.diff</a>

</details>
