### PR TITLE
8296555: Enable hotspot/tier1 for 64-bit builds in GHA for 8u

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -202,14 +202,14 @@ jobs:
         test:
           - jdk/tier1
           - langtools/tier1
-#          - hotspot/tier1
+          - hotspot/tier1
         include:
           - test: jdk/tier1
             suites: jdk_tier1
           - test: langtools/tier1
             suites: langtools_tier1
-#          - test: hotspot/tier1
-#            suites: hotspot_tier1
+          - test: hotspot/tier1
+            suites: hotspot_tier1
 
     env:
       JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).JDK_MAJOR_VERSION }}.${{ fromJson(needs.prerequisites.outputs.dependencies).JDK_MINOR_VERSION }}.${{ fromJson(needs.prerequisites.outputs.dependencies).JDK_MICRO_VERSION }}"
@@ -999,14 +999,14 @@ jobs:
         test:
           - jdk/tier1
           - langtools/tier1
-#          - hotspot/tier1
+          - hotspot/tier1
         include:
           - test: jdk/tier1
             suites: jdk_tier1
           - test: langtools/tier1
             suites: langtools_tier1
-#          - test: hotspot/tier1
-#            suites: hotspot_tier1
+          - test: hotspot/tier1
+            suites: hotspot_tier1
 
     env:
       JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).JDK_MAJOR_VERSION }}.${{ fromJson(needs.prerequisites.outputs.dependencies).JDK_MINOR_VERSION }}.${{ fromJson(needs.prerequisites.outputs.dependencies).JDK_MICRO_VERSION }}"
@@ -1387,14 +1387,14 @@ jobs:
         test:
           - jdk/tier1
           - langtools/tier1
-#          - hotspot/tier1
+          - hotspot/tier1
         include:
           - test: jdk/tier1
             suites: jdk_tier1
           - test: langtools/tier1
             suites: langtools_tier1
-#          - test: hotspot/tier1
-#            suites: hotspot_tier1
+          - test: hotspot/tier1
+            suites: hotspot_tier1
 
     env:
       JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).JDK_MAJOR_VERSION }}.${{ fromJson(needs.prerequisites.outputs.dependencies).JDK_MINOR_VERSION }}.${{ fromJson(needs.prerequisites.outputs.dependencies).JDK_MICRO_VERSION }}"


### PR DESCRIPTION
It is now possible to enable hostspot/tier1 in Github Actions at least for 64-bit builds as problematic compiler/rtm tests have been problem listed [1]. So far only for 64-bit builds, as there are still some tests failing for 32-bit builds, which need to be fixed, before it (hotspot/tier1) can be enabled there.

All tests passed.

[1] https://bugs.openjdk.org/browse/JDK-8295915

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296555](https://bugs.openjdk.org/browse/JDK-8296555): Enable hotspot/tier1 for 64-bit builds in GHA for 8u


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/163/head:pull/163` \
`$ git checkout pull/163`

Update a local copy of the PR: \
`$ git checkout pull/163` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/163/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 163`

View PR using the GUI difftool: \
`$ git pr show -t 163`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/163.diff">https://git.openjdk.org/jdk8u-dev/pull/163.diff</a>

</details>
