### PR TITLE
8295164: JDK 8 jdi tests should not use tasklist command on Windows

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -989,7 +989,6 @@ jobs:
   windows_x64_test:
     name: Windows x64
     runs-on: "windows-2019"
-    if: false
     needs:
       - prerequisites
       - windows_x64_build
@@ -999,15 +998,15 @@ jobs:
       matrix:
         test:
           - jdk/tier1
-          - langtools/tier1
-          - hotspot/tier1
+#          - langtools/tier1
+#          - hotspot/tier1
         include:
           - test: jdk/tier1
             suites: jdk_tier1
-          - test: langtools/tier1
-            suites: langtools_tier1
-          - test: hotspot/tier1
-            suites: hotspot_tier1
+#          - test: langtools/tier1
+#            suites: langtools_tier1
+#          - test: hotspot/tier1
+#            suites: hotspot_tier1
 
     env:
       JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).JDK_MAJOR_VERSION }}.${{ fromJson(needs.prerequisites.outputs.dependencies).JDK_MINOR_VERSION }}.${{ fromJson(needs.prerequisites.outputs.dependencies).JDK_MICRO_VERSION }}"
@@ -1135,7 +1134,6 @@ jobs:
   windows_x86_test:
     name: Windows x86
     runs-on: "windows-2019"
-    if: false
     needs:
       - prerequisites
       - windows_x86_build
@@ -1145,15 +1143,15 @@ jobs:
       matrix:
         test:
           - jdk/tier1
-          - langtools/tier1
-          - hotspot/tier1
+#          - langtools/tier1
+#          - hotspot/tier1
         include:
           - test: jdk/tier1
             suites: jdk_tier1
-          - test: langtools/tier1
-            suites: langtools_tier1
-          - test: hotspot/tier1
-            suites: hotspot_tier1
+#          - test: langtools/tier1
+#            suites: langtools_tier1
+#          - test: hotspot/tier1
+#            suites: hotspot_tier1
 
     env:
       JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).JDK_MAJOR_VERSION }}.${{ fromJson(needs.prerequisites.outputs.dependencies).JDK_MINOR_VERSION }}.${{ fromJson(needs.prerequisites.outputs.dependencies).JDK_MICRO_VERSION }}"

--- a/jdk/test/com/sun/jdi/ShellScaffold.sh
+++ b/jdk/test/com/sun/jdi/ShellScaffold.sh
@@ -201,9 +201,9 @@ findPid()
             res=$?
             ;;
         Windows* | CYGWIN*)
-            # Don't use ps on cygwin since it sometimes misses
-            # some processes (!).
-            tasklist /NH | $grep " $1 " > $devnull 2>&1
+            # No longer possible to use tasklist as Cygwin PIDs are no longer
+            # same as Windows PIDs
+            $psCmd | $grep '^ *'"$1 " > $devnull 2>&1
             res=$?
             ;;
        *)
@@ -281,7 +281,7 @@ EOF
          rm -f $tmpFile
          # on mks
          grep=egrep
-         psCmd=ps
+         psCmd="ps -W"
          jstack=jstack.exe
          ;;
        SunOS | Linux | Darwin | AIX)


### PR DESCRIPTION
Shell jdi tests are currently failing on windows. These tests are part of jdk_tier1.

**Problem:**
Tests fail because ShellScaffold.sh uses (native) tasklist command to check if process with given PID is alive. However this no longer works, since PIDs by Cygwin/Msys2 are no longer same as native Windows PIDs [1][2].

**Solution:**
Fixed by switching to ps command. Original comment says tasklist was used due to ps sometimes missing some processes. This could be because ps, by default, only shows cygwin processes. I added -W argument to also show native windows processes [3] and I have seen no problems. Fix is targeted for JDK8, since newer JDKs migrated to java based tests (in several steps [4][5][6][7]...), but i think backporting all of that work, just to fix this issue would be overkill. (However nothing prevents anyone from doing so in the future, if desired.)

**Testing:**
With this fix jdk_tier1 passes for me on Windows.

[1] https://github.com/msys2/MSYS2-packages/issues/1724
[2] https://cygwin.com/git/?p=newlib-cygwin.git;a=commit;h=b5e1003722cb14235c4f166be72c09acdffc62ea
[3] https://www.cygwin.com/cygwin-ug-net/ps.html
[4] https://bugs.openjdk.org/browse/JDK-8209109
[5] https://bugs.openjdk.org/browse/JDK-8209604
[6] https://bugs.openjdk.org/browse/JDK-8210243
[7] https://bugs.openjdk.org/browse/JDK-8210760

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295164](https://bugs.openjdk.org/browse/JDK-8295164): JDK 8 jdi tests should not use tasklist command on Windows


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/133/head:pull/133` \
`$ git checkout pull/133`

Update a local copy of the PR: \
`$ git checkout pull/133` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/133/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 133`

View PR using the GUI difftool: \
`$ git pr show -t 133`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/133.diff">https://git.openjdk.org/jdk8u-dev/pull/133.diff</a>

</details>
