### PR TITLE
8224506: [TESTBUG] TestDockerMemoryMetrics.java fails with exitValue = 137

### DIFF
--- a/jdk/test/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
+++ b/jdk/test/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,7 @@ public class TestDockerMemoryMetrics {
             testOomKillFlag("100m", false);
             testOomKillFlag("100m", true);
 
-            testMemoryFailCount("20m");
+            testMemoryFailCount("64m");
 
             testMemorySoftLimit("500m","200m");
 


### PR DESCRIPTION
Clean backport from 11u which helps testing of cgroups v2 work.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8224506](https://bugs.openjdk.org/browse/JDK-8224506): [TESTBUG] TestDockerMemoryMetrics.java fails with exitValue = 137


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/156/head:pull/156` \
`$ git checkout pull/156`

Update a local copy of the PR: \
`$ git checkout pull/156` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/156/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 156`

View PR using the GUI difftool: \
`$ git pr show -t 156`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/156.diff">https://git.openjdk.org/jdk8u-dev/pull/156.diff</a>

</details>
