### PR TITLE
8054066: com/sun/jdi/DoubleAgentTest.java fails with timeout

### DIFF
--- a/jdk/test/com/sun/jdi/DoubleAgentTest.java
+++ b/jdk/test/com/sun/jdi/DoubleAgentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2014, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,137 +21,39 @@
  * questions.
  */
 
+import jdk.testlibrary.OutputAnalyzer;
+import jdk.testlibrary.ProcessTools;
+import jdk.testlibrary.Utils;
+
 /* @test
  * @bug 6354345
- * @summary Check that a double agent request fails
+ * @summary Check that multiple -agentlib statements in command line fails
  *
- * @build VMConnection DoubleAgentTest Exit0
- * @run main DoubleAgentTest
- *
+ * @library /lib/testlibrary
+ * @build jdk.testlibrary.*
+ * @build DoubleAgentTest Exit0
+ * @run driver DoubleAgentTest
  */
-import java.io.InputStream;
-import java.io.IOException;
-import java.io.File;
-import java.net.ServerSocket;
-import java.net.Socket;
 
 public class DoubleAgentTest {
 
-    static Object locker = new Object();
-    static String outputText = "";
+    private static final String TEST_CLASSES = System.getProperty(
+            "test.classes", ".");
 
-    /*
-     * Helper class to redirect process output/error
-     */
-    static class IOHandler implements Runnable {
-        InputStream in;
+    public static void main(String[] args) throws Throwable {
+        int port = Utils.getFreePort();
 
-        IOHandler(InputStream in) {
-            this.in = in;
-        }
-
-        static Thread handle(InputStream in) {
-            IOHandler handler = new IOHandler(in);
-            Thread thr = new Thread(handler);
-            thr.setDaemon(true);
-            thr.start();
-            return thr;
-        }
-
-        public void run() {
-            try {
-                byte b[] = new byte[100];
-                for (;;) {
-                    int n = in.read(b, 0, 100);
-                    // The first thing that will get read is
-                    //    Listening for transport dt_socket at address: xxxxx
-                    // which shows the debuggee is ready to accept connections.
-                    synchronized(locker) {
-                        locker.notify();
-                    }
-                    if (n < 0) {
-                        break;
-                    }
-                    String s = new String(b, 0, n, "UTF-8");
-                    System.out.print(s);
-                    synchronized(outputText) {
-                        outputText += s;
-                    }
-                }
-            } catch (IOException ioe) {
-                ioe.printStackTrace();
-            }
-        }
-
-    }
-
-    /*
-     * Launch a server debuggee with the given address
-     */
-    private static Process launch(String address, String class_name) throws IOException {
-        String exe =   System.getProperty("java.home")
-                     + File.separator + "bin" + File.separator + "java";
         String jdwpOption = "-agentlib:jdwp=transport=dt_socket"
-                         + ",server=y" + ",suspend=y" + ",address=" + address;
-        String cmd = exe + " " + VMConnection.getDebuggeeVMOptions()
-                         + " " + jdwpOption
-                         + " " + jdwpOption
-                         + " " + class_name;
+                         + ",server=y" + ",suspend=n" + ",address=*:" + String.valueOf(port);
 
-        System.out.println("Starting: " + cmd);
+        OutputAnalyzer output = ProcessTools.executeTestJvm("-classpath",
+                TEST_CLASSES,
+                jdwpOption, // Notice jdwpOption specified twice
+                jdwpOption,
+                "Exit0");
 
-        Process p = Runtime.getRuntime().exec(cmd);
-
-        return p;
-    }
-
-    /*
-     * - pick a TCP port
-     * - Launch a server debuggee that should fail
-     * - verify we saw error
-     */
-    public static void main(String args[]) throws Exception {
-        // find a free port
-        ServerSocket ss = new ServerSocket(0);
-        int port = ss.getLocalPort();
-        ss.close();
-
-        String address = String.valueOf(port);
-
-        // launch the server debuggee
-        Process process = launch(address, "Exit0");
-        Thread t1 = IOHandler.handle(process.getInputStream());
-        Thread t2 = IOHandler.handle(process.getErrorStream());
-
-        // wait for the debugge to be ready
-        synchronized(locker) {
-            locker.wait();
-        }
-
-        int exitCode = process.waitFor();
-        try {
-            t1.join();
-            t2.join();
-        } catch ( InterruptedException e ) {
-            e.printStackTrace();
-            throw new Exception("Debuggee failed InterruptedException");
-        }
-
-        if ( outputText.contains("capabilities") ) {
-            throw new Exception(
-                "Debuggee failed with ERROR about capabilities: " + outputText);
-        }
-
-        if ( !outputText.contains("ERROR") ) {
-            throw new Exception(
-                "Debuggee does not have ERROR in the output: " + outputText);
-        }
-
-        if ( exitCode == 0 ) {
-            throw new Exception(
-                "Debuggee should have failed with an non-zero exit code");
-        }
-
+        output.shouldContain("Cannot load this JVM TI agent twice");
+        output.shouldHaveExitValue(1);
     }
 
 }


### PR DESCRIPTION
Current form of `com/sun/jdi/DoubleAgentTest.java` has some problems, which should be fixed by this backport. Apart from problem mentioned in backported bug, test in current form also suffers race condition causing random failures (See my comment here: [1]) and should be fixed.

**Few notes about this backport:**
There was one intermediate change to DoubleAgentTest.java by JDK-6622468 [2]. But as that changeset modifies lot of files and only modifies DoubleAgentTest.java slightly, only to be basically rewritten from scratch by following changeset (the backported one). I decided to skip it (intermediate changeset) and go directly to rewritten test. Also there is a typo in changeset being backported, which was later fixed as part of JDK-8143583 [3] (which also does other stuff). I fixed this typo right away in this backport. I don't think backporting these 2 whole additional changesets (and dependent changesets) just because of this backport would be reasonable. Also I don't think including tiny part of these other changesets here would cause much problems even if someone decides backport them in the future.

**Testing:**
Test is part of jdk_tier1 and passes testing in GHA (results should appear here).

[1] https://github.com/openjdk/jdk8u-dev/pull/133#issuecomment-1276759194
[2] https://bugs.openjdk.org/browse/JDK-6622468
[3] https://bugs.openjdk.org/browse/JDK-8143583

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8054066](https://bugs.openjdk.org/browse/JDK-8054066): com/sun/jdi/DoubleAgentTest.java fails with timeout


### Reviewers
 * [Dmitry Samersoff](https://openjdk.org/census#dsamersoff) (@dsamersoff - Committer)
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/143/head:pull/143` \
`$ git checkout pull/143`

Update a local copy of the PR: \
`$ git checkout pull/143` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/143/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 143`

View PR using the GUI difftool: \
`$ git pr show -t 143`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/143.diff">https://git.openjdk.org/jdk8u-dev/pull/143.diff</a>

</details>
