### PR TITLE
8221529: [TESTBUG] Docker tests use old/deprecated image on AArch64

### DIFF
--- a/hotspot/test/testlibrary/com/oracle/java/testlibrary/DockerfileConfig.java
+++ b/hotspot/test/testlibrary/com/oracle/java/testlibrary/DockerfileConfig.java
@@ -44,7 +44,7 @@ public class DockerfileConfig {
 
         switch (Platform.getOsArch()) {
             case "aarch64":
-                return "aarch64/ubuntu";
+                return "arm64v8/ubuntu";
             case "ppc64le":
                 return "ppc64le/ubuntu";
             case "s390x":

--- a/jdk/test/lib/jdk/test/lib/containers/docker/DockerfileConfig.java
+++ b/jdk/test/lib/jdk/test/lib/containers/docker/DockerfileConfig.java
@@ -46,7 +46,7 @@ public class DockerfileConfig {
 
         switch (Platform.getOsArch()) {
             case "aarch64":
-                return "aarch64/ubuntu";
+                return "arm64v8/ubuntu";
             case "ppc64le":
                 return "ppc64le/ubuntu";
             case "s390x":


### PR DESCRIPTION
Backport trivial test fix to use correct base image architecture for aarch64.

Patch applied cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8221529](https://bugs.openjdk.org/browse/JDK-8221529): [TESTBUG] Docker tests use old/deprecated image on AArch64


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/166/head:pull/166` \
`$ git checkout pull/166`

Update a local copy of the PR: \
`$ git checkout pull/166` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/166/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 166`

View PR using the GUI difftool: \
`$ git pr show -t 166`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/166.diff">https://git.openjdk.org/jdk8u-dev/pull/166.diff</a>

</details>
