### PR TITLE
8295950: Enable langtools/tier1 in GHA for 8u

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -201,13 +201,13 @@ jobs:
       matrix:
         test:
           - jdk/tier1
-#          - langtools/tier1
+          - langtools/tier1
 #          - hotspot/tier1
         include:
           - test: jdk/tier1
             suites: jdk_tier1
-#          - test: langtools/tier1
-#            suites: langtools_tier1
+          - test: langtools/tier1
+            suites: langtools_tier1
 #          - test: hotspot/tier1
 #            suites: hotspot_tier1
 
@@ -557,13 +557,13 @@ jobs:
       matrix:
         test:
           - jdk/tier1
-#          - langtools/tier1
+          - langtools/tier1
 #          - hotspot/tier1
         include:
           - test: jdk/tier1
             suites: jdk_tier1
-#          - test: langtools/tier1
-#            suites: langtools_tier1
+          - test: langtools/tier1
+            suites: langtools_tier1
 #          - test: hotspot/tier1
 #            suites: hotspot_tier1
 
@@ -998,13 +998,13 @@ jobs:
       matrix:
         test:
           - jdk/tier1
-#          - langtools/tier1
+          - langtools/tier1
 #          - hotspot/tier1
         include:
           - test: jdk/tier1
             suites: jdk_tier1
-#          - test: langtools/tier1
-#            suites: langtools_tier1
+          - test: langtools/tier1
+            suites: langtools_tier1
 #          - test: hotspot/tier1
 #            suites: hotspot_tier1
 
@@ -1143,13 +1143,13 @@ jobs:
       matrix:
         test:
           - jdk/tier1
-#          - langtools/tier1
+          - langtools/tier1
 #          - hotspot/tier1
         include:
           - test: jdk/tier1
             suites: jdk_tier1
-#          - test: langtools/tier1
-#            suites: langtools_tier1
+          - test: langtools/tier1
+            suites: langtools_tier1
 #          - test: hotspot/tier1
 #            suites: hotspot_tier1
 
@@ -1386,13 +1386,13 @@ jobs:
       matrix:
         test:
           - jdk/tier1
-#          - langtools/tier1
+          - langtools/tier1
 #          - hotspot/tier1
         include:
           - test: jdk/tier1
             suites: jdk_tier1
-#          - test: langtools/tier1
-#            suites: langtools_tier1
+          - test: langtools/tier1
+            suites: langtools_tier1
 #          - test: hotspot/tier1
 #            suites: hotspot_tier1
 


### PR DESCRIPTION
It is now possible to enable langtools/tier1 in Github actions for jdk8u as the only failure there has been resolved [1].

[1] https://bugs.openjdk.org/browse/JDK-8265527

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295950](https://bugs.openjdk.org/browse/JDK-8295950): Enable langtools/tier1 in GHA for 8u


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/149/head:pull/149` \
`$ git checkout pull/149`

Update a local copy of the PR: \
`$ git checkout pull/149` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/149/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 149`

View PR using the GUI difftool: \
`$ git pr show -t 149`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/149.diff">https://git.openjdk.org/jdk8u-dev/pull/149.diff</a>

</details>
