### PR TITLE
8237479: 8230305 causes slowdebug build failure

### DIFF
--- a/hotspot/src/os/linux/vm/cgroupSubsystem_linux.hpp
+++ b/hotspot/src/os/linux/vm/cgroupSubsystem_linux.hpp
@@ -57,7 +57,7 @@ typedef char * cptr;
 
 class CgroupController: public CHeapObj<mtInternal> {
   public:
-    virtual char *subsystem_path();
+    virtual char *subsystem_path() = 0;
 };
 
 PRAGMA_DIAG_PUSH
@@ -246,19 +246,19 @@ class CgroupSubsystem: public CHeapObj<mtInternal> {
     jlong memory_limit_in_bytes();
     int active_processor_count();
 
-    virtual int cpu_quota();
-    virtual int cpu_period();
-    virtual int cpu_shares();
-    virtual jlong memory_usage_in_bytes();
-    virtual jlong memory_and_swap_limit_in_bytes();
-    virtual jlong memory_soft_limit_in_bytes();
-    virtual jlong memory_max_usage_in_bytes();
-    virtual char * cpu_cpuset_cpus();
-    virtual char * cpu_cpuset_memory_nodes();
-    virtual jlong read_memory_limit_in_bytes();
-    virtual const char * container_type();
-    virtual CachingCgroupController* memory_controller();
-    virtual CachingCgroupController* cpu_controller();
+    virtual int cpu_quota() = 0;
+    virtual int cpu_period() = 0;
+    virtual int cpu_shares() = 0;
+    virtual jlong memory_usage_in_bytes() = 0;
+    virtual jlong memory_and_swap_limit_in_bytes() = 0;
+    virtual jlong memory_soft_limit_in_bytes() = 0;
+    virtual jlong memory_max_usage_in_bytes() = 0;
+    virtual char * cpu_cpuset_cpus() = 0;
+    virtual char * cpu_cpuset_memory_nodes() = 0;
+    virtual jlong read_memory_limit_in_bytes() = 0;
+    virtual const char * container_type() = 0;
+    virtual CachingCgroupController* memory_controller() = 0;
+    virtual CachingCgroupController* cpu_controller() = 0;
 };
 
 class CgroupSubsystemFactory: AllStatic {


### PR DESCRIPTION
This is a backport of 8237479 to jdk8u-dev, as part of cgroups v2 support. It deepnds on 8230305 (pr/127) and I've set up the GitHub PR accordingly.

Apart from path shuffling, it applies clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8237479](https://bugs.openjdk.org/browse/JDK-8237479): 8230305 causes slowdebug build failure


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**) ⚠️ Review applies to [463f7511](https://git.openjdk.org/jdk8u-dev/pull/128/files/463f7511dd8b3525414c2a5d6911a30183d9781b)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/128/head:pull/128` \
`$ git checkout pull/128`

Update a local copy of the PR: \
`$ git checkout pull/128` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/128/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 128`

View PR using the GUI difftool: \
`$ git pr show -t 128`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/128.diff">https://git.openjdk.org/jdk8u-dev/pull/128.diff</a>

</details>
