### PR TITLE
8265527: tools/javac/diags/CheckExamples.java fails after JDK-8078024 8u backport

### DIFF
--- a/langtools/test/tools/javac/diags/examples.not-yet.txt
+++ b/langtools/test/tools/javac/diags/examples.not-yet.txt
@@ -93,6 +93,7 @@ compiler.misc.verbose.retro.with                        # UNUSED
 compiler.misc.verbose.retro.with.list                   # UNUSED
 compiler.misc.version.not.available                     # JavaCompiler; implies build error
 compiler.misc.where.description.captured
+compiler.misc.where.description.intersection.1
 compiler.misc.where.typevar.1
 compiler.misc.wrong.version                             # ClassReader
 compiler.warn.annotation.method.not.found               # ClassReader

--- a/langtools/test/tools/javac/diags/examples/WhereIntersection.java
+++ b/langtools/test/tools/javac/diags/examples/WhereIntersection.java
@@ -21,10 +21,9 @@
  * questions.
  */
 
-// key: compiler.misc.inferred.do.not.conform.to.upper.bounds
-// key: compiler.misc.intersection.type
-// key: compiler.misc.where.description.intersection.1
-// key: compiler.misc.where.intersection
+// key: compiler.misc.incompatible.upper.lower.bounds
+// key: compiler.misc.where.description.typevar
+// key: compiler.misc.where.typevar
 // key: compiler.err.prob.found.req
 // options: -XDdiags=where
 // run: simple


### PR DESCRIPTION
This fix reverts some of the changes made to jtreg tests by the 8078024 backport. Changes to javac itself are not reverted.

The failing test checks error messages emitted by javac while compiling invalid code. The exact messages differ in JDKs 8 and 9, where 8078024 fix was backported from. So this fix updates the expected messages to match those issued by JDK8.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8265527](https://bugs.openjdk.org/browse/JDK-8265527): tools/javac/diags/CheckExamples.java fails after JDK-8078024 8u backport


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/146/head:pull/146` \
`$ git checkout pull/146`

Update a local copy of the PR: \
`$ git checkout pull/146` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/146/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 146`

View PR using the GUI difftool: \
`$ git pr show -t 146`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/146.diff">https://git.openjdk.org/jdk8u-dev/pull/146.diff</a>

</details>
