### PR TITLE
8296959: Fix hotspot shell tests of 8u on multilib systems

### DIFF
--- a/hotspot/test/compiler/criticalnatives/argumentcorruption/Test8167409.sh
+++ b/hotspot/test/compiler/criticalnatives/argumentcorruption/Test8167409.sh
@@ -73,7 +73,7 @@ THIS_DIR=.
 cp ${TESTSRC}${FS}*.java ${THIS_DIR}
 ${TESTJAVA}${FS}bin${FS}javac *.java
 
-$cc_cmd -fPIC -shared -o libCNCheckLongArgs.so \
+$cc_cmd ${CFLAGBITS} -fPIC -shared -o libCNCheckLongArgs.so \
     -I${TESTJAVA}${FS}include -I${TESTJAVA}${FS}include${FS}linux \
     ${TESTSRC}${FS}libCNCheckLongArgs.c
 

--- a/hotspot/test/runtime/7107135/Test7107135.sh
+++ b/hotspot/test/runtime/7107135/Test7107135.sh
@@ -65,7 +65,7 @@ THIS_DIR=.
 cp ${TESTSRC}${FS}*.java ${THIS_DIR}
 ${TESTJAVA}${FS}bin${FS}javac *.java
 
-$gcc_cmd -fPIC -shared -c -o test.o \
+$gcc_cmd ${CFLAGBITS} -fPIC -shared -c -o test.o \
     -I${TESTJAVA}${FS}include -I${TESTJAVA}${FS}include${FS}linux \
     ${TESTSRC}${FS}test.c
 

--- a/hotspot/test/runtime/InitialThreadOverflow/testme.sh
+++ b/hotspot/test/runtime/InitialThreadOverflow/testme.sh
@@ -49,8 +49,6 @@ if [ "x$gcc_cmd" = "x" ]; then
     exit 0;
 fi
 
-CFLAGS="-m${VM_BITS}"
-
 LD_LIBRARY_PATH=.:${COMPILEJAVA}/jre/lib/${VM_CPU}/${VM_TYPE}:/usr/lib:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH
 
@@ -59,12 +57,11 @@ cp ${TESTSRC}${FS}invoke.cxx .
 # Copy the result of our @compile action:
 cp ${TESTCLASSES}${FS}DoOverflow.class .
 
-echo "Compilation flag: ${COMP_FLAG}"
 # Note pthread may not be found thus invoke creation will fail to be created.
 # Check to ensure you have a /usr/lib/libpthread.so if you don't please look
 # for /usr/lib/`uname -m`-linux-gnu version ensure to add that path to below compilation.
 
-$gcc_cmd -DLINUX ${CFLAGS} -o invoke \
+$gcc_cmd -DLINUX ${CFLAGBITS} -o invoke \
     -I${COMPILEJAVA}/include -I${COMPILEJAVA}/include/linux \
     -L${COMPILEJAVA}/jre/lib/${VM_CPU}/${VM_TYPE} \
     -ljvm -lpthread invoke.cxx

--- a/hotspot/test/runtime/StackGap/testme.sh
+++ b/hotspot/test/runtime/StackGap/testme.sh
@@ -49,11 +49,6 @@ if [ "x$gcc_cmd" = "x" ]; then
     exit 0;
 fi
 
-if [ "x${VM_CPU}" != "xaarch64" ];
-then
-    CFLAGS="-m${VM_BITS}"
-fi
-
 LD_LIBRARY_PATH=.:${COMPILEJAVA}/jre/lib/${VM_CPU}/${VM_TYPE}:/usr/lib:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH
 
@@ -62,12 +57,11 @@ cp ${TESTSRC}${FS}exestack-gap.c .
 # Copy the result of our @compile action:
 cp ${TESTCLASSES}${FS}T.class .
 
-echo "Compilation flag: ${COMP_FLAG}"
 # Note pthread may not be found thus invoke creation will fail to be created.
 # Check to ensure you have a /usr/lib/libpthread.so if you don't please look
 # for /usr/lib/`uname -m`-linux-gnu version ensure to add that path to below compilation.
 
-$gcc_cmd -DLINUX ${CFLAGS} -o stack-gap \
+$gcc_cmd -DLINUX ${CFLAGBITS} -o stack-gap \
     -I${COMPILEJAVA}/include -I${COMPILEJAVA}/include/linux \
     -L${COMPILEJAVA}/jre/lib/${VM_CPU}/${VM_TYPE} \
     exestack-gap.c \

--- a/hotspot/test/runtime/jni/CallWithJNIWeak/test.sh
+++ b/hotspot/test/runtime/jni/CallWithJNIWeak/test.sh
@@ -68,7 +68,7 @@ THIS_DIR=.
 cp ${TESTSRC}${FS}*.java ${THIS_DIR}
 ${TESTJAVA}${FS}bin${FS}javac *.java
 
-$cc_cmd -fPIC -shared -o libCallWithJNIWeak.so \
+$cc_cmd ${CFLAGBITS} -fPIC -shared -o libCallWithJNIWeak.so \
     -I${TESTJAVA}${FS}include -I${TESTJAVA}${FS}include${FS}linux \
     ${TESTSRC}${FS}CallWithJNIWeak.c
 

