### PR TITLE
8241086: Test runtime/NMT/HugeArenaTracking.java is failing on 32bit Windows

### DIFF
--- a/hotspot/test/runtime/NMT/HugeArenaTracking.java
+++ b/hotspot/test/runtime/NMT/HugeArenaTracking.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2019, 2020, Red Hat, Inc. All rights reserved.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
@@ -25,6 +25,7 @@
  * @test
  * @key nmt jcmd
  * @library /testlibrary /testlibrary/whitebox
+ * @requires vm.bits == 64
  * @build HugeArenaTracking
  * @run main ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:NativeMemoryTracking=detail HugeArenaTracking

--- a/hotspot/test/runtime/NMT/HugeArenaTracking.java
+++ b/hotspot/test/runtime/NMT/HugeArenaTracking.java
@@ -25,7 +25,6 @@
  * @test
  * @key nmt jcmd
  * @library /testlibrary /testlibrary/whitebox
- * @requires vm.bits == 64
  * @build HugeArenaTracking
  * @run main ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:NativeMemoryTracking=detail HugeArenaTracking
@@ -39,6 +38,10 @@ public class HugeArenaTracking {
   private static final long GB = 1024 * 1024 * 1024;
 
   public static void main(String args[]) throws Exception {
+    if (!Platform.is64bit()) {
+        System.out.println("Test requires 64-bit JVM. Skipping...");
+        return;
+    }
     OutputAnalyzer output;
     final WhiteBox wb = WhiteBox.getWhiteBox();
 


### PR DESCRIPTION
Test `hotspot/test/runtime/NMT/HugeArenaTracking.java` (from hotspot/tier1) currently fails on Windows x86. This backport fixes this test to only run on 64-bit archs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8241086](https://bugs.openjdk.org/browse/JDK-8241086): Test runtime/NMT/HugeArenaTracking.java is failing on 32bit Windows


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/182/head:pull/182` \
`$ git checkout pull/182`

Update a local copy of the PR: \
`$ git checkout pull/182` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/182/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 182`

View PR using the GUI difftool: \
`$ git pr show -t 182`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/182.diff">https://git.openjdk.org/jdk8u-dev/pull/182.diff</a>

</details>
