### PR TITLE
8292083: Detected container memory limit may exceed physical machine memory

### DIFF
--- a/hotspot/src/os/linux/vm/cgroupSubsystem_linux.cpp
+++ b/hotspot/src/os/linux/vm/cgroupSubsystem_linux.cpp
@@ -543,7 +543,30 @@ jlong CgroupSubsystem::memory_limit_in_bytes() {
   if (!memory_limit->should_check_metric()) {
     return memory_limit->value();
   }
+  jlong phys_mem = os::Linux::physical_memory();
+  log_trace(os, container)("total physical memory: " JLONG_FORMAT, phys_mem);
   jlong mem_limit = read_memory_limit_in_bytes();
+
+  if (mem_limit <= 0 || mem_limit >= phys_mem) {
+    jlong read_mem_limit = mem_limit;
+    const char *reason;
+    if (mem_limit >= phys_mem) {
+      // Exceeding physical memory is treated as unlimited. Cg v1's implementation
+      // of read_memory_limit_in_bytes() caps this at phys_mem since Cg v1 has no
+      // value to represent 'max'. Cg v2 may return a value >= phys_mem if e.g. the
+      // container engine was started with a memory flag exceeding it.
+      reason = "ignored";
+      mem_limit = -1;
+    } else if (OSCONTAINER_ERROR == mem_limit) {
+      reason = "failed";
+    } else {
+      assert(mem_limit == -1, "Expected unlimited");
+      reason = "unlimited";
+    }
+    log_debug(os, container)("container memory limit %s: " JLONG_FORMAT ", using host value " JLONG_FORMAT,
+                             reason, read_mem_limit, phys_mem);
+  }
+
   // Update cached metric to avoid re-reading container settings too often
   memory_limit->set_value(mem_limit, OSCONTAINER_CACHE_TIMEOUT);
   return mem_limit;

--- a/hotspot/src/os/linux/vm/cgroupSubsystem_linux.cpp
+++ b/hotspot/src/os/linux/vm/cgroupSubsystem_linux.cpp
@@ -544,7 +544,9 @@ jlong CgroupSubsystem::memory_limit_in_bytes() {
     return memory_limit->value();
   }
   jlong phys_mem = os::Linux::physical_memory();
-  log_trace(os, container)("total physical memory: " JLONG_FORMAT, phys_mem);
+  if (PrintContainerInfo) {
+    tty->print_cr("total physical memory: " JLONG_FORMAT, phys_mem);
+  }
   jlong mem_limit = read_memory_limit_in_bytes();
 
   if (mem_limit <= 0 || mem_limit >= phys_mem) {
@@ -563,8 +565,10 @@ jlong CgroupSubsystem::memory_limit_in_bytes() {
       assert(mem_limit == -1, "Expected unlimited");
       reason = "unlimited";
     }
-    log_debug(os, container)("container memory limit %s: " JLONG_FORMAT ", using host value " JLONG_FORMAT,
-                             reason, read_mem_limit, phys_mem);
+    if (PrintContainerInfo) {
+      tty->print_cr("container memory limit %s: " JLONG_FORMAT ", using host value " JLONG_FORMAT,
+                    reason, read_mem_limit, phys_mem);
+    }
   }
 
   // Update cached metric to avoid re-reading container settings too often

--- a/hotspot/src/os/linux/vm/cgroupV1Subsystem_linux.cpp
+++ b/hotspot/src/os/linux/vm/cgroupV1Subsystem_linux.cpp
@@ -30,6 +30,7 @@
 #include "runtime/globals.hpp"
 #include "runtime/os.hpp"
 #include "utilities/globalDefinitions.hpp"
+#include "os_linux.hpp"
 
 /*
  * Set directory to subsystem specific files based
@@ -104,7 +105,7 @@ jlong CgroupV1Subsystem::read_memory_limit_in_bytes() {
   GET_CONTAINER_INFO(julong, _memory->controller(), "/memory.limit_in_bytes",
                      "Memory Limit is: " JULONG_FORMAT, JULONG_FORMAT, memlimit);
 
-  if (memlimit >= _unlimited_memory) {
+  if (memlimit >= os::Linux::physical_memory()) {
     if (PrintContainerInfo) {
       tty->print_cr("Non-Hierarchical Memory Limit is: Unlimited");
     }
@@ -114,7 +115,7 @@ jlong CgroupV1Subsystem::read_memory_limit_in_bytes() {
       const char* format = "%s " JULONG_FORMAT;
       GET_CONTAINER_INFO_LINE(julong, _memory->controller(), "/memory.stat", matchline,
                              "Hierarchical Memory Limit is: " JULONG_FORMAT, format, hier_memlimit)
-      if (hier_memlimit >= _unlimited_memory) {
+      if (hier_memlimit >= os::Linux::physical_memory()) {
         if (PrintContainerInfo) {
           tty->print_cr("Hierarchical Memory Limit is: Unlimited");
         }
@@ -130,9 +131,11 @@ jlong CgroupV1Subsystem::read_memory_limit_in_bytes() {
 }
 
 jlong CgroupV1Subsystem::memory_and_swap_limit_in_bytes() {
+  julong host_total_memsw;
   GET_CONTAINER_INFO(julong, _memory->controller(), "/memory.memsw.limit_in_bytes",
                      "Memory and Swap Limit is: " JULONG_FORMAT, JULONG_FORMAT, memswlimit);
-  if (memswlimit >= _unlimited_memory) {
+  host_total_memsw = os::Linux::host_swap() + os::Linux::physical_memory();
+  if (memswlimit >= host_total_memsw) {
     if (PrintContainerInfo) {
       tty->print_cr("Non-Hierarchical Memory and Swap Limit is: Unlimited");
     }
@@ -142,7 +145,7 @@ jlong CgroupV1Subsystem::memory_and_swap_limit_in_bytes() {
       const char* format = "%s " JULONG_FORMAT;
       GET_CONTAINER_INFO_LINE(julong, _memory->controller(), "/memory.stat", matchline,
                              "Hierarchical Memory and Swap Limit is : " JULONG_FORMAT, format, hier_memlimit)
-      if (hier_memlimit >= _unlimited_memory) {
+      if (hier_memlimit >= host_total_memsw) {
         if (PrintContainerInfo) {
           tty->print_cr("Hierarchical Memory and Swap Limit is: Unlimited");
         }
@@ -159,7 +162,7 @@ jlong CgroupV1Subsystem::memory_and_swap_limit_in_bytes() {
 jlong CgroupV1Subsystem::memory_soft_limit_in_bytes() {
   GET_CONTAINER_INFO(julong, _memory->controller(), "/memory.soft_limit_in_bytes",
                      "Memory Soft Limit is: " JULONG_FORMAT, JULONG_FORMAT, memsoftlimit);
-  if (memsoftlimit >= _unlimited_memory) {
+  if (memsoftlimit >= os::Linux::physical_memory()) {
     if (PrintContainerInfo) {
       tty->print_cr("Memory Soft Limit is: Unlimited");
     }

--- a/hotspot/src/os/linux/vm/cgroupV1Subsystem_linux.hpp
+++ b/hotspot/src/os/linux/vm/cgroupV1Subsystem_linux.hpp
@@ -94,8 +94,6 @@ class CgroupV1Subsystem: public CgroupSubsystem {
     CachingCgroupController * cpu_controller() { return _cpu; }
 
   private:
-    julong _unlimited_memory;
-
     /* controllers */
     CachingCgroupController* _memory;
     CgroupV1Controller* _cpuset;
@@ -111,7 +109,6 @@ class CgroupV1Subsystem: public CgroupSubsystem {
       _cpu = new CachingCgroupController(cpu);
       _cpuacct = cpuacct;
       _memory = new CachingCgroupController(memory);
-      _unlimited_memory = (LONG_MAX / os::vm_page_size()) * os::vm_page_size();
     }
 };
 

