### PR TITLE
8284756: [11u] Remove unused isUseContainerSupport in CgroupV1Subsystem

### DIFF
--- a/jdk/src/linux/classes/jdk/internal/platform/cgroupv1/CgroupV1Subsystem.java
+++ b/jdk/src/linux/classes/jdk/internal/platform/cgroupv1/CgroupV1Subsystem.java
@@ -408,6 +408,4 @@ public class CgroupV1Subsystem implements CgroupSubsystem, CgroupV1Metrics {
         return CgroupV1SubsystemController.getLongEntry(blkio, "blkio.throttle.io_serviced", "Total");
     }
 
-    private static native boolean isUseContainerSupport();
-
 }


### PR DESCRIPTION
Clean simple backport of 8284756 for jdk8u-dev cgroups v2 support.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284756](https://bugs.openjdk.org/browse/JDK-8284756): [11u] Remove unused isUseContainerSupport in CgroupV1Subsystem


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/178/head:pull/178` \
`$ git checkout pull/178`

Update a local copy of the PR: \
`$ git checkout pull/178` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/178/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 178`

View PR using the GUI difftool: \
`$ git pr show -t 178`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/178.diff">https://git.openjdk.org/jdk8u-dev/pull/178.diff</a>

</details>
