### PR TITLE
8278951: containers/cgroup/PlainRead.java fails on Ubuntu 21.10

### DIFF
--- a/hotspot/src/os/linux/vm/cgroupSubsystem_linux.hpp
+++ b/hotspot/src/os/linux/vm/cgroupSubsystem_linux.hpp
@@ -169,8 +169,10 @@ PRAGMA_DIAG_POP
                                      NULL,                                \
                                      scan_fmt,                            \
                                      &variable);                          \
-  if (err != 0)                                                           \
+  if (err != 0) {                                                         \
+    log_trace(os, container)(logstring, (return_type) OSCONTAINER_ERROR); \
     return (return_type) OSCONTAINER_ERROR;                               \
+  }                                                                       \
                                                                           \
   if (PrintContainerInfo) {                                               \
     tty->print_cr(logstring, variable);                                   \

--- a/hotspot/src/os/linux/vm/cgroupSubsystem_linux.hpp
+++ b/hotspot/src/os/linux/vm/cgroupSubsystem_linux.hpp
@@ -170,7 +170,9 @@ PRAGMA_DIAG_POP
                                      scan_fmt,                            \
                                      &variable);                          \
   if (err != 0) {                                                         \
-    log_trace(os, container)(logstring, (return_type) OSCONTAINER_ERROR); \
+    if (PrintContainerInfo) {                                             \
+      tty->print_cr(logstring, (return_type) OSCONTAINER_ERROR);          \
+    }                                                                     \
     return (return_type) OSCONTAINER_ERROR;                               \
   }                                                                       \
                                                                           \

--- a/hotspot/src/os/linux/vm/cgroupV2Subsystem_linux.cpp
+++ b/hotspot/src/os/linux/vm/cgroupV2Subsystem_linux.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Red Hat Inc.
+ * Copyright (c) 2020, 2022, Red Hat Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@
  */
 int CgroupV2Subsystem::cpu_shares() {
   GET_CONTAINER_INFO(int, _unified, "/cpu.weight",
-                     "Raw value for CPU shares is: %d", "%d", shares);
+                     "Raw value for CPU Shares is: %d", "%d", shares);
   // Convert default value of 100 to no shares setup
   if (shares == 100) {
     if (PrintContainerInfo) {


### PR DESCRIPTION
This is a backport of 8278951 to jdk8u-dev as part of the cgroups v2 backport initiative.

Dependent PRs are in use.

It was clean (modulo path shuffles). The use of `log_trace` needed adjusting for jdk8u-dev.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8278951](https://bugs.openjdk.org/browse/JDK-8278951): containers/cgroup/PlainRead.java fails on Ubuntu 21.10


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/155/head:pull/155` \
`$ git checkout pull/155`

Update a local copy of the PR: \
`$ git checkout pull/155` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/155/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 155`

View PR using the GUI difftool: \
`$ git pr show -t 155`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/155.diff">https://git.openjdk.org/jdk8u-dev/pull/155.diff</a>

</details>
