### PR TITLE
8197408: Bad pointer comparison and small cleanup in os_linux.cpp

### DIFF
--- a/hotspot/src/os/linux/vm/os_linux.cpp
+++ b/hotspot/src/os/linux/vm/os_linux.cpp
@@ -2284,7 +2284,7 @@ void os::Linux::print_full_memory_info(outputStream* st) {
 }
 
 void os::Linux::print_container_info(outputStream* st) {
-if (!OSContainer::is_containerized()) {
+  if (!OSContainer::is_containerized()) {
     return;
   }
 

--- a/hotspot/test/runtime/containers/cgroup/PlainRead.java
+++ b/hotspot/test/runtime/containers/cgroup/PlainRead.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test PlainRead
+ * @requires os.family == "linux"
+ * @library /testlibrary /test/lib
+ * @build sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ *                              sun.hotspot.WhiteBox$WhiteBoxPermission
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI PlainRead
+ */
+
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.Platform;
+import sun.hotspot.WhiteBox;
+
+public class PlainRead {
+
+    static public void match(OutputAnalyzer oa, String what, String value) {
+       oa.shouldMatch("^.*" + what + " *" + value + ".*$");
+    }
+
+    static public void noMatch(OutputAnalyzer oa, String what, String value) {
+       oa.shouldNotMatch("^.*" + what + " *" + value + ".*$");
+    }
+
+    static final String good_value = "(\\d+|-1|Unlimited)";
+    static final String bad_value = "(failed)";
+
+    static final String[] variables = {"Memory Limit is:", "CPU Shares is:", "CPU Quota is:", "CPU Period is:", "active_processor_count:"};
+
+    static public void isContainer(OutputAnalyzer oa) {
+        for (String v: variables) {
+            match(oa, v, good_value);
+        }
+        for (String v: variables) {
+            noMatch(oa, v, bad_value);
+        }
+    }
+
+    static public void isNotContainer(OutputAnalyzer oa) {
+       oa.shouldMatch("^.*Can't open /proc/self/mountinfo.*$");
+    }
+
+    public static void main(String[] args) throws Exception {
+        WhiteBox wb = WhiteBox.getWhiteBox();
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-Xlog:os+container=trace", "-version");
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+
+        if (wb.isContainerized()) {
+            System.out.println("Inside a cgroup, testing...");
+            isContainer(output);
+        } else {
+            System.out.println("Not in a cgroup, testing...");
+            isNotContainer(output);
+        }
+    }
+}

--- a/hotspot/test/runtime/containers/cgroup/PlainRead.java
+++ b/hotspot/test/runtime/containers/cgroup/PlainRead.java
@@ -66,7 +66,8 @@ public class PlainRead {
 
     public static void main(String[] args) throws Exception {
         WhiteBox wb = WhiteBox.getWhiteBox();
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-Xlog:os+container=trace", "-version");
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-XX:+UnlockDiagnosticVMOptions", "-XX:+PrintContainerInfo", "-version");
+
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
 
         if (wb.isContainerized()) {

--- a/hotspot/test/runtime/containers/cgroup/PlainRead.java
+++ b/hotspot/test/runtime/containers/cgroup/PlainRead.java
@@ -24,16 +24,16 @@
 /*
  * @test PlainRead
  * @requires os.family == "linux"
- * @library /testlibrary /test/lib
- * @build sun.hotspot.WhiteBox
- * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ * @library /testlibrary /testlibrary/whitebox
+ * @build PlainRead
+ * @run main ClassFileInstaller sun.hotspot.WhiteBox
  *                              sun.hotspot.WhiteBox$WhiteBoxPermission
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI PlainRead
  */
 
-import jdk.test.lib.process.ProcessTools;
-import jdk.test.lib.process.OutputAnalyzer;
-import jdk.test.lib.Platform;
+import com.oracle.java.testlibrary.ProcessTools;
+import com.oracle.java.testlibrary.OutputAnalyzer;
+import com.oracle.java.testlibrary.Platform;
 import sun.hotspot.WhiteBox;
 
 public class PlainRead {


### PR DESCRIPTION
This is a backport of [JDK-8197408](https://bugs.openjdk.org/browse/JDK-8197408) to jdk8u-dev as part of cgroups v2. I've backported it as a pre-requisite for 8278951: containers/cgroup/PlainRead.java fails on Ubuntu 21.10 (<https://github.com/openjdk/jdk8u-dev/pull/155>)

Most of the original patch has been integrated already: I've left a whitespace change in for os_linux.cpp to hopefully avoid context problems later on. The majority of this patch is introducing the test PlainRead.java.

Not clean: test adjustments to jtreg metadata, imports, and JVM flags needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8197408](https://bugs.openjdk.org/browse/JDK-8197408): Bad pointer comparison and small cleanup in os_linux.cpp


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/164/head:pull/164` \
`$ git checkout pull/164`

Update a local copy of the PR: \
`$ git checkout pull/164` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/164/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 164`

View PR using the GUI difftool: \
`$ git pr show -t 164`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/164.diff">https://git.openjdk.org/jdk8u-dev/pull/164.diff</a>

</details>
