### PR TITLE
8291570: [TESTBUG] Part of JDK-8250984 absent from 11u

### DIFF
--- a/hotspot/test/runtime/containers/cgroup/PlainRead.java
+++ b/hotspot/test/runtime/containers/cgroup/PlainRead.java
@@ -46,7 +46,7 @@ public class PlainRead {
        oa.shouldNotMatch("^.*" + what + " *" + value + ".*$");
     }
 
-    static final String good_value = "(\\d+|-1|Unlimited)";
+    static final String good_value = "(\\d+|-1|-2|Unlimited)";
     static final String bad_value = "(failed)";
 
     static final String[] variables = {"Memory Limit is:", "CPU Shares is:", "CPU Quota is:", "CPU Period is:", "active_processor_count:"};


### PR DESCRIPTION
This is a clean backport of 8291570 (from jdk11u) as part of cgroups v2 support.

The affected test passes for me after the patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291570](https://bugs.openjdk.org/browse/JDK-8291570): [TESTBUG] Part of JDK-8250984 absent from 11u


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**) ⚠️ Review applies to [428514ec](https://git.openjdk.org/jdk8u-dev/pull/175/files/428514ecdbf1ab4469bbdfe6c309a12a06d3f284)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/175/head:pull/175` \
`$ git checkout pull/175`

Update a local copy of the PR: \
`$ git checkout pull/175` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/175/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 175`

View PR using the GUI difftool: \
`$ git pr show -t 175`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/175.diff">https://git.openjdk.org/jdk8u-dev/pull/175.diff</a>

</details>
