### PR TITLE
8159720: Failure of C2 compilation with tiered prevents some C1 compilations

### DIFF
--- a/hotspot/src/share/vm/opto/compile.cpp
+++ b/hotspot/src/share/vm/opto/compile.cpp
@@ -791,7 +791,7 @@ Compile::Compile( ciEnv* ci_env, C2Compiler* compiler, ciMethod* target, int osr
     }
     if (failing())  return;
     if (cg == NULL) {
-      record_method_not_compilable_all_tiers("cannot parse method");
+      record_method_not_compilable("cannot parse method");
       return;
     }
     JVMState* jvms = build_start_state(start(), tf());

--- a/hotspot/src/share/vm/opto/compile.hpp
+++ b/hotspot/src/share/vm/opto/compile.hpp
@@ -733,15 +733,11 @@ class Compile : public Phase {
   bool              failure_reason_is(const char* r) { return (r==_failure_reason) || (r!=NULL && _failure_reason!=NULL && strcmp(r, _failure_reason)==0); }
 
   void record_failure(const char* reason);
-  void record_method_not_compilable(const char* reason, bool all_tiers = false) {
-    // All bailouts cover "all_tiers" when TieredCompilation is off.
-    if (!TieredCompilation) all_tiers = true;
-    env()->record_method_not_compilable(reason, all_tiers);
+  void record_method_not_compilable(const char* reason) {
+    // Bailouts cover "all_tiers" when TieredCompilation is off.
+    env()->record_method_not_compilable(reason, !TieredCompilation);
     // Record failure reason.
     record_failure(reason);
-  }
-  void record_method_not_compilable_all_tiers(const char* reason) {
-    record_method_not_compilable(reason, true);
   }
   bool check_node_count(uint margin, const char* reason) {
     if (live_nodes() + margin > max_node_limit()) {

--- a/hotspot/src/share/vm/opto/matcher.cpp
+++ b/hotspot/src/share/vm/opto/matcher.cpp
@@ -137,7 +137,7 @@ OptoReg::Name Matcher::warp_incoming_stk_arg( VMReg reg ) {
       _in_arg_limit = OptoReg::add(warped, 1); // Bump max stack slot seen
     if (!RegMask::can_represent_arg(warped)) {
       // the compiler cannot represent this method's calling sequence
-      C->record_method_not_compilable_all_tiers("unsupported incoming calling sequence");
+      C->record_method_not_compilable("unsupported incoming calling sequence");
       return OptoReg::Bad;
     }
     return warped;
@@ -1139,7 +1139,7 @@ OptoReg::Name Matcher::warp_outgoing_stk_arg( VMReg reg, OptoReg::Name begin_out
     if( warped >= out_arg_limit_per_call )
       out_arg_limit_per_call = OptoReg::add(warped,1);
     if (!RegMask::can_represent_arg(warped)) {
-      C->record_method_not_compilable_all_tiers("unsupported calling sequence");
+      C->record_method_not_compilable("unsupported calling sequence");
       return OptoReg::Bad;
     }
     return warped;
@@ -1318,7 +1318,7 @@ MachNode *Matcher::match_sfpt( SafePointNode *sfpt ) {
     uint r_cnt = mcall->tf()->range()->cnt();
     MachProjNode *proj = new (C) MachProjNode( mcall, r_cnt+10000, RegMask::Empty, MachProjNode::fat_proj );
     if (!RegMask::can_represent_arg(OptoReg::Name(out_arg_limit_per_call-1))) {
-      C->record_method_not_compilable_all_tiers("unsupported outgoing calling sequence");
+      C->record_method_not_compilable("unsupported outgoing calling sequence");
     } else {
       for (int i = begin_out_arg_area; i < out_arg_limit_per_call; i++)
         proj->_rout.Insert(OptoReg::Name(i));
@@ -1506,7 +1506,7 @@ Node *Matcher::Label_Root( const Node *n, State *svec, Node *control, const Node
   // out of stack space.  See bugs 6272980 & 6227033 for more info.
   LabelRootDepth++;
   if (LabelRootDepth > MaxLabelRootDepth) {
-    C->record_method_not_compilable_all_tiers("Out of stack space, increase MaxLabelRootDepth");
+    C->record_method_not_compilable("Out of stack space, increase MaxLabelRootDepth");
     return NULL;
   }
   uint care = 0;                // Edges matcher cares about

--- a/hotspot/src/share/vm/opto/parse1.cpp
+++ b/hotspot/src/share/vm/opto/parse1.cpp
@@ -415,7 +415,7 @@ Parse::Parse(JVMState* caller, ciMethod* parse_method, float expected_uses)
   _iter.reset_to_method(method());
   _flow = method()->get_flow_analysis();
   if (_flow->failing()) {
-    C->record_method_not_compilable_all_tiers(_flow->failure_reason());
+    C->record_method_not_compilable(_flow->failure_reason());
   }
 
 #ifndef PRODUCT
@@ -1080,7 +1080,7 @@ SafePointNode* Parse::create_entry_map() {
   // Check for really stupid bail-out cases.
   uint len = TypeFunc::Parms + method()->max_locals() + method()->max_stack();
   if (len >= 32760) {
-    C->record_method_not_compilable_all_tiers("too many local variables");
+    C->record_method_not_compilable("too many local variables");
     return NULL;
   }
 


### PR DESCRIPTION
8u backport request: Spark observes a significant performance deterioration between jdk17 and jdk8, too many live locals prevent C2 from compilation and it refreshes all tiers of results, please see [SPARK-40303](https://issues.apache.org/jira/browse/SPARK-40303?focusedCommentId=17619978&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17619978) for more details and explanations. This fix makes C2 compilation failure not affect C1. Low risk and apply clean.

Please help review it, thanks in advance.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8159720](https://bugs.openjdk.org/browse/JDK-8159720): Failure of C2 compilation with tiered prevents some C1 compilations


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/161/head:pull/161` \
`$ git checkout pull/161`

Update a local copy of the PR: \
`$ git checkout pull/161` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/161/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 161`

View PR using the GUI difftool: \
`$ git pr show -t 161`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/161.diff">https://git.openjdk.org/jdk8u-dev/pull/161.diff</a>

</details>
