### PR TITLE
8253435: Cgroup: 'stomping of _mount_path' crash if manually mounted cpusets exist

### DIFF
--- a/hotspot/src/os/linux/vm/cgroupSubsystem_linux.cpp
+++ b/hotspot/src/os/linux/vm/cgroupSubsystem_linux.cpp
@@ -315,13 +315,17 @@ bool CgroupSubsystemFactory::determine_type(CgroupInfo* cg_infos,
             // the main cgroup controllers most likely under /sys/fs/cgroup. In that
             // case pick the one under /sys/fs/cgroup and discard others.
             if (strstr(cg_infos[CPUSET_IDX]._mount_path, "/sys/fs/cgroup") != cg_infos[CPUSET_IDX]._mount_path) {
-              log_warning(os, container)("Duplicate cpuset controllers detected. Picking %s, skipping %s.",
-                                         tmpmount, cg_infos[CPUSET_IDX]._mount_path);
+              if (PrintContainerInfo) {
+                tty->print_cr("Duplicate cpuset controllers detected. Picking %s, skipping %s.",
+                              tmpmount, cg_infos[CPUSET_IDX]._mount_path);
+              }
               os::free(cg_infos[CPUSET_IDX]._mount_path);
               cg_infos[CPUSET_IDX]._mount_path = os::strdup(tmpmount);
             } else {
-              log_warning(os, container)("Duplicate cpuset controllers detected. Picking %s, skipping %s.",
-                                         cg_infos[CPUSET_IDX]._mount_path, tmpmount);
+              if (PrintContainerInfo) {
+                tty->print_cr("Duplicate cpuset controllers detected. Picking %s, skipping %s.",
+                              cg_infos[CPUSET_IDX]._mount_path, tmpmount);
+              }
             }
           } else {
             cg_infos[CPUSET_IDX]._mount_path = os::strdup(tmpmount);

--- a/hotspot/src/os/linux/vm/cgroupSubsystem_linux.cpp
+++ b/hotspot/src/os/linux/vm/cgroupSubsystem_linux.cpp
@@ -310,8 +310,22 @@ bool CgroupSubsystemFactory::determine_type(CgroupInfo* cg_infos,
           cg_infos[MEMORY_IDX]._root_mount_path = os::strdup(tmproot);
           cg_infos[MEMORY_IDX]._data_complete = true;
         } else if (strcmp(token, "cpuset") == 0) {
-          assert(cg_infos[CPUSET_IDX]._mount_path == NULL, "stomping of _mount_path");
-          cg_infos[CPUSET_IDX]._mount_path = os::strdup(tmpmount);
+          if (cg_infos[CPUSET_IDX]._mount_path != NULL) {
+            // On some systems duplicate cpuset controllers get mounted in addition to
+            // the main cgroup controllers most likely under /sys/fs/cgroup. In that
+            // case pick the one under /sys/fs/cgroup and discard others.
+            if (strstr(cg_infos[CPUSET_IDX]._mount_path, "/sys/fs/cgroup") != cg_infos[CPUSET_IDX]._mount_path) {
+              log_warning(os, container)("Duplicate cpuset controllers detected. Picking %s, skipping %s.",
+                                         tmpmount, cg_infos[CPUSET_IDX]._mount_path);
+              os::free(cg_infos[CPUSET_IDX]._mount_path);
+              cg_infos[CPUSET_IDX]._mount_path = os::strdup(tmpmount);
+            } else {
+              log_warning(os, container)("Duplicate cpuset controllers detected. Picking %s, skipping %s.",
+                                         cg_infos[CPUSET_IDX]._mount_path, tmpmount);
+            }
+          } else {
+            cg_infos[CPUSET_IDX]._mount_path = os::strdup(tmpmount);
+          }
           cg_infos[CPUSET_IDX]._root_mount_path = os::strdup(tmproot);
           cg_infos[CPUSET_IDX]._data_complete = true;
         } else if (strcmp(token, "cpu") == 0) {

--- a/hotspot/test/runtime/containers/cgroup/CgroupSubsystemFactory.java
+++ b/hotspot/test/runtime/containers/cgroup/CgroupSubsystemFactory.java
@@ -63,6 +63,8 @@ public class CgroupSubsystemFactory {
     private Path cgroupv1CgInfoNonZeroHierarchy;
     private Path cgroupv1MntInfoNonZeroHierarchyOtherOrder;
     private Path cgroupv1MntInfoNonZeroHierarchy;
+    private Path cgroupv1MntInfoDoubleCpuset;
+    private Path cgroupv1MntInfoDoubleCpuset2;
     private String mntInfoEmpty = "";
     private Path cgroupV1SelfCgroup;
     private Path cgroupV2SelfCgroup;
@@ -105,11 +107,14 @@ public class CgroupSubsystemFactory {
             "41 30 0:37 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime shared:13 - cgroup none rw,seclabel,devices\n" +
             "42 30 0:38 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:14 - cgroup none rw,seclabel,cpuset\n" +
             "43 30 0:39 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime shared:15 - cgroup none rw,seclabel,blkio\n" +
-            "44 30 0:40 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime shared:16 - cgroup none rw,seclabel,freezer";
+            "44 30 0:40 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime shared:16 - cgroup none rw,seclabel,freezer\n";
     private String mntInfoHybridRest = cgroupv1MountInfoLineMemory + mntInfoHybridStub;
     private String mntInfoHybridMissingMemory = mntInfoHybridStub;
     private String mntInfoHybrid = cgroupV2LineHybrid + mntInfoHybridRest;
     private String mntInfoHybridFlippedOrder = mntInfoHybridRest + cgroupV2LineHybrid;
+    private String mntInfoCgroupv1MoreCpusetLine = "121 32 0:37 / /cpusets rw,relatime shared:69 - cgroup none rw,cpuset\n";
+    private String mntInfoCgroupv1DoubleCpuset = mntInfoCgroupv1MoreCpusetLine + mntInfoHybrid;
+    private String mntInfoCgroupv1DoubleCpuset2 =  mntInfoHybrid + mntInfoCgroupv1MoreCpusetLine;
     private String cgroupsNonZeroHierarchy =
             "#subsys_name hierarchy   num_cgroups enabled\n" +
             "cpuset  3   1   1\n" +
@@ -159,7 +164,13 @@ public class CgroupSubsystemFactory {
             Files.write(cgroupv1MntInfoMissingMemoryController, mntInfoHybridMissingMemory.getBytes());
 
             cgroupV2MntInfoMissingCgroupv2 = Paths.get(existingDirectory.toString(), "mnt_info_missing_cgroup2");
-            Files.write(cgroupV2MntInfoMissingCgroupv2, mntInfoHybridStub.getBytes());
+            Files.writeString(cgroupV2MntInfoMissingCgroupv2, mntInfoHybridStub);
+
+            cgroupv1MntInfoDoubleCpuset = Paths.get(existingDirectory.toString(), "mnt_info_cgroupv1_double_cpuset");
+            Files.writeString(cgroupv1MntInfoDoubleCpuset, mntInfoCgroupv1DoubleCpuset);
+
+            cgroupv1MntInfoDoubleCpuset2 = Paths.get(existingDirectory.toString(), "mnt_info_cgroupv1_double_cpuset2");
+            Files.writeString(cgroupv1MntInfoDoubleCpuset2, mntInfoCgroupv1DoubleCpuset2);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -194,6 +205,16 @@ public class CgroupSubsystemFactory {
 
     private boolean isValidCgroup(int value) {
         return value == CGROUPS_V1 || value == CGROUPS_V2;
+    }
+
+    public void testCgroupv1MultipleCpusetMounts(WhiteBox wb, Path mountInfo) {
+        String procCgroups = cgroupv1CgInfoNonZeroHierarchy.toString();
+        String procSelfCgroup = cgroupV1SelfCgroup.toString();
+        String procSelfMountinfo = mountInfo.toString();
+        int retval = wb.validateCgroup(procCgroups, procSelfCgroup, procSelfMountinfo);
+        Asserts.assertEQ(CGROUPS_V1, retval, "Multiple cpuset controllers, but only one in /sys/fs/cgroup");
+        Asserts.assertTrue(isValidCgroup(retval));
+        System.out.println("testCgroupv1MultipleCpusetMounts PASSED!");
     }
 
     public void testCgroupv1NoMounts(WhiteBox wb) {
@@ -268,6 +289,8 @@ public class CgroupSubsystemFactory {
             test.testCgroupV1HybridMntInfoOrder(wb);
             test.testCgroupv1MissingMemoryController(wb);
             test.testCgroupv2NoCgroup2Fs(wb);
+            test.testCgroupv1MultipleCpusetMounts(wb, test.cgroupv1MntInfoDoubleCpuset);
+            test.testCgroupv1MultipleCpusetMounts(wb, test.cgroupv1MntInfoDoubleCpuset2);
         } finally {
             test.teardown();
         }

--- a/hotspot/test/runtime/containers/cgroup/CgroupSubsystemFactory.java
+++ b/hotspot/test/runtime/containers/cgroup/CgroupSubsystemFactory.java
@@ -164,13 +164,13 @@ public class CgroupSubsystemFactory {
             Files.write(cgroupv1MntInfoMissingMemoryController, mntInfoHybridMissingMemory.getBytes());
 
             cgroupV2MntInfoMissingCgroupv2 = Paths.get(existingDirectory.toString(), "mnt_info_missing_cgroup2");
-            Files.writeString(cgroupV2MntInfoMissingCgroupv2, mntInfoHybridStub);
+            Files.write(cgroupV2MntInfoMissingCgroupv2, mntInfoHybridStub.getBytes());
 
             cgroupv1MntInfoDoubleCpuset = Paths.get(existingDirectory.toString(), "mnt_info_cgroupv1_double_cpuset");
-            Files.writeString(cgroupv1MntInfoDoubleCpuset, mntInfoCgroupv1DoubleCpuset);
+            Files.write(cgroupv1MntInfoDoubleCpuset, mntInfoCgroupv1DoubleCpuset.getBytes());
 
             cgroupv1MntInfoDoubleCpuset2 = Paths.get(existingDirectory.toString(), "mnt_info_cgroupv1_double_cpuset2");
-            Files.writeString(cgroupv1MntInfoDoubleCpuset2, mntInfoCgroupv1DoubleCpuset2);
+            Files.write(cgroupv1MntInfoDoubleCpuset2, mntInfoCgroupv1DoubleCpuset2.getBytes());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
This is a backport of 8253435 to jdk8u-dev for cgroups v2 support.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8253435](https://bugs.openjdk.org/browse/JDK-8253435): Cgroup: 'stomping of _mount_path' crash if manually mounted cpusets exist


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/158/head:pull/158` \
`$ git checkout pull/158`

Update a local copy of the PR: \
`$ git checkout pull/158` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/158/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 158`

View PR using the GUI difftool: \
`$ git pr show -t 158`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/158.diff">https://git.openjdk.org/jdk8u-dev/pull/158.diff</a>

</details>
