### PR TITLE
8252957: Wrong comment in CgroupV1Subsystem::cpu_quota

### DIFF
--- a/hotspot/src/os/linux/vm/cgroupV1Subsystem_linux.cpp
+++ b/hotspot/src/os/linux/vm/cgroupV1Subsystem_linux.cpp
@@ -212,11 +212,11 @@ char * CgroupV1Subsystem::cpu_cpuset_memory_nodes() {
 
 /* cpu_quota
  *
- * Return the number of milliseconds per period
+ * Return the number of microseconds per period
  * process is guaranteed to run.
  *
  * return:
- *    quota time in milliseconds
+ *    quota time in microseconds
  *    -1 for no quota
  *    OSCONTAINER_ERROR for not supported
  */

--- a/hotspot/src/os/linux/vm/cgroupV2Subsystem_linux.cpp
+++ b/hotspot/src/os/linux/vm/cgroupV2Subsystem_linux.cpp
@@ -82,11 +82,11 @@ int CgroupV2Subsystem::cpu_shares() {
 
 /* cpu_quota
  *
- * Return the number of milliseconds per period
+ * Return the number of microseconds per period
  * process is guaranteed to run.
  *
  * return:
- *    quota time in milliseconds
+ *    quota time in microseconds
  *    -1 for no quota
  *    OSCONTAINER_ERROR for not supported
  */


### PR DESCRIPTION
Simple, comment-only backport for cgroups v2 support in jdk8u. Clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8252957](https://bugs.openjdk.org/browse/JDK-8252957): Wrong comment in CgroupV1Subsystem::cpu_quota


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/176/head:pull/176` \
`$ git checkout pull/176`

Update a local copy of the PR: \
`$ git checkout pull/176` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/176/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 176`

View PR using the GUI difftool: \
`$ git pr show -t 176`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/176.diff">https://git.openjdk.org/jdk8u-dev/pull/176.diff</a>

</details>
