### PR TITLE
6829250: Reg test: java/awt/Toolkit/ScreenInsetsTest/ScreenInsetsTest.java fails in Windows

### DIFF
--- a/jdk/test/java/awt/Toolkit/ScreenInsetsTest/ScreenInsetsTest.java
+++ b/jdk/test/java/awt/Toolkit/ScreenInsetsTest/ScreenInsetsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,6 @@ public class ScreenInsetsTest
         GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
         GraphicsDevice[] gds = ge.getScreenDevices();
         for (GraphicsDevice gd : gds) {
-
             GraphicsConfiguration gc = gd.getDefaultConfiguration();
             Rectangle gcBounds = gc.getBounds();
             Insets gcInsets = Toolkit.getDefaultToolkit().getScreenInsets(gc);
@@ -99,7 +98,13 @@ public class ScreenInsetsTest
                                          gcBounds.y + gcBounds.height - fBounds.y - fBounds.height,
                                          gcBounds.x + gcBounds.width - fBounds.x - fBounds.width);
 
-            if (!expected.equals(gcInsets))
+            // On Windows 10 and up system allows undecorated maximized windows
+            // to be placed over the taskbar so calculated insets might
+            // be smaller than reported ones depending on the taskbar position
+            if (gcInsets.top < expected.top
+                    || gcInsets.bottom < expected.bottom
+                    || gcInsets.left < expected.left
+                    || gcInsets.right < expected.right)
             {
                 passed = false;
                 System.err.println("Wrong insets for GraphicsConfig: " + gc);


### PR DESCRIPTION
Passes `jdk/test/java/awt/Toolkit/ScreenInsetsTest/ScreenInsetsTest.java` on my Windows machine. Not a clean backport due to:

* fix file paths
* affected test not included in ProblemList.txt in JDK8. No change required in ProblemList.txt
* conflict in copyright year

Rest is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-6829250](https://bugs.openjdk.org/browse/JDK-6829250): Reg test: java/awt/Toolkit/ScreenInsetsTest/ScreenInsetsTest.java fails in Windows


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/145/head:pull/145` \
`$ git checkout pull/145`

Update a local copy of the PR: \
`$ git checkout pull/145` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/145/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 145`

View PR using the GUI difftool: \
`$ git pr show -t 145`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/145.diff">https://git.openjdk.org/jdk8u-dev/pull/145.diff</a>

</details>
