### PR TITLE
8245543: Cgroups: Incorrect detection logic on some systems (still reproducible)

### DIFF
--- a/hotspot/src/os/linux/vm/cgroupSubsystem_linux.cpp
+++ b/hotspot/src/os/linux/vm/cgroupSubsystem_linux.cpp
@@ -302,14 +302,15 @@ bool CgroupSubsystemFactory::determine_type(CgroupInfo* cg_infos,
         // Skip cgroup2 fs lines on hybrid or unified hierarchy.
         continue;
       }
-      any_cgroup_mounts_found = true;
       while ((token = strsep(&cptr, ",")) != NULL) {
         if (strcmp(token, "memory") == 0) {
+          any_cgroup_mounts_found = true;
           assert(cg_infos[MEMORY_IDX]._mount_path == NULL, "stomping of _mount_path");
           cg_infos[MEMORY_IDX]._mount_path = os::strdup(tmpmount);
           cg_infos[MEMORY_IDX]._root_mount_path = os::strdup(tmproot);
           cg_infos[MEMORY_IDX]._data_complete = true;
         } else if (strcmp(token, "cpuset") == 0) {
+          any_cgroup_mounts_found = true;
           if (cg_infos[CPUSET_IDX]._mount_path != NULL) {
             // On some systems duplicate cpuset controllers get mounted in addition to
             // the main cgroup controllers most likely under /sys/fs/cgroup. In that
@@ -333,11 +334,13 @@ bool CgroupSubsystemFactory::determine_type(CgroupInfo* cg_infos,
           cg_infos[CPUSET_IDX]._root_mount_path = os::strdup(tmproot);
           cg_infos[CPUSET_IDX]._data_complete = true;
         } else if (strcmp(token, "cpu") == 0) {
+          any_cgroup_mounts_found = true;
           assert(cg_infos[CPU_IDX]._mount_path == NULL, "stomping of _mount_path");
           cg_infos[CPU_IDX]._mount_path = os::strdup(tmpmount);
           cg_infos[CPU_IDX]._root_mount_path = os::strdup(tmproot);
           cg_infos[CPU_IDX]._data_complete = true;
         } else if (strcmp(token, "cpuacct") == 0) {
+          any_cgroup_mounts_found = true;
           assert(cg_infos[CPUACCT_IDX]._mount_path == NULL, "stomping of _mount_path");
           cg_infos[CPUACCT_IDX]._mount_path = os::strdup(tmpmount);
           cg_infos[CPUACCT_IDX]._root_mount_path = os::strdup(tmproot);
@@ -352,7 +355,7 @@ bool CgroupSubsystemFactory::determine_type(CgroupInfo* cg_infos,
   // No point in continuing.
   if (!any_cgroup_mounts_found) {
     if (PrintContainerInfo) {
-      tty->print_cr("No cgroup controllers mounted.");
+      tty->print_cr("No relevant cgroup controllers mounted.");
     }
     cleanup(cg_infos);
     *flags = INVALID_CGROUPS_NO_MOUNT;

--- a/jdk/src/linux/classes/jdk/internal/platform/CgroupSubsystemFactory.java
+++ b/jdk/src/linux/classes/jdk/internal/platform/CgroupSubsystemFactory.java
@@ -31,6 +31,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import jdk.internal.platform.cgroupv1.CgroupV1Subsystem;
@@ -43,6 +45,31 @@ public class CgroupSubsystemFactory {
     private static final String CPUSET_CTRL = "cpuset";
     private static final String BLKIO_CTRL = "blkio";
     private static final String MEMORY_CTRL = "memory";
+
+    /*
+     * From https://www.kernel.org/doc/Documentation/filesystems/proc.txt
+     *
+     *  36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 - ext3 /dev/root rw,errors=continue
+     *  (1)(2)(3)   (4)   (5)      (6)      (7)   (8) (9)   (10)         (11)
+     *
+     *  (1) mount ID:  unique identifier of the mount (may be reused after umount)
+     *  (2) parent ID:  ID of parent (or of self for the top of the mount tree)
+     *  (3) major:minor:  value of st_dev for files on filesystem
+     *  (4) root:  root of the mount within the filesystem
+     *  (5) mount point:  mount point relative to the process's root
+     *  (6) mount options:  per mount options
+     *  (7) optional fields:  zero or more fields of the form "tag[:value]"
+     *  (8) separator:  marks the end of the optional fields
+     *  (9) filesystem type:  name of filesystem of the form "type[.subtype]"
+     *  (10) mount source:  filesystem specific information or "none"
+     *  (11) super options:  per super block options
+     */
+    private static final Pattern MOUNTINFO_PATTERN = Pattern.compile(
+        "^[^\\s]+\\s+[^\\s]+\\s+[^\\s]+\\s+" + // (1), (2), (3)
+        "[^\\s]+\\s+([^\\s]+)\\s+" +           // (4), (5)     - group 1: mount point
+        "[^-]+-\\s+" +                         // (6), (7), (8)
+        "([^\\s]+)\\s+" +                      // (9)          - group 2: filesystem type
+        ".*$");                                // (10), (11)
 
     static CgroupMetrics create() {
         Optional<CgroupTypeResult> optResult = null;
@@ -109,18 +136,44 @@ public class CgroupSubsystemFactory {
             anyControllersEnabled = anyControllersEnabled || info.isEnabled();
         }
 
-        // If there are no mounted controllers in mountinfo, but we've only
-        // seen 0 hierarchy IDs in /proc/cgroups, we are on a cgroups v1 system.
+        // If there are no mounted, relevant cgroup controllers in mountinfo and only
+        // 0 hierarchy IDs in /proc/cgroups have been seen, we are on a cgroups v1 system.
         // However, continuing in that case does not make sense as we'd need
-        // information from mountinfo for the mounted controller paths anyway.
+        // information from mountinfo for the mounted controller paths which we wouldn't
+        // find anyway in that case.
         try (Stream<String> mntInfo = CgroupUtil.readFilePrivileged(Paths.get(mountInfo))) {
-            boolean anyCgroupMounted = mntInfo.anyMatch(line -> line.contains("cgroup"));
+            boolean anyCgroupMounted = mntInfo.anyMatch(CgroupSubsystemFactory::isRelevantControllerMount);
             if (!anyCgroupMounted && isCgroupsV2) {
                 return Optional.empty();
             }
         }
         CgroupTypeResult result = new CgroupTypeResult(isCgroupsV2, anyControllersEnabled, anyCgroupsV2Controller, anyCgroupsV1Controller);
         return Optional.of(result);
+    }
+
+    private static boolean isRelevantControllerMount(String line) {
+         Matcher lineMatcher = MOUNTINFO_PATTERN.matcher(line.trim());
+         if (lineMatcher.matches()) {
+             String mountPoint = lineMatcher.group(1);
+             String fsType = lineMatcher.group(2);
+             if (fsType.equals("cgroup")) {
+                 String filename = Paths.get(mountPoint).getFileName().toString();
+                 for (String fn: filename.split(",")) {
+                     switch (fn) {
+                         case MEMORY_CTRL: // fall through
+                         case CPU_CTRL:
+                         case CPUSET_CTRL:
+                         case CPUACCT_CTRL:
+                         case BLKIO_CTRL:
+                             return true;
+                         default: break; // ignore not recognized controllers
+                     }
+                 }
+             } else if (fsType.equals("cgroup2")) {
+                 return true;
+             }
+         }
+         return false;
     }
 
     public static final class CgroupTypeResult {

--- a/jdk/test/jdk/internal/platform/cgroup/TestCgroupSubsystemFactory.java
+++ b/jdk/test/jdk/internal/platform/cgroup/TestCgroupSubsystemFactory.java
@@ -56,6 +56,7 @@ public class TestCgroupSubsystemFactory {
     private Path cgroupv2MntInfoZeroHierarchy;
     private Path cgroupv1CgInfoNonZeroHierarchy;
     private Path cgroupv1MntInfoNonZeroHierarchy;
+    private Path cgroupv1MntInfoSystemdOnly;
     private String mntInfoEmpty = "";
     private String cgroupsZeroHierarchy =
             "#subsys_name hierarchy num_cgroups enabled\n" +
@@ -98,6 +99,9 @@ public class TestCgroupSubsystemFactory {
             "pids    3   80  1";
     private String mntInfoCgroupsV2Only =
             "28 21 0:25 / /sys/fs/cgroup rw,nosuid,nodev,noexec,relatime shared:4 - cgroup2 cgroup2 rw,seclabel,nsdelegate";
+    private String mntInfoCgroupsV1SystemdOnly =
+            "35 26 0:26 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime - cgroup systemd rw,name=systemd\n" +
+            "26 18 0:19 / /sys/fs/cgroup rw,relatime - tmpfs none rw,size=4k,mode=755\n";
 
     @Before
     public void setup() {
@@ -118,6 +122,9 @@ public class TestCgroupSubsystemFactory {
 
             cgroupv1MntInfoNonZeroHierarchy = Paths.get(existingDirectory.toString(), "mountinfo_non_zero");
             Files.write(cgroupv1MntInfoNonZeroHierarchy, mntInfoHybrid.getBytes());
+
+            cgroupv1MntInfoSystemdOnly = Paths.get(existingDirectory.toString(), "mountinfo_cgroupv1_systemd_only");
+            Files.write(cgroupv1MntInfoSystemdOnly, mntInfoCgroupsV1SystemdOnly.getBytes());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -130,6 +137,15 @@ public class TestCgroupSubsystemFactory {
         } catch (IOException e) {
             System.err.println("Teardown failed. " + e.getMessage());
         }
+    }
+
+    @Test
+    public void testCgroupv1SystemdOnly() throws IOException {
+        String cgroups = cgroupv1CgInfoZeroHierarchy.toString();
+        String mountInfo = cgroupv1MntInfoSystemdOnly.toString();
+        Optional<CgroupTypeResult> result = CgroupSubsystemFactory.determineType(mountInfo, cgroups);
+
+        assertTrue("zero hierarchy ids with no *relevant* controllers mounted", result.isEmpty());
     }
 
     @Test

--- a/jdk/test/jdk/internal/platform/cgroup/TestCgroupSubsystemFactory.java
+++ b/jdk/test/jdk/internal/platform/cgroup/TestCgroupSubsystemFactory.java
@@ -145,7 +145,7 @@ public class TestCgroupSubsystemFactory {
         String mountInfo = cgroupv1MntInfoSystemdOnly.toString();
         Optional<CgroupTypeResult> result = CgroupSubsystemFactory.determineType(mountInfo, cgroups);
 
-        assertTrue("zero hierarchy ids with no *relevant* controllers mounted", result.isEmpty());
+        assertTrue("zero hierarchy ids with no *relevant* controllers mounted", Optional.empty().equals(result));
     }
 
     @Test


### PR DESCRIPTION
A backport of 8245543 to jdk8u-dev for cgroups v2 support.

Not clean: needed minor adjusting for 8u approach to log output.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8245543](https://bugs.openjdk.org/browse/JDK-8245543): Cgroups: Incorrect detection logic on some systems (still reproducible)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/159/head:pull/159` \
`$ git checkout pull/159`

Update a local copy of the PR: \
`$ git checkout pull/159` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/159/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 159`

View PR using the GUI difftool: \
`$ git pr show -t 159`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/159.diff">https://git.openjdk.org/jdk8u-dev/pull/159.diff</a>

</details>
