### PR TITLE
8274563: jfr/event/oldobject/TestClassLoaderLeak.java fails when GC cycles are not happening

### DIFF
--- a/jdk/test/jdk/jfr/event/oldobject/TestClassLoaderLeak.java
+++ b/jdk/test/jdk/jfr/event/oldobject/TestClassLoaderLeak.java
@@ -45,7 +45,7 @@ import jdk.test.lib.jfr.Events;
  *
  * @library /lib /
  *
- * @run main/othervm -XX:TLABSize=2k jdk.jfr.event.oldobject.TestClassLoaderLeak
+ * @run main/othervm -XX:TLABSize=2k -Xmx128m jdk.jfr.event.oldobject.TestClassLoaderLeak
  */
 public class TestClassLoaderLeak {
 


### PR DESCRIPTION
Not a clean backport. This change does not need to remove this line because it does not exist:

```
* @requires vm.gc != "Serial"
```

passing tests on my local machine. I've seen reports that max heap size needs to be decreased further for more consistent tests on other machines, so we should also backport https://bugs.openjdk.org/browse/JDK-8293828 after this.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8274563](https://bugs.openjdk.org/browse/JDK-8274563): jfr/event/oldobject/TestClassLoaderLeak.java fails when GC cycles are not happening


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/120/head:pull/120` \
`$ git checkout pull/120`

Update a local copy of the PR: \
`$ git checkout pull/120` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/120/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 120`

View PR using the GUI difftool: \
`$ git pr show -t 120`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/120.diff">https://git.openjdk.org/jdk8u-dev/pull/120.diff</a>

</details>
