### PR TITLE
8262379: Add regression test for JDK-8257746

### DIFF
--- a/jdk/test/jdk/internal/platform/cgroup/TestCgroupSubsystemFactory.java
+++ b/jdk/test/jdk/internal/platform/cgroup/TestCgroupSubsystemFactory.java
@@ -23,6 +23,8 @@
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -30,6 +32,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
+import java.util.Map;
 
 import org.junit.After;
 import org.junit.Before;
@@ -38,6 +41,9 @@ import org.junit.Test;
 import jdk.internal.platform.CgroupInfo;
 import jdk.internal.platform.CgroupSubsystemFactory;
 import jdk.internal.platform.CgroupSubsystemFactory.CgroupTypeResult;
+import jdk.internal.platform.CgroupV1MetricsImpl;
+import jdk.internal.platform.cgroupv1.CgroupV1Subsystem;
+import jdk.internal.platform.Metrics;
 import jdk.testlibrary.Utils;
 import jdk.testlibrary.FileUtils;
 
@@ -66,6 +72,9 @@ public class TestCgroupSubsystemFactory {
     private Path cgroupv1SelfCgroup;
     private Path cgroupv2SelfCgroup;
     private Path cgroupv1SelfCgroupJoinCtrl;
+    private Path cgroupv1CgroupsOnlyCPUCtrl;
+    private Path cgroupv1SelfCgroupsOnlyCPUCtrl;
+    private Path cgroupv1MountInfoCgroupsOnlyCPUCtrl;
     private String mntInfoEmpty = "";
     private String cgroupsNonZeroJoinControllers =
             "#subsys_name hierarchy num_cgroups enabled\n" +
@@ -82,6 +91,12 @@ public class TestCgroupSubsystemFactory {
             "hugetlb\t4\t153\t1\n" +
             "pids\t5\t95\t1\n" +
             "rdma\t8\t1\t1\n";
+    private String cgroupsNonZeroCpuControllerOnly =
+            "#subsys_name hierarchy num_cgroups enabled\n" +
+            "cpu\t4\t153\t1\n" +
+            "cpuacct\t4\t153\t1\n";
+    private String selfCgroupNonZeroCpuControllerOnly =
+            "4:cpu,cpuacct:/user.slice/user-1000.slice/session-3.scope\n";
     private String selfCgroupNonZeroJoinControllers =
             "9:cpuset:/\n" +
             "8:perf_event:/\n" +
@@ -118,6 +133,9 @@ public class TestCgroupSubsystemFactory {
             "42 30 0:38 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:14 - cgroup none rw,seclabel,cpuset\n" +
             "43 30 0:39 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime shared:15 - cgroup none rw,seclabel,blkio\n" +
             "44 30 0:40 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime shared:16 - cgroup none rw,seclabel,freezer\n";
+    private String mntInfoCpuOnly =
+            "30 23 0:26 / /sys/fs/cgroup ro,nosuid,nodev,noexec shared:4 - tmpfs tmpfs ro,seclabel,mode=755\n" +
+            "40 30 0:36 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:12 - cgroup none rw,seclabel,cpu,cpuacct\n";
     private String mntInfoCgroupv1JoinControllers =
             "31 22 0:26 / /sys/fs/cgroup ro,nosuid,nodev,noexec shared:9 - tmpfs tmpfs ro,mode=755\n" +
             "32 31 0:27 / /sys/fs/cgroup/unified rw,nosuid,nodev,noexec,relatime shared:10 - cgroup2 cgroup2 rw,nsdelegate\n" +
@@ -209,6 +227,15 @@ public class TestCgroupSubsystemFactory {
 
             cgroupv1SelfCgroupJoinCtrl = Paths.get(existingDirectory.toString(), "self_cgroup_cgv1_join_controllers");
             Files.write(cgroupv1SelfCgroupJoinCtrl, selfCgroupNonZeroJoinControllers.getBytes());
+
+            cgroupv1CgroupsOnlyCPUCtrl = Paths.get(existingDirectory.toString(), "cgroups_cpu_only_controller");
+            Files.write(cgroupv1CgroupsOnlyCPUCtrl, cgroupsNonZeroCpuControllerOnly.getBytes());
+
+            cgroupv1SelfCgroupsOnlyCPUCtrl = Paths.get(existingDirectory.toString(), "self_cgroup_cpu_only_controller");
+            Files.write(cgroupv1SelfCgroupsOnlyCPUCtrl, selfCgroupNonZeroCpuControllerOnly.getBytes());
+
+            cgroupv1MountInfoCgroupsOnlyCPUCtrl = Paths.get(existingDirectory.toString(), "self_mountinfo_cpu_only_controller");
+            Files.write(cgroupv1MountInfoCgroupsOnlyCPUCtrl, mntInfoCpuOnly.getBytes());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -221,6 +248,34 @@ public class TestCgroupSubsystemFactory {
         } catch (IOException e) {
             System.err.println("Teardown failed. " + e.getMessage());
         }
+    }
+
+    @Test
+    public void testCgroupv1CpuControllerOnly() throws IOException {
+        String cgroups = cgroupv1CgroupsOnlyCPUCtrl.toString();
+        String mountInfo = cgroupv1MountInfoCgroupsOnlyCPUCtrl.toString();
+        String selfCgroup = cgroupv1SelfCgroupsOnlyCPUCtrl.toString();
+        Optional<CgroupTypeResult> result = CgroupSubsystemFactory.determineType(mountInfo, cgroups, selfCgroup);
+
+        assertTrue("Expected non-empty cgroup result", result.isPresent());
+        CgroupTypeResult res = result.get();
+        assertFalse("Expected cgroup v1", res.isCgroupV2());
+        Map<String, CgroupInfo> infos = res.getInfos();
+        assertNull("Memory controller expected null", infos.get("memory"));
+        assertNotNull("Cpu controller expected non-null", infos.get("cpu"));
+
+        // cgroup v1 tests only as this isn't possible with unified hierarchy
+        // where all controllers have the same mount point
+        CgroupV1Subsystem subsystem = CgroupV1Subsystem.getInstance(infos);
+        // This throws NPEs prior JDK-8257746
+        long val = subsystem.getMemoryAndSwapLimit();
+        assertEquals("expected unlimited, and no NPE", -1, val);
+        val = subsystem.getMemoryAndSwapFailCount();
+        assertEquals("expected unlimited, and no NPE", -1, val);
+        val = subsystem.getMemoryAndSwapMaxUsage();
+        assertEquals("expected unlimited, and no NPE", -1, val);
+        val = subsystem.getMemoryAndSwapUsage();
+        assertEquals("expected unlimited, and no NPE", -1, val);
     }
 
     @Test


### PR DESCRIPTION
This is a backport of 8262379: Add regression test for JDK-8257746 for jdk8u-dev as part of cgroups v2 support.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8262379](https://bugs.openjdk.org/browse/JDK-8262379): Add regression test for JDK-8257746


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/171/head:pull/171` \
`$ git checkout pull/171`

Update a local copy of the PR: \
`$ git checkout pull/171` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/171/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 171`

View PR using the GUI difftool: \
`$ git pr show -t 171`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/171.diff">https://git.openjdk.org/jdk8u-dev/pull/171.diff</a>

</details>
