### PR TITLE
8297141: Fix hotspot/test/runtime/SharedArchiveFile/DefaultUseWithClient.java for 8u

### DIFF
--- a/hotspot/test/runtime/SharedArchiveFile/DefaultUseWithClient.java
+++ b/hotspot/test/runtime/SharedArchiveFile/DefaultUseWithClient.java
@@ -25,7 +25,7 @@
  * @test DefaultUseWithClient
  * @summary Test default behavior of sharing with -client
  * @library /testlibrary
- * @run main DefaultUseWithClient
+ * @run main/othervm -client DefaultUseWithClient
  * @bug 8032224
  */
 
@@ -38,9 +38,9 @@ public class DefaultUseWithClient {
 
         // On 32-bit windows CDS should be on by default in "-client" config
         // Skip this test on any other platform
-        boolean is32BitWindows = (Platform.isWindows() && Platform.is32bit());
-        if (!is32BitWindows) {
-            System.out.println("Test only applicable on 32-bit Windows. Skipping");
+        boolean is32BitWindowsClient = (Platform.isWindows() && Platform.is32bit() && Platform.isClient());
+        if (!is32BitWindowsClient) {
+            System.out.println("Test only applicable on 32-bit Windows Client VM. Skipping");
             return;
         }
 
@@ -60,10 +60,6 @@ public class DefaultUseWithClient {
            "-version");
 
         output = new OutputAnalyzer(pb.start());
-        if (!output.getOutput().contains("Client")) {
-            System.out.println("Client VM not available. Skipping...");
-            return;
-        }
         try {
             output.shouldContain("sharing");
         } catch (RuntimeException e) {

--- a/hotspot/test/runtime/SharedArchiveFile/DefaultUseWithClient.java
+++ b/hotspot/test/runtime/SharedArchiveFile/DefaultUseWithClient.java
@@ -60,6 +60,10 @@ public class DefaultUseWithClient {
            "-version");
 
         output = new OutputAnalyzer(pb.start());
+        if (!output.getOutput().contains("Client")) {
+            System.out.println("Client VM not available. Skipping...");
+            return;
+        }
         try {
             output.shouldContain("sharing");
         } catch (RuntimeException e) {


### PR DESCRIPTION
Following test (from hotspot/tier1) currently fails on Windows x86:
`hotspot/test/runtime/SharedArchiveFile/DefaultUseWithClient.java`

**Test output:**
```
...
 stdout: [];
 stderr: [openjdk version "1.8.0_362-internal"
OpenJDK Runtime Environment (build 1.8.0_362-internal-zzambers-54a485c13e59fa68ea9dc088f320520eedbe33fe-b00)
OpenJDK Server VM (build 25.362-b00, mixed mode)
]
 exitValue = 0

java.lang.RuntimeException: 'UseSharedSpaces:' missing from stdout/stderr 

	at com.oracle.java.testlibrary.OutputAnalyzer.shouldContain(OutputAnalyzer.java:134)
	at DefaultUseWithClient.main(DefaultUseWithClient.java:68)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.sun.javatest.regtest.agent.MainActionHelper$AgentVMRunnable.run(MainActionHelper.java:298)
	at java.lang.Thread.run(Thread.java:750)
...
```

**Problem:**
Test is Windows 32-bit only, only applies to Client VM and checks default behaviour of shared archive feature. Problem is, that default build of 32-bit windows JDK does not include Client VM, so Server VM is used (so -client arg does nothing). With Server VM tests fails. I tried to make build which has Client VM and then this test passes (It breaks other tests which expect default to be Server VM though).

**Fix:**
Test runs java with `-version` argument, which can print something similar to:
```
openjdk version "1.8.0_362-internal"
OpenJDK Runtime Environment (build 1.8.0_362-internal-zzambers-2bbffac3199782df1f9b81867fdfeb3d72889fcd-b00)
OpenJDK Client VM (build 25.362-b00, mixed mode)
```
This output can be used to check if Client VM and skip other checks, if Client VM is not used. Fix is JDK 8 only as test has been removed on newer JDKs by JDK-8154204 by [2]. But I decided to fix it for JDK 8.

**Testing:**
With this change test passes on Windows 32-bit. (both with Server [3] and Client [4] Vms)

[1] https://github.com/zzambers/jdk8u-dev/actions/runs/3438556844
[2] https://bugs.openjdk.org/browse/JDK-8154204
[3] https://github.com/zzambers/jdk8u-dev/actions/runs/3462926725
[4] https://github.com/zzambers/jdk8u-dev/actions/runs/3462887672

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297141](https://bugs.openjdk.org/browse/JDK-8297141): Fix hotspot/test/runtime/SharedArchiveFile/DefaultUseWithClient.java for 8u


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/181/head:pull/181` \
`$ git checkout pull/181`

Update a local copy of the PR: \
`$ git checkout pull/181` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/181/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 181`

View PR using the GUI difftool: \
`$ git pr show -t 181`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/181.diff">https://git.openjdk.org/jdk8u-dev/pull/181.diff</a>

</details>
