### PR TITLE
8159599: [TEST_BUG] java/awt/Modal/ModalInternalFrameTest/ModalInternalFrameTest.java

### DIFF
--- a/jdk/test/java/awt/Focus/SimpleWindowActivationTest/SimpleWindowActivationTest.java
+++ b/jdk/test/java/awt/Focus/SimpleWindowActivationTest/SimpleWindowActivationTest.java
@@ -26,15 +26,24 @@
  * @bug       6385277
  * @summary   Tests that override redirect window gets activated on click.
  * @author    anton.tarasov@sun.com: area=awt.focus
- * @library   ../../regtesthelpers
- * @build     Util
  * @run       main SimpleWindowActivationTest
  */
-import java.awt.*;
-import java.awt.event.*;
-import java.util.concurrent.Callable;
-import javax.swing.SwingUtilities;
-import test.java.awt.regtesthelpers.Util;
+
+import java.awt.AWTEvent;
+import java.awt.Button;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Label;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.Toolkit;
+import java.awt.Window;
+import java.awt.event.AWTEventListener;
+import java.awt.event.FocusEvent;
+import java.awt.event.InputEvent;
+import java.awt.event.WindowEvent;
 
 public class SimpleWindowActivationTest {
 
@@ -64,9 +73,11 @@ public class SimpleWindowActivationTest {
 
         createAndShowWindow();
         robot.waitForIdle();
+        robot.delay(500);
 
         createAndShowFrame();
         robot.waitForIdle();
+        robot.delay(500);
 
         // click on Frame
         clickOn(getClickPoint(frame));
@@ -135,8 +146,8 @@ public class SimpleWindowActivationTest {
         robot.mouseMove(point.x, point.y);
         robot.waitForIdle();
 
-        robot.mousePress(InputEvent.BUTTON1_MASK);
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
 
         robot.waitForIdle();
     }


### PR DESCRIPTION
Backport for parity with Oracle.

Backport does not apply to ProblemList.txt because the affected test is not there in JDK8. Cleanly applies to SimpleWindowActivationTest.java after fixing paths.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8159599](https://bugs.openjdk.org/browse/JDK-8159599): [TEST_BUG] java/awt/Modal/ModalInternalFrameTest/ModalInternalFrameTest.java


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/134/head:pull/134` \
`$ git checkout pull/134`

Update a local copy of the PR: \
`$ git checkout pull/134` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/134/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 134`

View PR using the GUI difftool: \
`$ git pr show -t 134`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/134.diff">https://git.openjdk.org/jdk8u-dev/pull/134.diff</a>

</details>
