### PR TITLE
8253702: BigSur version number reported as 10.16, should be 11.nn

### DIFF
--- a/jdk/src/solaris/native/java/lang/java_props_macosx.c
+++ b/jdk/src/solaris/native/java/lang/java_props_macosx.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -191,15 +191,35 @@ void setOSNameAndVersion(java_props_t *sprops) {
         OSVerStruct osVer = procInfoFn([NSProcessInfo processInfo],
                                        @selector(operatingSystemVersion));
         NSString *nsVerStr;
-        if (osVer.patchVersion == 0) { // Omit trailing ".0"
-            nsVerStr = [NSString stringWithFormat:@"%ld.%ld",
-                    (long)osVer.majorVersion, (long)osVer.minorVersion];
+        // Copy out the char* if running on version other than 10.16 Mac OS (10.16 == 11.x)
+        // or explicitly requesting version compatibility
+        if (!((long)osVer.majorVersion == 10 && (long)osVer.minorVersion >= 16) ||
+                (getenv("SYSTEM_VERSION_COMPAT") != NULL)) {
+            if (osVer.patchVersion == 0) { // Omit trailing ".0"
+                nsVerStr = [NSString stringWithFormat:@"%ld.%ld",
+                        (long)osVer.majorVersion, (long)osVer.minorVersion];
+            } else {
+                nsVerStr = [NSString stringWithFormat:@"%ld.%ld.%ld",
+                        (long)osVer.majorVersion, (long)osVer.minorVersion, (long)osVer.patchVersion];
+            }
+            // Copy out the char*
+            osVersionCStr = strdup([nsVerStr UTF8String]);
         } else {
-            nsVerStr = [NSString stringWithFormat:@"%ld.%ld.%ld",
-                    (long)osVer.majorVersion, (long)osVer.minorVersion, (long)osVer.patchVersion];
+            // Version 10.16, without explicit env setting of SYSTEM_VERSION_COMPAT
+            // AKA 11.x; compute the version number from the letter in the ProductBuildVersion
+            NSDictionary *version = [NSDictionary dictionaryWithContentsOfFile :
+                             @"/System/Library/CoreServices/SystemVersion.plist"];
+            if (version != NULL) {
+                NSString *nsBuildVerStr = [version objectForKey : @"ProductBuildVersion"];
+                if (nsBuildVerStr != NULL && nsBuildVerStr.length >= 3) {
+                    int letter = [nsBuildVerStr characterAtIndex:2];
+                    if (letter >= 'B' && letter <= 'Z') {
+                        int vers = letter - 'A' - 1;
+                        asprintf(&osVersionCStr, "11.%d", vers);
+                    }
+                }
+            }
         }
-        // Copy out the char*
-        osVersionCStr = strdup([nsVerStr UTF8String]);
     }
     // Fallback if running on pre-10.9 Mac OS
     if (osVersionCStr == NULL) {


### PR DESCRIPTION
I'd like to backport JDK-8253702 to jdk8u in order to fix the incorrect version detection for macOS.

The patch applied manually due to the location difference:
`src/java.base/macosx/native/libjava/java_props_macosx.c` (source)
`jdk/src/solaris/native/java/lang/java_props_macosx.c` (destination)
But it's small and low risk. The changes are related only to one function `void setOSNameAndVersion(..)` within the single file. The patch is identical to the original one.

Tested with a simple test printing the OS version on macOS Big Sur:
```
public class Main {
    public static void main(String[] args) {
        System.out.println(System.getProperty("os.version"));
    }
}
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8253702](https://bugs.openjdk.org/browse/JDK-8253702): BigSur version number reported as 10.16, should be 11.nn


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/125/head:pull/125` \
`$ git checkout pull/125`

Update a local copy of the PR: \
`$ git checkout pull/125` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/125/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 125`

View PR using the GUI difftool: \
`$ git pr show -t 125`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/125.diff">https://git.openjdk.org/jdk8u-dev/pull/125.diff</a>

</details>
