### PR TITLE
8295982: Failure in sun/security/tools/keytool/WeakAlg.java - ks: The process cannot access the file because it is being used by another process

### DIFF
--- a/jdk/test/sun/security/tools/keytool/WeakAlg.java
+++ b/jdk/test/sun/security/tools/keytool/WeakAlg.java
@@ -329,10 +329,12 @@ public class WeakAlg {
                 .shouldMatch("The original.*ks.old5");
 
         KeyStore test_ks = KeyStore.getInstance("JKS");
-        test_ks.load(new FileInputStream(new File("ks")),
+        FileInputStream inputStream = new FileInputStream(new File("ks"));
+        test_ks.load(inputStream,
                 "changeit".toCharArray());
         Asserts.assertEQ(
                     test_ks.getType(), "JKS");
+        inputStream.close();
 
         importkeystore("ks", "ks", "-deststoretype PKCS12")
                 .shouldContain("Warning:")
@@ -340,16 +342,20 @@ public class WeakAlg {
                 .shouldMatch("Migrated.*Non.*JKS.*ks.old6");
 
         test_ks = KeyStore.getInstance("PKCS12");
-        test_ks.load(new FileInputStream(new File("ks")),
+        inputStream = new FileInputStream(new File("ks"));
+        test_ks.load(inputStream,
                 "changeit".toCharArray());
         Asserts.assertEQ(
                 test_ks.getType(), "PKCS12");
+        inputStream.close();
 
         test_ks = KeyStore.getInstance("JKS");
-        test_ks.load(new FileInputStream(new File("ks.old6")),
+        inputStream = new FileInputStream(new File("ks.old6"));
+        test_ks.load(inputStream,
                 "changeit".toCharArray());
         Asserts.assertEQ(
                 test_ks.getType(), "JKS");
+        inputStream.close();
 
         // One password prompt is enough for migration
         kt0("-importkeystore -srckeystore ks -destkeystore ks", "changeit")


### PR DESCRIPTION
Test sun/security/tools/keytool/WeakAlg.java occasionally fails on Windows 64 bit (win2016, win11) with the following message "java.nio.file.FileSystemException: ks: The process cannot access the file because it is being used by another process".

The root cause of the problem is "ks" file is still open by FileInputStream instance used by KeyStore in the test code. Perhaps, forcing GC to run may avoid this issue, but I guess explicit closing of the input stream is more suitable here.

No regression, only the test code is changed.
The test passes on Windows and Linux now.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295982](https://bugs.openjdk.org/browse/JDK-8295982): Failure in sun/security/tools/keytool/WeakAlg.java - ks: The process cannot access the file because it is being used by another process


### Reviewers
 * [Dmitry Cherepanov](https://openjdk.org/census#dcherepanov) (@dimitryc - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/150/head:pull/150` \
`$ git checkout pull/150`

Update a local copy of the PR: \
`$ git checkout pull/150` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/150/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 150`

View PR using the GUI difftool: \
`$ git pr show -t 150`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/150.diff">https://git.openjdk.org/jdk8u-dev/pull/150.diff</a>

</details>
