### PR TITLE
8240189: [TESTBUG] Some cgroup tests are failing after JDK-8231111

### DIFF
--- a/jdk/test/jdk/internal/platform/docker/MetricsCpuTester.java
+++ b/jdk/test/jdk/internal/platform/docker/MetricsCpuTester.java
@@ -24,6 +24,7 @@
 import java.util.Arrays;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+
 import jdk.internal.platform.Metrics;
 
 public class MetricsCpuTester {
@@ -96,7 +97,7 @@ public class MetricsCpuTester {
         }
 
         // Check to see if this metric is supported on this platform
-        if (effectiveCpus.length != 0) {
+        if (effectiveCpus != null) {
             if (!Arrays.equals(ipCpuSet, effectiveCpus)) {
                 throw new RuntimeException("Effective Cpusets not equal, expected : "
                         + Arrays.toString(ipCpuSet) + ", got : "
@@ -131,7 +132,7 @@ public class MetricsCpuTester {
         }
 
         // Check to see if this metric is supported on this platform
-        if (effectiveMems.length != 0) {
+        if (effectiveMems != null) {
             if (!Arrays.equals(ipCpuSet, effectiveMems)) {
                 throw new RuntimeException("Effective mem nodes not equal, expected : "
                         + Arrays.toString(ipCpuSet) + ", got : "

--- a/jdk/test/jdk/internal/platform/docker/MetricsMemoryTester.java
+++ b/jdk/test/jdk/internal/platform/docker/MetricsMemoryTester.java
@@ -135,7 +135,7 @@ public class MetricsMemoryTester {
                             + kmemlimit + "]");
             }
         } else {
-            throw new RuntimeException("oomKillFlag test not supported for cgroups v2");
+            throw new RuntimeException("kernel memory limit test not supported for cgroups v2");
         }
     }
 

--- a/jdk/test/lib/jdk/test/lib/containers/cgroup/CgroupMetricsTester.java
+++ b/jdk/test/lib/jdk/test/lib/containers/cgroup/CgroupMetricsTester.java
@@ -25,6 +25,7 @@ package jdk.test.lib.containers.cgroup;
 
 import java.io.IOException;
 import java.math.BigInteger;
+import java.util.Arrays;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -41,9 +42,9 @@ interface CgroupMetricsTester {
     public void testMemoryUsage() throws Exception;
     public void testMisc();
 
-    public static long convertStringToLong(String strval, long overflowRetval) {
-        long retval = 0;
-        if (strval == null) return 0L;
+    public static long convertStringToLong(String strval, long initialVal, long overflowRetval) {
+        long retval = initialVal;
+        if (strval == null) return retval;
 
         try {
             retval = Long.parseLong(strval);
@@ -93,7 +94,7 @@ interface CgroupMetricsTester {
 
     public static Integer[] convertCpuSetsToArray(String cpusstr) {
         if (cpusstr == null || EMPTY_STR.equals(cpusstr)) {
-            return new Integer[0];
+            return null;
         }
         // Parse range string in the format 1,2-6,7
         Integer[] cpuSets = Stream.of(cpusstr.split(",")).flatMap(a -> {
@@ -106,6 +107,21 @@ interface CgroupMetricsTester {
             }
         }).toArray(Integer[]::new);
         return cpuSets;
+    }
+
+    public static Integer[] boxedArrayOrNull(int[] primitiveArray) {
+        if (primitiveArray == null) {
+            return null;
+        }
+        return Arrays.stream(primitiveArray).boxed().toArray(Integer[]::new);
+    }
+
+    public static Integer[] sortAllowNull(Integer[] array) {
+        if (array == null) {
+            return null;
+        }
+        Arrays.sort(array);
+        return array;
     }
 
 }

--- a/jdk/test/lib/jdk/test/lib/containers/cgroup/MetricsTesterCgroupV1.java
+++ b/jdk/test/lib/jdk/test/lib/containers/cgroup/MetricsTesterCgroupV1.java
@@ -38,11 +38,15 @@ import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
-import jdk.internal.platform.Metrics;
+import jdk.internal.platform.CgroupSubsystem;
 import jdk.internal.platform.CgroupV1Metrics;
+import jdk.internal.platform.Metrics;
+import jdk.test.lib.Asserts;
 
 public class MetricsTesterCgroupV1 implements CgroupMetricsTester {
 
+    // Aliased for readability
+    private static final long RETVAL_UNAVAILABLE = CgroupSubsystem.LONG_RETVAL_UNLIMITED;
     private static long unlimited_minimum = 0x7FFFFFFFFF000000L;
     long startSysVal;
     long startUserVal;
@@ -127,9 +131,6 @@ public class MetricsTesterCgroupV1 implements CgroupMetricsTester {
         startUserVal = metrics.getCpuUserUsage();
         startUsage = metrics.getCpuUsage();
         startPerCpu = metrics.getPerCpuUsage();
-        if (startPerCpu == null) {
-            startPerCpu = new long[0];
-        }
 
         try {
             Stream<String> lines = Files.lines(Paths.get("/proc/self/mountinfo"));
@@ -159,11 +160,11 @@ public class MetricsTesterCgroupV1 implements CgroupMetricsTester {
 
     private static long getLongValueFromFile(Controller subSystem, String fileName) {
         String data = getFileContents(subSystem, fileName);
-        return (data == null || data.isEmpty()) ? 0L : convertStringToLong(data);
+        return (data == null || data.isEmpty()) ? RETVAL_UNAVAILABLE : convertStringToLong(data);
     }
 
     private static long convertStringToLong(String strval) {
-        return CgroupMetricsTester.convertStringToLong(strval, Long.MAX_VALUE);
+        return CgroupMetricsTester.convertStringToLong(strval, RETVAL_UNAVAILABLE, Long.MAX_VALUE);
     }
 
     private static long getLongValueFromFile(Controller subSystem, String metric, String subMetric) {
@@ -175,12 +176,12 @@ public class MetricsTesterCgroupV1 implements CgroupMetricsTester {
                 return convertStringToLong(strval);
             }
         }
-        return 0L;
+        return RETVAL_UNAVAILABLE;
     }
 
     private static double getDoubleValueFromFile(Controller subSystem, String fileName) {
         String data = getFileContents(subSystem, fileName);
-        return data.isEmpty() ? 0.0 : Double.parseDouble(data);
+        return data == null || data.isEmpty() ? RETVAL_UNAVAILABLE : Double.parseDouble(data);
     }
 
     private static void fail(Controller system, String metric, long oldVal, long testVal) {
@@ -203,6 +204,13 @@ public class MetricsTesterCgroupV1 implements CgroupMetricsTester {
         CgroupMetricsTester.warn(system.value, metric, oldVal, testVal);
     }
 
+    private Long[] boxedArrayOrNull(long[] primitiveArray) {
+        if (primitiveArray == null) {
+            return null;
+        }
+        return LongStream.of(primitiveArray).boxed().toArray(Long[]::new);
+    }
+
     public void testMemorySubsystem() {
         CgroupV1Metrics metrics = (CgroupV1Metrics)Metrics.systemMetrics();
 
@@ -215,7 +223,7 @@ public class MetricsTesterCgroupV1 implements CgroupMetricsTester {
 
         oldVal = metrics.getMemoryLimit();
         newVal = getLongValueFromFile(Controller.MEMORY, "memory.limit_in_bytes");
-        newVal = newVal > unlimited_minimum ? -1L : newVal;
+        newVal = newVal > unlimited_minimum ? CgroupSubsystem.LONG_RETVAL_UNLIMITED : newVal;
         if (!CgroupMetricsTester.compareWithErrorMargin(oldVal, newVal)) {
             fail(Controller.MEMORY, "memory.limit_in_bytes", oldVal, newVal);
         }
@@ -241,7 +249,7 @@ public class MetricsTesterCgroupV1 implements CgroupMetricsTester {
 
         oldVal = metrics.getKernelMemoryLimit();
         newVal = getLongValueFromFile(Controller.MEMORY, "memory.kmem.limit_in_bytes");
-        newVal = newVal > unlimited_minimum ? -1L : newVal;
+        newVal = newVal > unlimited_minimum ? CgroupSubsystem.LONG_RETVAL_UNLIMITED : newVal;
         if (!CgroupMetricsTester.compareWithErrorMargin(oldVal, newVal)) {
             fail(Controller.MEMORY, "memory.kmem.limit_in_bytes", oldVal, newVal);
         }
@@ -267,7 +275,7 @@ public class MetricsTesterCgroupV1 implements CgroupMetricsTester {
 
         oldVal = metrics.getTcpMemoryLimit();
         newVal = getLongValueFromFile(Controller.MEMORY, "memory.kmem.tcp.limit_in_bytes");
-        newVal = newVal > unlimited_minimum ? -1L : newVal;
+        newVal = newVal > unlimited_minimum ? CgroupSubsystem.LONG_RETVAL_UNLIMITED: newVal;
         if (!CgroupMetricsTester.compareWithErrorMargin(oldVal, newVal)) {
             fail(Controller.MEMORY, "memory.kmem.tcp.limit_in_bytes", oldVal, newVal);
         }
@@ -295,7 +303,7 @@ public class MetricsTesterCgroupV1 implements CgroupMetricsTester {
 
             oldVal = metrics.getMemoryAndSwapLimit();
             newVal = getLongValueFromFile(Controller.MEMORY, "memory.memsw.limit_in_bytes");
-            newVal = newVal > unlimited_minimum ? -1L : newVal;
+            newVal = newVal > unlimited_minimum ? CgroupSubsystem.LONG_RETVAL_UNLIMITED : newVal;
             if (!CgroupMetricsTester.compareWithErrorMargin(oldVal, newVal)) {
                 fail(Controller.MEMORY, "memory.memsw.limit_in_bytes", oldVal, newVal);
             }
@@ -318,7 +326,7 @@ public class MetricsTesterCgroupV1 implements CgroupMetricsTester {
 
         oldVal = metrics.getMemorySoftLimit();
         newVal = getLongValueFromFile(Controller.MEMORY, "memory.soft_limit_in_bytes");
-        newVal = newVal > unlimited_minimum ? -1L : newVal;
+        newVal = newVal > unlimited_minimum ? CgroupSubsystem.LONG_RETVAL_UNLIMITED : newVal;
         if (!CgroupMetricsTester.compareWithErrorMargin(oldVal, newVal)) {
             fail(Controller.MEMORY, "memory.soft_limit_in_bytes", oldVal, newVal);
         }
@@ -343,20 +351,22 @@ public class MetricsTesterCgroupV1 implements CgroupMetricsTester {
         }
 
         String newValsStr = getFileContents(Controller.CPUACCT, "cpuacct.usage_percpu");
-        Long[] newVals = new Long[0];
+        Long[] newVals = null;
         if (newValsStr != null) {
             newVals = Stream.of(newValsStr
                 .split("\\s+"))
                 .map(Long::parseLong)
                 .toArray(Long[]::new);
         }
-        long[] oldValsPrim = metrics.getPerCpuUsage();
-        Long[] oldVals = LongStream.of(oldValsPrim == null ? new long[0] : oldValsPrim)
-                                    .boxed().toArray(Long[]::new);
-        for (int i = 0; i < oldVals.length; i++) {
-            if (!CgroupMetricsTester.compareWithErrorMargin(oldVals[i], newVals[i])) {
-                warn(Controller.CPUACCT, "cpuacct.usage_percpu", oldVals[i], newVals[i]);
+        Long[] oldVals = boxedArrayOrNull(metrics.getPerCpuUsage());
+        if (oldVals != null) {
+            for (int i = 0; i < oldVals.length; i++) {
+                if (!CgroupMetricsTester.compareWithErrorMargin(oldVals[i], newVals[i])) {
+                    warn(Controller.CPUACCT, "cpuacct.usage_percpu", oldVals[i], newVals[i]);
+                }
             }
+        } else {
+            Asserts.assertNull(newVals, Controller.CPUACCT.value() + "cpuacct.usage_percpu not both null");
         }
 
         oldVal = metrics.getCpuUserUsage();
@@ -414,13 +424,13 @@ public class MetricsTesterCgroupV1 implements CgroupMetricsTester {
 
     public void testCpuSets() {
         CgroupV1Metrics metrics = (CgroupV1Metrics)Metrics.systemMetrics();
-        Integer[] oldVal = Arrays.stream(metrics.getCpuSetCpus()).boxed().toArray(Integer[]::new);
-        Arrays.sort(oldVal);
+        Integer[] oldVal = CgroupMetricsTester.boxedArrayOrNull(metrics.getCpuSetCpus());
+        oldVal = CgroupMetricsTester.sortAllowNull(oldVal);
 
         String cpusstr = getFileContents(Controller.CPUSET, "cpuset.cpus");
         // Parse range string in the format 1,2-6,7
         Integer[] newVal = CgroupMetricsTester.convertCpuSetsToArray(cpusstr);
-        Arrays.sort(newVal);
+        newVal = CgroupMetricsTester.sortAllowNull(newVal);
         if (!Arrays.equals(oldVal, newVal)) {
             fail(Controller.CPUSET, "cpuset.cpus", Arrays.toString(oldVal),
                 Arrays.toString(newVal));
@@ -428,24 +438,21 @@ public class MetricsTesterCgroupV1 implements CgroupMetricsTester {
 
         int [] cpuSets = metrics.getEffectiveCpuSetCpus();
 
-        // Skip this test if this metric is not supported on this platform
-        if (cpuSets.length != 0) {
-            oldVal = Arrays.stream(cpuSets).boxed().toArray(Integer[]::new);
-            Arrays.sort(oldVal);
-            cpusstr = getFileContents(Controller.CPUSET, "cpuset.effective_cpus");
-            newVal = CgroupMetricsTester.convertCpuSetsToArray(cpusstr);
-            Arrays.sort(newVal);
-            if (!Arrays.equals(oldVal, newVal)) {
-                fail(Controller.CPUSET, "cpuset.effective_cpus", Arrays.toString(oldVal),
-                        Arrays.toString(newVal));
-            }
+        oldVal = CgroupMetricsTester.boxedArrayOrNull(cpuSets);
+        oldVal = CgroupMetricsTester.sortAllowNull(oldVal);
+        cpusstr = getFileContents(Controller.CPUSET, "cpuset.effective_cpus");
+        newVal = CgroupMetricsTester.convertCpuSetsToArray(cpusstr);
+        newVal = CgroupMetricsTester.sortAllowNull(newVal);
+        if (!Arrays.equals(oldVal, newVal)) {
+            fail(Controller.CPUSET, "cpuset.effective_cpus", Arrays.toString(oldVal),
+                    Arrays.toString(newVal));
         }
 
-        oldVal = Arrays.stream(metrics.getCpuSetMems()).boxed().toArray(Integer[]::new);
-        Arrays.sort(oldVal);
+        oldVal = CgroupMetricsTester.boxedArrayOrNull(metrics.getCpuSetMems());
+        oldVal = CgroupMetricsTester.sortAllowNull(oldVal);
         cpusstr = getFileContents(Controller.CPUSET, "cpuset.mems");
         newVal = CgroupMetricsTester.convertCpuSetsToArray(cpusstr);
-        Arrays.sort(newVal);
+        newVal = CgroupMetricsTester.sortAllowNull(newVal);
         if (!Arrays.equals(oldVal, newVal)) {
             fail(Controller.CPUSET, "cpuset.mems", Arrays.toString(oldVal),
                     Arrays.toString(newVal));
@@ -453,17 +460,14 @@ public class MetricsTesterCgroupV1 implements CgroupMetricsTester {
 
         int [] cpuSetMems = metrics.getEffectiveCpuSetMems();
 
-        // Skip this test if this metric is not supported on this platform
-        if (cpuSetMems.length != 0) {
-            oldVal = Arrays.stream(cpuSetMems).boxed().toArray(Integer[]::new);
-            Arrays.sort(oldVal);
-            cpusstr = getFileContents(Controller.CPUSET, "cpuset.effective_mems");
-            newVal = CgroupMetricsTester.convertCpuSetsToArray(cpusstr);
-            Arrays.sort(newVal);
-            if (!Arrays.equals(oldVal, newVal)) {
-                fail(Controller.CPUSET, "cpuset.effective_mems", Arrays.toString(oldVal),
-                        Arrays.toString(newVal));
-            }
+        oldVal = CgroupMetricsTester.boxedArrayOrNull(cpuSetMems);
+        oldVal = CgroupMetricsTester.sortAllowNull(oldVal);
+        cpusstr = getFileContents(Controller.CPUSET, "cpuset.effective_mems");
+        newVal = CgroupMetricsTester.convertCpuSetsToArray(cpusstr);
+        newVal = CgroupMetricsTester.sortAllowNull(newVal);
+        if (!Arrays.equals(oldVal, newVal)) {
+            fail(Controller.CPUSET, "cpuset.effective_mems", Arrays.toString(oldVal),
+                    Arrays.toString(newVal));
         }
 
         double oldValue = metrics.getCpuSetMemoryPressure();
@@ -504,9 +508,6 @@ public class MetricsTesterCgroupV1 implements CgroupMetricsTester {
         long newUserVal = metrics.getCpuUserUsage();
         long newUsage = metrics.getCpuUsage();
         long[] newPerCpu = metrics.getPerCpuUsage();
-        if (newPerCpu == null) {
-            newPerCpu = new long[0];
-        }
 
         // system/user CPU usage counters may be slowly increasing.
         // allow for equal values for a pass
@@ -524,16 +525,22 @@ public class MetricsTesterCgroupV1 implements CgroupMetricsTester {
             fail(Controller.CPU, "getCpuUsage", newUsage, startUsage);
         }
 
-        boolean success = false;
-        for (int i = 0; i < startPerCpu.length; i++) {
-            if (newPerCpu[i] > startPerCpu[i]) {
-                success = true;
-                break;
+        if (startPerCpu != null) {
+            boolean success = false;
+            for (int i = 0; i < startPerCpu.length; i++) {
+                if (newPerCpu[i] > startPerCpu[i]) {
+                    success = true;
+                    break;
+                }
             }
+            if (!success) {
+                fail(Controller.CPU, "getPerCpuUsage", Arrays.toString(newPerCpu),
+                                                       Arrays.toString(startPerCpu));
+            }
+        } else {
+            Asserts.assertNull(newPerCpu, Controller.CPU.value() + " getPerCpuUsage not both null");
         }
 
-        if(!success) fail(Controller.CPU, "getPerCpuUsage", Arrays.toString(newPerCpu),
-                Arrays.toString(startPerCpu));
     }
 
     public void testMemoryUsage() throws Exception {

--- a/jdk/test/lib/jdk/test/lib/containers/cgroup/MetricsTesterCgroupV2.java
+++ b/jdk/test/lib/jdk/test/lib/containers/cgroup/MetricsTesterCgroupV2.java
@@ -32,12 +32,12 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import jdk.internal.platform.CgroupSubsystem;
 import jdk.internal.platform.Metrics;
 
 public class MetricsTesterCgroupV2 implements CgroupMetricsTester {
 
     private static final long UNLIMITED = -1;
+    private static final long NOT_AVAILABLE = -1;
     private static final UnifiedController UNIFIED = new UnifiedController();
     private static final String MAX = "max";
     private static final int PER_CPU_SHARES = 1024;
@@ -125,7 +125,7 @@ public class MetricsTesterCgroupV2 implements CgroupMetricsTester {
             String value = keyValues[1];
             return convertStringToLong(value);
         } catch (IOException e) {
-            return 0;
+            return NOT_AVAILABLE;
         }
     }
 
@@ -152,7 +152,7 @@ public class MetricsTesterCgroupV2 implements CgroupMetricsTester {
 
     private long getCpuShares(String file) {
         long rawVal = getLongValueFromFile(file);
-        if (rawVal == 0 || rawVal == 100) {
+        if (rawVal == NOT_AVAILABLE || rawVal == 100) {
             return UNLIMITED;
         }
         int shares = (int)rawVal;
@@ -200,7 +200,14 @@ public class MetricsTesterCgroupV2 implements CgroupMetricsTester {
     }
 
     private long convertStringToLong(String val) {
-        return CgroupMetricsTester.convertStringToLong(val, UNLIMITED);
+        return CgroupMetricsTester.convertStringToLong(val, NOT_AVAILABLE, UNLIMITED);
+    }
+
+    private long nanosOrUnlimited(long micros) {
+        if (micros < 0) {
+            return UNLIMITED;
+        }
+        return TimeUnit.MICROSECONDS.toNanos(micros);
     }
 
     @Override
@@ -265,20 +272,20 @@ public class MetricsTesterCgroupV2 implements CgroupMetricsTester {
     public void testCpuAccounting() {
         Metrics metrics = Metrics.systemMetrics();
         long oldVal = metrics.getCpuUsage();
-        long newVal = TimeUnit.MICROSECONDS.toNanos(getLongValueEntryFromFile("cpu.stat", "usage_usec"));
+        long newVal = nanosOrUnlimited(getLongValueEntryFromFile("cpu.stat", "usage_usec"));
 
         if (!CgroupMetricsTester.compareWithErrorMargin(oldVal, newVal)) {
             warn("cpu.stat[usage_usec]", oldVal, newVal);
         }
 
         oldVal = metrics.getCpuUserUsage();
-        newVal = TimeUnit.MICROSECONDS.toNanos(getLongValueEntryFromFile("cpu.stat", "user_usec"));
+        newVal = nanosOrUnlimited(getLongValueEntryFromFile("cpu.stat", "user_usec"));
         if (!CgroupMetricsTester.compareWithErrorMargin(oldVal, newVal)) {
             warn("cpu.stat[user_usec]", oldVal, newVal);
         }
 
         oldVal = metrics.getCpuSystemUsage();
-        newVal = TimeUnit.MICROSECONDS.toNanos(getLongValueEntryFromFile("cpu.stat", "system_usec"));
+        newVal = nanosOrUnlimited(getLongValueEntryFromFile("cpu.stat", "system_usec"));
         if (!CgroupMetricsTester.compareWithErrorMargin(oldVal, newVal)) {
             warn("cpu.stat[system_usec]", oldVal, newVal);
         }
@@ -318,7 +325,7 @@ public class MetricsTesterCgroupV2 implements CgroupMetricsTester {
         }
 
         oldVal = metrics.getCpuThrottledTime();
-        newVal = TimeUnit.MICROSECONDS.toNanos(getLongValueEntryFromFile("cpu.stat", "throttled_usec"));
+        newVal = nanosOrUnlimited(getLongValueEntryFromFile("cpu.stat", "throttled_usec"));
         if (!CgroupMetricsTester.compareWithErrorMargin(oldVal, newVal)) {
             fail("cpu.stat[throttled_usec]", oldVal, newVal);
         }
@@ -327,60 +334,47 @@ public class MetricsTesterCgroupV2 implements CgroupMetricsTester {
     @Override
     public void testCpuSets() {
         Metrics metrics = Metrics.systemMetrics();
-        int[] cpus = mapNullToEmpty(metrics.getCpuSetCpus());
-        Integer[] oldVal = Arrays.stream(cpus).boxed().toArray(Integer[]::new);
-        Arrays.sort(oldVal);
+        Integer[] oldVal = CgroupMetricsTester.boxedArrayOrNull(metrics.getCpuSetCpus());
+        oldVal = CgroupMetricsTester.sortAllowNull(oldVal);
 
         String cpusstr = getStringVal("cpuset.cpus");
         // Parse range string in the format 1,2-6,7
         Integer[] newVal = CgroupMetricsTester.convertCpuSetsToArray(cpusstr);
-        Arrays.sort(newVal);
+        newVal = CgroupMetricsTester.sortAllowNull(newVal);
         if (!Arrays.equals(oldVal, newVal)) {
             fail("cpuset.cpus", Arrays.toString(oldVal),
                                 Arrays.toString(newVal));
         }
 
-        cpus = mapNullToEmpty(metrics.getEffectiveCpuSetCpus());
-        oldVal = Arrays.stream(cpus).boxed().toArray(Integer[]::new);
-        Arrays.sort(oldVal);
+        oldVal = CgroupMetricsTester.boxedArrayOrNull(metrics.getEffectiveCpuSetCpus());
+        oldVal = CgroupMetricsTester.sortAllowNull(oldVal);
         cpusstr = getStringVal("cpuset.cpus.effective");
         newVal = CgroupMetricsTester.convertCpuSetsToArray(cpusstr);
-        Arrays.sort(newVal);
+        newVal = CgroupMetricsTester.sortAllowNull(newVal);
         if (!Arrays.equals(oldVal, newVal)) {
             fail("cpuset.cpus.effective", Arrays.toString(oldVal),
                                           Arrays.toString(newVal));
         }
 
-        cpus = mapNullToEmpty(metrics.getCpuSetMems());
-        oldVal = Arrays.stream(cpus).boxed().toArray(Integer[]::new);
-        Arrays.sort(oldVal);
+        oldVal = CgroupMetricsTester.boxedArrayOrNull(metrics.getCpuSetMems());
+        oldVal = CgroupMetricsTester.sortAllowNull(oldVal);
         cpusstr = getStringVal("cpuset.mems");
         newVal = CgroupMetricsTester.convertCpuSetsToArray(cpusstr);
-        Arrays.sort(newVal);
+        newVal = CgroupMetricsTester.sortAllowNull(newVal);
         if (!Arrays.equals(oldVal, newVal)) {
             fail("cpuset.mems", Arrays.toString(oldVal),
                                 Arrays.toString(newVal));
         }
 
-        cpus = mapNullToEmpty(metrics.getEffectiveCpuSetMems());
-        oldVal = Arrays.stream(cpus).boxed().toArray(Integer[]::new);
-        Arrays.sort(oldVal);
+        oldVal = CgroupMetricsTester.boxedArrayOrNull(metrics.getEffectiveCpuSetMems());
+        oldVal = CgroupMetricsTester.sortAllowNull(oldVal);
         cpusstr = getStringVal("cpuset.mems.effective");
         newVal = CgroupMetricsTester.convertCpuSetsToArray(cpusstr);
-        Arrays.sort(newVal);
+        newVal = CgroupMetricsTester.sortAllowNull(newVal);
         if (!Arrays.equals(oldVal, newVal)) {
             fail("cpuset.mems.effective", Arrays.toString(oldVal),
                                           Arrays.toString(newVal));
         }
-    }
-
-    private int[] mapNullToEmpty(int[] cpus) {
-        if (cpus == null) {
-            // Not available. For sake of testing continue with an
-            // empty array.
-            cpus = new int[0];
-        }
-        return cpus;
     }
 
     @Override
@@ -471,7 +465,7 @@ public class MetricsTesterCgroupV2 implements CgroupMetricsTester {
                         return accumulator;
                     }).collect(Collectors.summingLong(e -> e));
         } catch (IOException e) {
-            return CgroupSubsystem.LONG_RETVAL_UNLIMITED;
+            return NOT_AVAILABLE;
         }
     }
 }


### PR DESCRIPTION
This is a back port of 8240189: [TESTBUG] Some cgroup tests are failing after JDK-8231111
for jdk8u-dev as part of an effort to backport support for Cgroups V2.

The intention is for this PR to depend upon [8231111: 2Cgroups v2: Rework Metrics in java.base so as to recognize unified hierarchy](https://github.com/openjdk/jdk8u-dev/pull/121), which in turn depends upon [8206456: [TESTBUG] docker jtreg tests fail on systems without cpuset.effective_cpus / cpuset.effective_mems](https://github.com/openjdk/jdk8u-dev/pull/123), both of which are dependencies for this patch-set.

This backport is one commit on top of pr/121. It does not apply clean after path unshuffling: some of the patch contexts around `MetricsMemoryTester.java`,  `MetricsTesterCgroupV1.java` and  `MetricsTesterCgroupV2.java` differ due to changes made in pr/121 to adjust for jdk8u-dev support (replacing `Arrays.compare` with `Arrays.equals`)

I'll report back testing results to this PR, I have to untangle them a bit first.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8240189](https://bugs.openjdk.org/browse/JDK-8240189): [TESTBUG] Some cgroup tests are failing after JDK-8231111


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/124/head:pull/124` \
`$ git checkout pull/124`

Update a local copy of the PR: \
`$ git checkout pull/124` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/124/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 124`

View PR using the GUI difftool: \
`$ git pr show -t 124`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/124.diff">https://git.openjdk.org/jdk8u-dev/pull/124.diff</a>

</details>
