### PR TITLE
Backport d4c7db5060978302382549246f9ad6831f19377d

### DIFF
--- a/jdk/src/solaris/native/java/lang/java_props_macosx.c
+++ b/jdk/src/solaris/native/java/lang/java_props_macosx.c
@@ -186,11 +186,15 @@ void setOSNameAndVersion(java_props_t *sprops) {
     NSString *nsVerStr = NULL;
     char* osVersionCStr = NULL;
     // Mac OS 10.9 includes the [NSProcessInfo operatingSystemVersion] function,
-    // but it's not in the 10.9 SDK.  So, call it via objc_msgSend_stret.
+    // but it's not in the 10.9 SDK.  So, call it via NSInvocation.
     if ([[NSProcessInfo processInfo] respondsToSelector:@selector(operatingSystemVersion)]) {
-        OSVerStruct (*procInfoFn)(id rec, SEL sel) = (OSVerStruct(*)(id, SEL))objc_msgSend_stret;
-        OSVerStruct osVer = procInfoFn([NSProcessInfo processInfo],
-                                       @selector(operatingSystemVersion));
+        OSVerStruct osVer;
+        NSMethodSignature *sig = [[NSProcessInfo processInfo] methodSignatureForSelector:
+                @selector(operatingSystemVersion)];
+        NSInvocation *invoke = [NSInvocation invocationWithMethodSignature:sig];
+        invoke.selector = @selector(operatingSystemVersion);
+        [invoke invokeWithTarget:[NSProcessInfo processInfo]];
+        [invoke getReturnValue:&osVer];
 
         // Copy out the char* if running on version other than 10.16 Mac OS (10.16 == 11.x)
         // or explicitly requesting version compatibility


### PR DESCRIPTION
This backports [JDK-8257620](https://bugs.openjdk.org/browse/JDK-8257620) for parity with Oracle JDK8 and OpenJDK 11+. 

The backport is not clean because [JDK-8269850](https://bugs.openjdk.org/browse/JDK-8269850) was applied first in 8u. If that change is backed out and reapplied after this backport, both are clean.

Change applied with:
- `git revert 43cfe27fa3a11dd6d4fffcb1c1336ac7fdd0233b` (backout JDK-8269850)
- `git backport --from https://github.com/openjdk/jdk d4c7db5060978302382549246f9ad6831f19377d` (apply JDK-8257620)
- `git backport --from https://github.com/openjdk/jdk 3b1b8fc646493eae5f4df828afe29abb75fa5e60gig` (re-apply JDK-826985)
- `git rebase -i HEAD~3` (squash commits)