### PR TITLE
8253714: [cgroups v2] Soft memory limit incorrectly using memory.high

### DIFF
--- a/hotspot/src/os/linux/vm/cgroupV2Subsystem_linux.cpp
+++ b/hotspot/src/os/linux/vm/cgroupV2Subsystem_linux.cpp
@@ -161,7 +161,7 @@ jlong CgroupV2Subsystem::memory_max_usage_in_bytes() {
 }
 
 char* CgroupV2Subsystem::mem_soft_limit_val() {
-  GET_CONTAINER_INFO_CPTR(cptr, _unified, "/memory.high",
+  GET_CONTAINER_INFO_CPTR(cptr, _unified, "/memory.low",
                          "Memory Soft Limit is: %s", "%s", mem_soft_limit_str, 1024);
   if (mem_soft_limit_str == NULL) {
     return NULL;

--- a/jdk/src/linux/classes/jdk/internal/platform/cgroupv2/CgroupV2Subsystem.java
+++ b/jdk/src/linux/classes/jdk/internal/platform/cgroupv2/CgroupV2Subsystem.java
@@ -292,7 +292,7 @@ public class CgroupV2Subsystem implements CgroupSubsystem {
 
     @Override
     public long getMemorySoftLimit() {
-        String softLimitStr = CgroupSubsystemController.getStringValue(unified, "memory.high");
+        String softLimitStr = CgroupSubsystemController.getStringValue(unified, "memory.low");
         return limitFromString(softLimitStr);
     }
 

--- a/jdk/test/lib/jdk/test/lib/containers/cgroup/MetricsTesterCgroupV2.java
+++ b/jdk/test/lib/jdk/test/lib/containers/cgroup/MetricsTesterCgroupV2.java
@@ -245,9 +245,9 @@ public class MetricsTesterCgroupV2 implements CgroupMetricsTester {
         }
 
         oldVal = metrics.getMemorySoftLimit();
-        newVal = getLongLimitValueFromFile("memory.high");
+        newVal = getLongLimitValueFromFile("memory.low");
         if (!CgroupMetricsTester.compareWithErrorMargin(oldVal, newVal)) {
-            fail("memory.high", oldVal, newVal);
+            fail("memory.low", oldVal, newVal);
         }
 
     }


### PR DESCRIPTION
This is a backport of a cgroupsv2 related change for jdk8u-dev.

----

The early implementation of cgroups v2 support was done with crun 0.8 and it contained a bug which set memory.high over memory.low when --memory-reservation was being used as a CLI option.

This bug has been fixed in later crun versions, starting with crun 0.11. Use memory.low in OpenJDK as well.

Backport-of: ff6843ca4842498791061f924c545fa9469cc1dc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8253714](https://bugs.openjdk.org/browse/JDK-8253714): [cgroups v2] Soft memory limit incorrectly using memory.high


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**) ⚠️ Review applies to [c6fad8b5](https://git.openjdk.org/jdk8u-dev/pull/130/files/c6fad8b52681c7eb1a10ceaab95cbb8173c66f13)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/130/head:pull/130` \
`$ git checkout pull/130`

Update a local copy of the PR: \
`$ git checkout pull/130` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/130/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 130`

View PR using the GUI difftool: \
`$ git pr show -t 130`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/130.diff">https://git.openjdk.org/jdk8u-dev/pull/130.diff</a>

</details>
