### PR TITLE
8295915: Problemlist compiler/rtm failures specific to 8u

### DIFF
--- a/hotspot/test/ProblemList.txt
+++ b/hotspot/test/ProblemList.txt
@@ -64,3 +64,8 @@ compiler/rtm/locking/TestRTMSpinLoopCount.java 8183263 generic-x64
 compiler/rtm/locking/TestUseRTMDeopt.java 8183263 generic-x64
 compiler/rtm/locking/TestUseRTMXendForLockBusy.java 8183263 generic-x64
 compiler/rtm/print/TestPrintPreciseRTMLockingStatistics.java 8183263 generic-x64
+compiler/rtm/locking/TestRTMTotalCountIncrRate.java 8183263 generic-x64,generic-i586
+compiler/rtm/locking/TestUseRTMAfterLockInflation.java 8183263 generic-x64,generic-i586
+compiler/rtm/locking/TestUseRTMForInflatedLocks.java 8183263 generic-x64,generic-i586
+compiler/rtm/locking/TestUseRTMForStackLocks.java 8183263 generic-x64,generic-i586
+compiler/rtm/method_options/TestUseRTMLockElidingOption.java 8183263 generic-x64,generic-i586


### PR DESCRIPTION
I would like to problemlist few more compiler/rtm tests on jdk8u. Tests are failing on machines used by Github actions. Failures are specific to jdk8 ( For more details see my comments in JDK-8183263 [1] ).
List of tests follows:
```
compiler/rtm/locking/TestRTMTotalCountIncrRate.java
compiler/rtm/locking/TestUseRTMAfterLockInflation.java
compiler/rtm/locking/TestUseRTMForInflatedLocks.java
compiler/rtm/locking/TestUseRTMForStackLocks.java
compiler/rtm/method_options/TestUseRTMLockElidingOption.java
```
These tests are part of hotspot_tier1 and are currently the only failures for 64-bit builds. (There are some additional (unrelated) issues on 32-bit builds.) This blocks enabling of hotspot_tier1 in Github Actions.

Tested in GHA with hotspot_tier1 testing enabled (64-bit builds), no failures [2].

[1] https://bugs.openjdk.org/browse/JDK-8183263
[2] https://github.com/zzambers/jdk8u-dev/commits/problemlist-rtm-8u-test

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295915](https://bugs.openjdk.org/browse/JDK-8295915): Problemlist compiler/rtm failures specific to 8u


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/148/head:pull/148` \
`$ git checkout pull/148`

Update a local copy of the PR: \
`$ git checkout pull/148` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/148/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 148`

View PR using the GUI difftool: \
`$ git pr show -t 148`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/148.diff">https://git.openjdk.org/jdk8u-dev/pull/148.diff</a>

</details>