--- a/hotspot/test/runtime/jni/ReturnJNIWeak/test.sh
+++ b/hotspot/test/runtime/jni/ReturnJNIWeak/test.sh
@@ -68,7 +68,7 @@ THIS_DIR=.
 cp ${TESTSRC}${FS}*.java ${THIS_DIR}
 ${TESTJAVA}${FS}bin${FS}javac *.java
 
-$cc_cmd -fPIC -shared -o libReturnJNIWeak.so \
+$cc_cmd ${CFLAGBITS} -fPIC -shared -o libReturnJNIWeak.so \
     -I${TESTJAVA}${FS}include -I${TESTJAVA}${FS}include${FS}linux \
     ${TESTSRC}${FS}ReturnJNIWeak.c
 

--- a/hotspot/test/runtime/jsig/Test8017498.sh
+++ b/hotspot/test/runtime/jsig/Test8017498.sh
@@ -70,7 +70,7 @@ THIS_DIR=.
 cp ${TESTSRC}${FS}*.java ${THIS_DIR}
 ${TESTJAVA}${FS}bin${FS}javac *.java
 
-$gcc_cmd -DLINUX -fPIC -shared \
+$gcc_cmd -DLINUX ${CFLAGBITS} -fPIC -shared \
     -o ${TESTSRC}${FS}libTestJNI.so \
     -I${TESTJAVA}${FS}include \
     -I${TESTJAVA}${FS}include${FS}linux \

--- a/hotspot/test/test_env.sh
+++ b/hotspot/test/test_env.sh
@@ -157,6 +157,7 @@ then
 fi
 
 VM_CPU="unknown"
+CFLAGBITS=""
 grep "sparc" vm_version.out > ${NULL}
 if [ $? = 0 ]
 then
@@ -164,12 +165,15 @@ then
   if [ $VM_BITS = "64" ]
   then
     VM_CPU="sparcv9"
+  else
+    CFLAGBITS="-m32"
   fi
 fi
 grep "x86" vm_version.out > ${NULL}
 if [ $? = 0 ]
 then
   VM_CPU="i386"
+  CFLAGBITS="-m32"
 fi
 grep "amd64" vm_version.out > ${NULL}
 if [ $? = 0 ]
@@ -193,6 +197,8 @@ then
     then
       VM_CPU="ppc64le"
     fi
+  else
+    CFLAGBITS="-m32"
   fi
 fi
 grep "ia64" vm_version.out > ${NULL}


### PR DESCRIPTION
Few hotspot tests (from hotspot/tier1) currently fail for x86 (32-bit) builds on 64-bit system (Linux).
```
compiler/criticalnatives/argumentcorruption/Test8167409.sh 
runtime/jni/CallWithJNIWeak/test.sh 
runtime/jni/ReturnJNIWeak/test.sh
```
**Problem:**
Tests build 64-bit JNI libraries and trying to use them for 32-bit jdk, resulting in error:
```
Exception in thread "main" java.lang.UnsatisfiedLinkError: /home/runner/work/jdk8u-dev/jdk8u-dev/test-results/testoutput/hotspot_tier1/JTwork/scratch/libCNCheckLongArgs.so: /home/runner/work/jdk8u-dev/jdk8u-dev/test-results/testoutput/hotspot_tier1/JTwork/scratch/libCNCheckLongArgs.so: wrong ELF class: ELFCLASS64 (Possible cause: architecture word width mismatch)
```
These tests only target Linux and (some) Solaris.

**Solution:**
Fixed by supplying appropriate compiler argument (-m32) to build 32-bit libraries for 32-bit JDK. (Some tests already did that, but not in uniform way). I verified in manpage of gcc that -m32 argument is supported for all 32-bit variants of architectures supported by JDK 8 [1]. Solaris cc also seems to support -m32 [2].
This fix is JDK 8 only as newer JDK use new approach, where JNI test libraries are build are build system and tests not longer build them themselfs.

**Testing:**
Change fixed these tests on linux-x86. (tested here [3])
Tests are part of hotspot/tier1. This is one of problems, which needs to be fixed, so that hotspot/tier1 can be enabled in GHA on linux-x86. Other one is JDK-8295952 [4] (will need to get fixed and backported).

[1]  https://man7.org/linux/man-pages/man1/gcc.1.html
[2] https://docs.oracle.com/cd/E37069_01/html/E54439/cc-1.html
[3] https://github.com/zzambers/jdk8u-dev/actions/runs/3441392968
[4] https://bugs.openjdk.org/browse/JDK-8295952

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296959](https://bugs.openjdk.org/browse/JDK-8296959): Fix hotspot shell tests of 8u on multilib systems


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/173/head:pull/173` \
`$ git checkout pull/173`

Update a local copy of the PR: \
`$ git checkout pull/173` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/173/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 173`

View PR using the GUI difftool: \
`$ git pr show -t 173`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/173.diff">https://git.openjdk.org/jdk8u-dev/pull/173.diff</a>

</details>
