### PR TITLE
8295288: Some vm_flags tests associate with a wrong BugID

### DIFF
--- a/hotspot/test/testlibrary_tests/whitebox/vm_flags/BooleanTest.java
+++ b/hotspot/test/testlibrary_tests/whitebox/vm_flags/BooleanTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test BooleanTest
- * @bug 8028756
+ * @bug 8038756
  * @library /testlibrary /testlibrary/whitebox
  * @build BooleanTest
  * @run main ClassFileInstaller sun.hotspot.WhiteBox

--- a/hotspot/test/testlibrary_tests/whitebox/vm_flags/DoubleTest.java
+++ b/hotspot/test/testlibrary_tests/whitebox/vm_flags/DoubleTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test DoubleTest
- * @bug 8028756
+ * @bug 8038756
  * @library /testlibrary /testlibrary/whitebox
  * @build DoubleTest
  * @run main ClassFileInstaller sun.hotspot.WhiteBox

--- a/hotspot/test/testlibrary_tests/whitebox/vm_flags/StringTest.java
+++ b/hotspot/test/testlibrary_tests/whitebox/vm_flags/StringTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test StringTest
- * @bug 8028756
+ * @bug 8038756
  * @library /testlibrary /testlibrary/whitebox
  * @build StringTest
  * @run main ClassFileInstaller sun.hotspot.WhiteBox

--- a/hotspot/test/testlibrary_tests/whitebox/vm_flags/Uint64Test.java
+++ b/hotspot/test/testlibrary_tests/whitebox/vm_flags/Uint64Test.java
@@ -23,7 +23,7 @@
 
 /*
  * @test Uint64Test
- * @bug 8028756
+ * @bug 8038756
  * @library /testlibrary /testlibrary/whitebox
  * @build Uint64Test
  * @run main ClassFileInstaller sun.hotspot.WhiteBox

--- a/hotspot/test/testlibrary_tests/whitebox/vm_flags/UintxTest.java
+++ b/hotspot/test/testlibrary_tests/whitebox/vm_flags/UintxTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test UintxTest
- * @bug 8028756
+ * @bug 8038756
  * @library /testlibrary /testlibrary/whitebox
  * @build UintxTest
  * @run main ClassFileInstaller sun.hotspot.WhiteBox


### PR DESCRIPTION
Backport is not clean. Test header is different between JDK8 and JDK11. All changed tests passing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295288](https://bugs.openjdk.org/browse/JDK-8295288): Some vm_flags tests associate with a wrong BugID


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/147/head:pull/147` \
`$ git checkout pull/147`

Update a local copy of the PR: \
`$ git checkout pull/147` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/147/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 147`

View PR using the GUI difftool: \
`$ git pr show -t 147`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/147.diff">https://git.openjdk.org/jdk8u-dev/pull/147.diff</a>

</details>
