### PR TITLE
8253939: [TESTBUG] Increase coverage of the cgroups detection code

### DIFF
--- a/hotspot/test/runtime/containers/cgroup/CgroupSubsystemFactory.java
+++ b/hotspot/test/runtime/containers/cgroup/CgroupSubsystemFactory.java
@@ -56,6 +56,9 @@ public class CgroupSubsystemFactory {
     private static final int INVALID_CGROUPS_V1 = 4;
     private static final int INVALID_CGROUPS_NO_MOUNT = 5;
     private Path existingDirectory;
+    private Path cgroupv1CgroupsJoinControllers;
+    private Path cgroupv1SelfCgroupsJoinControllers;
+    private Path cgroupv1MountInfoJoinControllers;
     private Path cgroupv1CgInfoZeroHierarchy;
     private Path cgroupv1MntInfoZeroHierarchy;
     private Path cgroupv2CgInfoZeroHierarchy;
@@ -84,6 +87,17 @@ public class CgroupSubsystemFactory {
             "1:name=systemd:/user.slice/user-15263.slice/user@15263.service/gnome-terminal-server.service\n" +
             "0::/user.slice/user-15263.slice/user@15263.service/gnome-terminal-server.service";
     private String procSelfCgroupV2UnifiedContent = "0::/user.slice/user-1000.slice/session-3.scope";
+    private String procSelfCgroupV1JoinControllers =
+            "9:freezer:/\n" +
+            "8:rdma:/\n" +
+            "7:blkio:/user.slice\n" +
+            "6:devices:/user.slice\n" +
+            "5:pids:/user.slice/user-1000.slice/session-2.scope\n" +
+            "4:cpu,cpuacct,memory,net_cls,net_prio,hugetlb:/user.slice/user-1000.slice/session-2.scope\n" +
+            "3:cpuset:/\n" +
+            "2:perf_event:/\n" +
+            "1:name=systemd:/user.slice/user-1000.slice/session-2.scope\n" +
+            "0::/user.slice/user-1000.slice/session-2.scope\n";
     private String cgroupsZeroHierarchy =
             "#subsys_name hierarchy num_cgroups enabled\n" +
             "cpuset 0 1 1\n" +
@@ -95,6 +109,21 @@ public class CgroupSubsystemFactory {
             "net_cls 0 1 1\n" +
             "blkio 0 1 1\n" +
             "perf_event 0 1 1 ";
+    private String cgroupsNonZeroJoinControllers =
+            "#subsys_name hierarchy num_cgroups enabled\n" +
+            "cpuset\t3\t1\t1\n" +
+            "cpu\t4\t153\t1\n" +
+            "cpuacct\t4\t153\t1\n" +
+            "blkio\t7\t87\t1\n" +
+            "memory\t4\t153\t1\n" +
+            "devices\t6\t87\t1\n" +
+            "freezer\t9\t1\t1\n" +
+            "net_cls\t4\t153\t1\n" +
+            "perf_event\t2\t1\t1\n" +
+            "net_prio\t4\t153\t1\n" +
+            "hugetlb\t4\t153\t1\n" +
+            "pids\t5\t95\t1\n" +
+            "rdma\t8\t1\t1\n";
     private String cgroupV2LineHybrid = "31 30 0:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime shared:5 - cgroup2 none rw,seclabel,nsdelegate\n";
     private String cgroupv1MountInfoLineMemory = "35 30 0:31 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime shared:7 - cgroup none rw,seclabel,memory\n";
     private String mntInfoHybridStub =
@@ -113,6 +142,18 @@ public class CgroupSubsystemFactory {
     private String mntInfoHybridMissingMemory = mntInfoHybridStub;
     private String mntInfoHybrid = cgroupV2LineHybrid + mntInfoHybridRest;
     private String mntInfoHybridFlippedOrder = mntInfoHybridRest + cgroupV2LineHybrid;
+    private String mntInfoCgroupv1JoinControllers =
+            "31 22 0:26 / /sys/fs/cgroup ro,nosuid,nodev,noexec shared:9 - tmpfs tmpfs ro,mode=755\n" +
+            "32 31 0:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime shared:10 - cgroup2 cgroup2 rw,nsdelegate\n" +
+            "33 31 0:28 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime shared:11 - cgroup cgroup rw,xattr,name=systemd\n" +
+            "36 31 0:31 / /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime shared:15 - cgroup cgroup rw,perf_event\n" +
+            "37 31 0:32 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:16 - cgroup cgroup rw,cpuset\n" +
+            "38 31 0:33 / /sys/fs/cgroup/cpu,cpuacct,net_cls,net_prio,hugetlb,memory rw,nosuid,nodev,noexec,relatime shared:17 - cgroup cgroup rw,cpu,cpuacct,memory,net_cls,net_prio,hugetlb\n" +
+            "39 31 0:34 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime shared:18 - cgroup cgroup rw,pids\n" +
+            "40 31 0:35 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime shared:19 - cgroup cgroup rw,devices\n" +
+            "41 31 0:36 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime shared:20 - cgroup cgroup rw,blkio\n" +
+            "42 31 0:37 / /sys/fs/cgroup/rdma rw,nosuid,nodev,noexec,relatime shared:21 - cgroup cgroup rw,rdma\n" +
+            "43 31 0:38 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime shared:22 - cgroup cgroup rw,freezer\n";
     private String mntInfoCgroupv1MoreCpusetLine = "121 32 0:37 / /cpusets rw,relatime shared:69 - cgroup none rw,cpuset\n";
     private String mntInfoCgroupv1DoubleCpuset = mntInfoCgroupv1MoreCpusetLine + mntInfoHybrid;
     private String mntInfoCgroupv1DoubleCpuset2 =  mntInfoHybrid + mntInfoCgroupv1MoreCpusetLine;
@@ -178,6 +219,15 @@ public class CgroupSubsystemFactory {
 
             cgroupv1MntInfoSystemdOnly = Paths.get(existingDirectory.toString(), "mnt_info_cgroupv1_systemd_only");
             Files.write(cgroupv1MntInfoSystemdOnly, mntInfoCgroupsV1SystemdOnly.getBytes());
+
+            cgroupv1CgroupsJoinControllers = Paths.get(existingDirectory.toString(), "cgroups_cgv1_join_controllers");
+            Files.write(cgroupv1CgroupsJoinControllers, cgroupsNonZeroJoinControllers.getBytes());
+
+            cgroupv1SelfCgroupsJoinControllers = Paths.get(existingDirectory.toString(), "self_cgroup_cgv1_join_controllers");
+            Files.write(cgroupv1SelfCgroupsJoinControllers, procSelfCgroupV1JoinControllers.getBytes());
+
+            cgroupv1MountInfoJoinControllers = Paths.get(existingDirectory.toString(), "mntinfo_cgv1_join_controllers");
+            Files.write(cgroupv1MountInfoJoinControllers, mntInfoCgroupv1JoinControllers.getBytes());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -212,6 +262,16 @@ public class CgroupSubsystemFactory {
 
     private boolean isValidCgroup(int value) {
         return value == CGROUPS_V1 || value == CGROUPS_V2;
+    }
+
+    public void testCgroupv1JoinControllerCombo(WhiteBox wb) {
+        String procCgroups = cgroupv1CgroupsJoinControllers.toString();
+        String procSelfCgroup = cgroupv1SelfCgroupsJoinControllers.toString();
+        String procSelfMountinfo = cgroupv1MountInfoJoinControllers.toString();
+        int retval = wb.validateCgroup(procCgroups, procSelfCgroup, procSelfMountinfo);
+        Asserts.assertEQ(CGROUPS_V1, retval, "Join controllers should be properly detected");
+        Asserts.assertTrue(isValidCgroup(retval));
+        System.out.println("testCgroupv1JoinControllerMounts PASSED!");
     }
 
     public void testCgroupv1MultipleCpusetMounts(WhiteBox wb, Path mountInfo) {
@@ -309,6 +369,7 @@ public class CgroupSubsystemFactory {
             test.testCgroupv2NoCgroup2Fs(wb);
             test.testCgroupv1MultipleCpusetMounts(wb, test.cgroupv1MntInfoDoubleCpuset);
             test.testCgroupv1MultipleCpusetMounts(wb, test.cgroupv1MntInfoDoubleCpuset2);
+            test.testCgroupv1JoinControllerCombo(wb);
         } finally {
             test.teardown();
         }

--- a/jdk/test/jdk/internal/platform/cgroup/TestCgroupSubsystemFactory.java
+++ b/jdk/test/jdk/internal/platform/cgroup/TestCgroupSubsystemFactory.java
@@ -50,6 +50,8 @@ import jdk.testlibrary.FileUtils;
 public class TestCgroupSubsystemFactory {
 
     private Path existingDirectory;
+    private Path cgroupv1CgroupsJoinControllers;
+    private Path cgroupv1MountInfoJoinControllers;
     private Path cgroupv1CgInfoZeroHierarchy;
     private Path cgroupv1MntInfoZeroHierarchy;
     private Path cgroupv2CgInfoZeroHierarchy;
@@ -57,7 +59,24 @@ public class TestCgroupSubsystemFactory {
     private Path cgroupv1CgInfoNonZeroHierarchy;
     private Path cgroupv1MntInfoNonZeroHierarchy;
     private Path cgroupv1MntInfoSystemdOnly;
+    private Path cgroupv1MntInfoDoubleCpusets;
+    private Path cgroupv1MntInfoDoubleCpusets2;
     private String mntInfoEmpty = "";
+    private String cgroupsNonZeroJoinControllers =
+            "#subsys_name hierarchy num_cgroups enabled\n" +
+            "cpuset\t3\t1\t1\n" +
+            "cpu\t4\t153\t1\n" +
+            "cpuacct\t4\t153\t1\n" +
+            "blkio\t7\t87\t1\n" +
+            "memory\t4\t153\t1\n" +
+            "devices\t6\t87\t1\n" +
+            "freezer\t9\t1\t1\n" +
+            "net_cls\t4\t153\t1\n" +
+            "perf_event\t2\t1\t1\n" +
+            "net_prio\t4\t153\t1\n" +
+            "hugetlb\t4\t153\t1\n" +
+            "pids\t5\t95\t1\n" +
+            "rdma\t8\t1\t1\n";
     private String cgroupsZeroHierarchy =
             "#subsys_name hierarchy num_cgroups enabled\n" +
             "cpuset 0 1 1\n" +
@@ -71,18 +90,30 @@ public class TestCgroupSubsystemFactory {
             "perf_event 0 1 1 ";
     private String mntInfoHybrid =
             "30 23 0:26 / /sys/fs/cgroup ro,nosuid,nodev,noexec shared:4 - tmpfs tmpfs ro,seclabel,mode=755\n" +
-            "31 30 0:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime shared:5 - cgroup2 cgroup2 rw,seclabel,nsdelegate\n" +
-            "32 30 0:28 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime shared:6 - cgroup cgroup rw,seclabel,xattr,name=systemd\n" +
-            "35 30 0:31 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime shared:7 - cgroup cgroup rw,seclabel,memory\n" +
-            "36 30 0:32 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime shared:8 - cgroup cgroup rw,seclabel,pids\n" +
-            "37 30 0:33 / /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime shared:9 - cgroup cgroup rw,seclabel,perf_event\n" +
-            "38 30 0:34 / /sys/fs/cgroup/net_cls,net_prio rw,nosuid,nodev,noexec,relatime shared:10 - cgroup cgroup rw,seclabel,net_cls,net_prio\n" +
-            "39 30 0:35 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime shared:11 - cgroup cgroup rw,seclabel,hugetlb\n" +
-            "40 30 0:36 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:12 - cgroup cgroup rw,seclabel,cpu,cpuacct\n" +
-            "41 30 0:37 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime shared:13 - cgroup cgroup rw,seclabel,devices\n" +
-            "42 30 0:38 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:14 - cgroup cgroup rw,seclabel,cpuset\n" +
-            "43 30 0:39 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime shared:15 - cgroup cgroup rw,seclabel,blkio\n" +
-            "44 30 0:40 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime shared:16 - cgroup cgroup rw,seclabel,freezer";
+            "31 30 0:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime shared:5 - cgroup2 none rw,seclabel,nsdelegate\n" +
+            "32 30 0:28 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime shared:6 - cgroup none rw,seclabel,xattr,name=systemd\n" +
+            "35 30 0:31 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime shared:7 - cgroup none rw,seclabel,memory\n" +
+            "36 30 0:32 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime shared:8 - cgroup none rw,seclabel,pids\n" +
+            "37 30 0:33 / /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime shared:9 - cgroup none rw,seclabel,perf_event\n" +
+            "38 30 0:34 / /sys/fs/cgroup/net_cls,net_prio rw,nosuid,nodev,noexec,relatime shared:10 - cgroup none rw,seclabel,net_cls,net_prio\n" +
+            "39 30 0:35 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime shared:11 - cgroup none rw,seclabel,hugetlb\n" +
+            "40 30 0:36 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:12 - cgroup none rw,seclabel,cpu,cpuacct\n" +
+            "41 30 0:37 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime shared:13 - cgroup none rw,seclabel,devices\n" +
+            "42 30 0:38 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:14 - cgroup none rw,seclabel,cpuset\n" +
+            "43 30 0:39 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime shared:15 - cgroup none rw,seclabel,blkio\n" +
+            "44 30 0:40 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime shared:16 - cgroup none rw,seclabel,freezer\n";
+    private String mntInfoCgroupv1JoinControllers =
+            "31 22 0:26 / /sys/fs/cgroup ro,nosuid,nodev,noexec shared:9 - tmpfs tmpfs ro,mode=755\n" +
+            "32 31 0:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime shared:10 - cgroup2 cgroup2 rw,nsdelegate\n" +
+            "33 31 0:28 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime shared:11 - cgroup cgroup rw,xattr,name=systemd\n" +
+            "36 31 0:31 / /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime shared:15 - cgroup cgroup rw,perf_event\n" +
+            "37 31 0:32 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:16 - cgroup cgroup rw,cpuset\n" +
+            "38 31 0:33 / /sys/fs/cgroup/cpu,cpuacct,net_cls,net_prio,hugetlb,memory rw,nosuid,nodev,noexec,relatime shared:17 - cgroup cgroup rw,cpu,cpuacct,memory,net_cls,net_prio,hugetlb\n" +
+            "39 31 0:34 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime shared:18 - cgroup cgroup rw,pids\n" +
+            "40 31 0:35 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime shared:19 - cgroup cgroup rw,devices\n" +
+            "41 31 0:36 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime shared:20 - cgroup cgroup rw,blkio\n" +
+            "42 31 0:37 / /sys/fs/cgroup/rdma rw,nosuid,nodev,noexec,relatime shared:21 - cgroup cgroup rw,rdma\n" +
+            "43 31 0:38 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime shared:22 - cgroup cgroup rw,freezer\n";
     private String cgroupsNonZeroHierarchy =
             "#subsys_name hierarchy   num_cgroups enabled\n" +
             "cpuset  9   1   1\n" +
@@ -98,10 +129,13 @@ public class TestCgroupSubsystemFactory {
             "hugetlb 6   1   1\n" +
             "pids    3   80  1";
     private String mntInfoCgroupsV2Only =
-            "28 21 0:25 / /sys/fs/cgroup rw,nosuid,nodev,noexec,relatime shared:4 - cgroup2 cgroup2 rw,seclabel,nsdelegate";
+            "28 21 0:25 / /sys/fs/cgroup rw,nosuid,nodev,noexec,relatime shared:4 - cgroup2 none rw,seclabel,nsdelegate";
     private String mntInfoCgroupsV1SystemdOnly =
             "35 26 0:26 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime - cgroup systemd rw,name=systemd\n" +
             "26 18 0:19 / /sys/fs/cgroup rw,relatime - tmpfs none rw,size=4k,mode=755\n";
+    private String mntInfoCgroupv1MoreCpusetLine = "121 32 0:37 / /cpuset rw,relatime shared:69 - cgroup none rw,cpuset\n";
+    private String mntInfoCgroupsV1DoubleCpuset = mntInfoHybrid + mntInfoCgroupv1MoreCpusetLine;
+    private String mntInfoCgroupsV1DoubleCpuset2 = mntInfoCgroupv1MoreCpusetLine + mntInfoHybrid;
 
     @Before
     public void setup() {
@@ -125,6 +159,18 @@ public class TestCgroupSubsystemFactory {
 
             cgroupv1MntInfoSystemdOnly = Paths.get(existingDirectory.toString(), "mountinfo_cgroupv1_systemd_only");
             Files.write(cgroupv1MntInfoSystemdOnly, mntInfoCgroupsV1SystemdOnly.getBytes());
+
+            cgroupv1MntInfoDoubleCpusets = Paths.get(existingDirectory.toString(), "mountinfo_cgroupv1_double_cpuset");
+            Files.write(cgroupv1MntInfoDoubleCpusets, mntInfoCgroupsV1DoubleCpuset.getBytes());
+
+            cgroupv1MntInfoDoubleCpusets2 = Paths.get(existingDirectory.toString(), "mountinfo_cgroupv1_double_cpuset2");
+            Files.write(cgroupv1MntInfoDoubleCpusets2, mntInfoCgroupsV1DoubleCpuset2.getBytes());
+
+            cgroupv1CgroupsJoinControllers = Paths.get(existingDirectory.toString(), "cgroups_cgv1_join_controllers");
+            Files.write(cgroupv1CgroupsJoinControllers, cgroupsNonZeroJoinControllers.getBytes());
+
+            cgroupv1MountInfoJoinControllers = Paths.get(existingDirectory.toString(), "mntinfo_cgv1_join_controllers");
+            Files.write(cgroupv1MountInfoJoinControllers, mntInfoCgroupv1JoinControllers.getBytes());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -140,12 +186,39 @@ public class TestCgroupSubsystemFactory {
     }
 
     @Test
+    public void testCgroupv1JoinControllerCombo() throws IOException {
+        String cgroups = cgroupv1CgroupsJoinControllers.toString();
+        String mountInfo = cgroupv1MountInfoJoinControllers.toString();
+        Optional<CgroupTypeResult> result = CgroupSubsystemFactory.determineType(mountInfo, cgroups);
+
+        assertTrue("Expected non-empty cgroup result", result.isPresent());
+        CgroupTypeResult res = result.get();
+        assertFalse("Join controller combination expected as cgroups v1", res.isCgroupV2());
+    }
+
+    @Test
     public void testCgroupv1SystemdOnly() throws IOException {
         String cgroups = cgroupv1CgInfoZeroHierarchy.toString();
         String mountInfo = cgroupv1MntInfoSystemdOnly.toString();
         Optional<CgroupTypeResult> result = CgroupSubsystemFactory.determineType(mountInfo, cgroups);
 
         assertTrue("zero hierarchy ids with no *relevant* controllers mounted", Optional.empty().equals(result));
+    }
+
+    @Test
+    public void testCgroupv1MultipleCpusetMounts() throws IOException {
+        doMultipleCpusetMountsTest(cgroupv1MntInfoDoubleCpusets);
+        doMultipleCpusetMountsTest(cgroupv1MntInfoDoubleCpusets2);
+    }
+
+    private void doMultipleCpusetMountsTest(Path info) throws IOException {
+        String cgroups = cgroupv1CgInfoNonZeroHierarchy.toString();
+        String mountInfo = info.toString();
+        Optional<CgroupTypeResult> result = CgroupSubsystemFactory.determineType(mountInfo, cgroups);
+
+        assertTrue("Expected non-empty cgroup result", result.isPresent());
+        CgroupTypeResult res = result.get();
+        assertFalse("Duplicate cpusets should not influence detection heuristic", res.isCgroupV2());
     }
 
     @Test


### PR DESCRIPTION
This is a backport of 8253939  to jdk8u-dev for cgroups v2 support.

It's not clean: several `Files.writeString` → `Files.write(…,.getBytes())` changes needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8253939](https://bugs.openjdk.org/browse/JDK-8253939): [TESTBUG] Increase coverage of the cgroups detection code


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/169/head:pull/169` \
`$ git checkout pull/169`

Update a local copy of the PR: \
`$ git checkout pull/169` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/169/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 169`

View PR using the GUI difftool: \
`$ git pr show -t 169`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/169.diff">https://git.openjdk.org/jdk8u-dev/pull/169.diff</a>

</details>