--- a/hotspot/src/os/linux/vm/osContainer_linux.cpp
+++ b/hotspot/src/os/linux/vm/osContainer_linux.cpp
@@ -42,8 +42,6 @@ CgroupSubsystem* cgroup_subsystem;
  * we are running under cgroup control.
  */
 void OSContainer::init() {
-  jlong mem_limit;
-
   assert(!_is_initialized, "Initializing OSContainer more than once");
 
   _is_initialized = true;
@@ -63,17 +61,8 @@ void OSContainer::init() {
   if (cgroup_subsystem == NULL) {
     return; // Required subsystem files not found or other error
   }
-  // We need to update the amount of physical memory now that
-  // cgroup subsystem files have been processed.
-  if ((mem_limit = cgroup_subsystem->memory_limit_in_bytes()) > 0) {
-    os::Linux::set_physical_memory(mem_limit);
-    if (PrintContainerInfo) {
-      tty->print_cr("Memory Limit is: " JLONG_FORMAT, mem_limit);
-    }
-  }
 
   _is_containerized = true;
-
 }
 
 const char * OSContainer::container_type() {

--- a/hotspot/src/os/linux/vm/os_linux.cpp
+++ b/hotspot/src/os/linux/vm/os_linux.cpp
@@ -184,21 +184,14 @@ julong os::Linux::available_memory() {
   julong avail_mem;
 
   if (OSContainer::is_containerized()) {
-    jlong mem_limit, mem_usage;
-    if ((mem_limit = OSContainer::memory_limit_in_bytes()) < 1) {
-      if (PrintContainerInfo) {
-        tty->print_cr("container memory limit %s: " JLONG_FORMAT ", using host value",
-                       mem_limit == OSCONTAINER_ERROR ? "failed" : "unlimited", mem_limit);
-      }
-    }
-
+    jlong mem_limit = OSContainer::memory_limit_in_bytes();
+    jlong mem_usage;
     if (mem_limit > 0 && (mem_usage = OSContainer::memory_usage_in_bytes()) < 1) {
       if (PrintContainerInfo) {
         tty->print_cr("container memory usage failed: " JLONG_FORMAT ", using host value", mem_usage);
       }
     }
-
-    if (mem_limit > 0 && mem_usage > 0 ) {
+    if (mem_limit > 0 && mem_usage > 0) {
       avail_mem = mem_limit > mem_usage ? (julong)mem_limit - (julong)mem_usage : 0;
       if (PrintContainerInfo) {
         tty->print_cr("available container memory: " JULONG_FORMAT, avail_mem);
@@ -224,11 +217,6 @@ julong os::physical_memory() {
         tty->print_cr("total container memory: " JLONG_FORMAT, mem_limit);
       }
       return mem_limit;
-    }
-
-    if (PrintContainerInfo) {
-      tty->print_cr("container memory limit %s: " JLONG_FORMAT ", using host value",
-                     mem_limit == OSCONTAINER_ERROR ? "failed" : "unlimited", mem_limit);
     }
   }
 
@@ -306,6 +294,14 @@ pid_t os::Linux::gettid() {
   } else {
      return (pid_t)rslt;
   }
+}
+
+// Returns the amount of swap currently configured, in bytes.
+// This can change at any time.
+julong os::Linux::host_swap() {
+  struct sysinfo si;
+  sysinfo(&si);
+  return (julong)si.totalswap;
 }
 
 // Most versions of linux have a bug where the number of processors are

--- a/hotspot/src/os/linux/vm/os_linux.hpp
+++ b/hotspot/src/os/linux/vm/os_linux.hpp
@@ -81,8 +81,6 @@ class Linux {
   static const int _vm_default_page_size;
 
   static julong available_memory();
-  static julong physical_memory() { return _physical_memory; }
-  static void set_physical_memory(julong phys_mem) { _physical_memory = phys_mem; }
   static int active_processor_count();
 
   static void initialize_system_info();
@@ -153,6 +151,9 @@ class Linux {
   static address   ucontext_get_pc(ucontext_t* uc);
   static intptr_t* ucontext_get_sp(ucontext_t* uc);
   static intptr_t* ucontext_get_fp(ucontext_t* uc);
+
+  static julong physical_memory() { return _physical_memory; }
+  static julong host_swap();
 
   // For Analyzer Forte AsyncGetCallTrace profiling support:
   //

--- a/hotspot/test/runtime/containers/docker/TestMemoryAwareness.java
+++ b/hotspot/test/runtime/containers/docker/TestMemoryAwareness.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @bug 8146115 8292083
  * @summary Test JVM's memory resource awareness when running inside docker container
  * @library /testlibrary /testlibrary/whitebox
  * @build AttemptOOM sun.hotspot.WhiteBox PrintContainerInfo CheckOperatingSystemMXBean
@@ -36,6 +37,8 @@ import com.oracle.java.testlibrary.DockerRunOptions;
 import com.oracle.java.testlibrary.DockerTestUtils;
 import com.oracle.java.testlibrary.OutputAnalyzer;
 
+
+import static jdk.test.lib.Asserts.assertNotNull;
 
 public class TestMemoryAwareness {
     private static final String imageName = Common.imageName("memory");
@@ -72,6 +75,7 @@ public class TestMemoryAwareness {
                 "1G", Integer.toString(((int) Math.pow(2, 20)) * 1024),
                 "1500M", Integer.toString(((int) Math.pow(2, 20)) * (1500 - 1024))
             );
+            testContainerMemExceedsPhysical();
         } finally {
             DockerTestUtils.removeDockerImage(imageName);
         }
@@ -88,6 +92,28 @@ public class TestMemoryAwareness {
 
         Common.run(opts)
             .shouldMatch("Memory Limit is:.*" + expectedTraceValue);
+    }
+
+    // JDK-8292083
+    // Ensure that Java ignores container memory limit values above the host's physical memory.
+    private static void testContainerMemExceedsPhysical()
+            throws Exception {
+
+        Common.logNewTestCase("container memory limit exceeds physical memory");
+
+        DockerRunOptions opts = Common.newOpts(imageName);
+
+        // first run: establish physical memory in test environment and derive
+        // a bad value one power of ten larger
+        String goodMem = Common.run(opts).firstMatch("total physical memory: (\\d+)", 1);
+        assertNotNull(goodMem, "no match for 'total physical memory' in trace output");
+        String badMem = goodMem + "0";
+
+        // second run: set a container memory limit to the bad value
+        opts = Common.newOpts(imageName)
+            .addDockerOpts("--memory", badMem);
+        Common.run(opts)
+            .shouldMatch("container memory limit (ignored: " + badMem + "|unlimited: -1), using host value " + goodMem);
     }
 
 

--- a/hotspot/test/runtime/containers/docker/TestMemoryAwareness.java
+++ b/hotspot/test/runtime/containers/docker/TestMemoryAwareness.java
@@ -37,8 +37,7 @@ import com.oracle.java.testlibrary.DockerRunOptions;
 import com.oracle.java.testlibrary.DockerTestUtils;
 import com.oracle.java.testlibrary.OutputAnalyzer;
 
-
-import static jdk.test.lib.Asserts.assertNotNull;
+import com.oracle.java.testlibrary.Asserts;
 
 public class TestMemoryAwareness {
     private static final String imageName = Common.imageName("memory");
@@ -106,7 +105,7 @@ public class TestMemoryAwareness {
         // first run: establish physical memory in test environment and derive
         // a bad value one power of ten larger
         String goodMem = Common.run(opts).firstMatch("total physical memory: (\\d+)", 1);
-        assertNotNull(goodMem, "no match for 'total physical memory' in trace output");
+        Asserts.assertNotNull(goodMem, "no match for 'total physical memory' in trace output");
         String badMem = goodMem + "0";
 
         // second run: set a container memory limit to the bad value


### PR DESCRIPTION
This is a backport of 8292083 for jdk8u-dev cgroups v2 support. It's not clean: context issues, replace the use of some log_debug and log_trace, and an adjustment to Asserts class location for hotspot tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292083](https://bugs.openjdk.org/browse/JDK-8292083): Detected container memory limit may exceed physical machine memory


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/180/head:pull/180` \
`$ git checkout pull/180`

Update a local copy of the PR: \
`$ git checkout pull/180` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/180/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 180`

View PR using the GUI difftool: \
`$ git pr show -t 180`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/180.diff">https://git.openjdk.org/jdk8u-dev/pull/180.diff</a>

</details>
