### PR TITLE
8206456: [TESTBUG] docker jtreg tests fail on systems without cpuset.effective_cpus / cpuset.effective_mems

### DIFF
--- a/jdk/test/jdk/internal/platform/docker/MetricsCpuTester.java
+++ b/jdk/test/jdk/internal/platform/docker/MetricsCpuTester.java
@@ -95,10 +95,13 @@ public class MetricsCpuTester {
                     + Arrays.toString(ipCpuSet) + ", got : " + Arrays.toString(cpuSets));
         }
 
-        if (!Arrays.equals(ipCpuSet, effectiveCpus)) {
-            throw new RuntimeException("Effective Cpusets not equal, expected : "
-                    + Arrays.toString(ipCpuSet) + ", got : "
-                    + Arrays.toString(effectiveCpus));
+        // Check to see if this metric is supported on this platform
+        if (effectiveCpus.length != 0) {
+            if (!Arrays.equals(ipCpuSet, effectiveCpus)) {
+                throw new RuntimeException("Effective Cpusets not equal, expected : "
+                        + Arrays.toString(ipCpuSet) + ", got : "
+                        + Arrays.toString(effectiveCpus));
+            }
         }
         System.out.println("TEST PASSED!!!");
     }
@@ -127,10 +130,13 @@ public class MetricsCpuTester {
                     + Arrays.toString(cpuSets));
         }
 
-        if (!Arrays.equals(ipCpuSet, effectiveMems)) {
-            throw new RuntimeException("Effective mem nodes not equal, expected : "
-                    + Arrays.toString(ipCpuSet) + ", got : "
-                    + Arrays.toString(effectiveMems));
+        // Check to see if this metric is supported on this platform
+        if (effectiveMems.length != 0) {
+            if (!Arrays.equals(ipCpuSet, effectiveMems)) {
+                throw new RuntimeException("Effective mem nodes not equal, expected : "
+                        + Arrays.toString(ipCpuSet) + ", got : "
+                        + Arrays.toString(effectiveMems));
+            }
         }
         System.out.println("TEST PASSED!!!");
     }


### PR DESCRIPTION
This is a backport of 6fc4db4799599df66a2cf5207068336ce68136ff to jdk8u-dev.

It's a test-only change, that I wish to backport as part of cgroups v2 support. Whilst not directly cgroups v2 specific, this will ease further backports by reducing merge conflicts.

The original commit touched two files: MetricsCpuTester.java and MetricsTester.java. This backport only touches MetricsCpuTester.java. The changes from the original comit to MetricsTester.java were already merged into jdk8u-dev with "8223147: JFR Backport...".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8206456](https://bugs.openjdk.org/browse/JDK-8206456): [TESTBUG] docker jtreg tests fail on systems without cpuset.effective_cpus / cpuset.effective_mems


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/123/head:pull/123` \
`$ git checkout pull/123`

Update a local copy of the PR: \
`$ git checkout pull/123` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/123/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 123`

View PR using the GUI difftool: \
`$ git pr show -t 123`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/123.diff">https://git.openjdk.org/jdk8u-dev/pull/123.diff</a>

</details>
