### PR TITLE
6885993: Named Thread: introduce print() and print_on(outputStream* st) methods

### DIFF
--- a/hotspot/src/share/vm/gc_implementation/concurrentMarkSweep/concurrentMarkSweepThread.cpp
+++ b/hotspot/src/share/vm/gc_implementation/concurrentMarkSweep/concurrentMarkSweepThread.cpp
@@ -223,12 +223,6 @@ void ConcurrentMarkSweepThread::threads_do(ThreadClosure* tc) {
   }
 }
 
-void ConcurrentMarkSweepThread::print_on(outputStream* st) const {
-  st->print("\"%s\" ", name());
-  Thread::print_on(st);
-  st->cr();
-}
-
 void ConcurrentMarkSweepThread::print_all_on(outputStream* st) {
   if (_cmst != NULL) {
     _cmst->print_on(st);

--- a/hotspot/src/share/vm/gc_implementation/concurrentMarkSweep/concurrentMarkSweepThread.hpp
+++ b/hotspot/src/share/vm/gc_implementation/concurrentMarkSweep/concurrentMarkSweepThread.hpp
@@ -94,8 +94,6 @@ class ConcurrentMarkSweepThread: public ConcurrentGCThread {
   static void threads_do(ThreadClosure* tc);
 
   // Printing
-  void print_on(outputStream* st) const;
-  void print() const                                  { print_on(tty); }
   static void print_all_on(outputStream* st);
   static void print_all()                             { print_all_on(tty); }
 

--- a/hotspot/src/share/vm/gc_implementation/g1/concurrentG1RefineThread.cpp
+++ b/hotspot/src/share/vm/gc_implementation/g1/concurrentG1RefineThread.cpp
@@ -58,6 +58,9 @@ ConcurrentG1RefineThread(ConcurrentG1Refine* cg1r, ConcurrentG1RefineThread *nex
   }
   initialize();
   create_and_start();
+
+  // set name
+  set_name("G1 Concurrent Refinement Thread#%d", worker_id);
 }
 
 void ConcurrentG1RefineThread::initialize() {
@@ -247,12 +250,3 @@ void ConcurrentG1RefineThread::stop() {
   }
 }
 
-void ConcurrentG1RefineThread::print() const {
-  print_on(tty);
-}
-
-void ConcurrentG1RefineThread::print_on(outputStream* st) const {
-  st->print("\"G1 Concurrent Refinement Thread#%d\" ", _worker_id);
-  Thread::print_on(st);
-  st->cr();
-}

--- a/hotspot/src/share/vm/gc_implementation/g1/concurrentG1RefineThread.hpp
+++ b/hotspot/src/share/vm/gc_implementation/g1/concurrentG1RefineThread.hpp
@@ -77,10 +77,6 @@ public:
 
   void initialize();
 
-  // Printing
-  void print() const;
-  void print_on(outputStream* st) const;
-
   // Total virtual time so far.
   double vtime_accum() { return _vtime_accum; }
 

--- a/hotspot/src/share/vm/gc_implementation/g1/concurrentMarkThread.cpp
+++ b/hotspot/src/share/vm/gc_implementation/g1/concurrentMarkThread.cpp
@@ -46,6 +46,8 @@ ConcurrentMarkThread::ConcurrentMarkThread(ConcurrentMark* cm) :
   _state(Idle),
   _vtime_accum(0.0),
   _vtime_mark_accum(0.0) {
+
+  set_name("G1 Main Concurrent Mark GC Thread");
   create_and_start();
 }
 
@@ -316,16 +318,6 @@ void ConcurrentMarkThread::stop() {
       Terminator_lock->wait();
     }
   }
-}
-
-void ConcurrentMarkThread::print() const {
-  print_on(tty);
-}
-
-void ConcurrentMarkThread::print_on(outputStream* st) const {
-  st->print("\"G1 Main Concurrent Mark GC Thread\" ");
-  Thread::print_on(st);
-  st->cr();
 }
 
 void ConcurrentMarkThread::sleepBeforeNextCycle() {

--- a/hotspot/src/share/vm/gc_implementation/g1/concurrentMarkThread.hpp
+++ b/hotspot/src/share/vm/gc_implementation/g1/concurrentMarkThread.hpp
@@ -66,10 +66,6 @@ class ConcurrentMarkThread: public ConcurrentGCThread {
   static void makeSurrogateLockerThread(TRAPS);
   static SurrogateLockerThread* slt() { return _slt; }
 
-  // Printing
-  void print_on(outputStream* st) const;
-  void print() const;
-
   // Total virtual time so far.
   double vtime_accum();
   // Marking virtual time so far

--- a/hotspot/src/share/vm/gc_implementation/g1/g1StringDedupThread.cpp
+++ b/hotspot/src/share/vm/gc_implementation/g1/g1StringDedupThread.cpp
@@ -53,12 +53,6 @@ G1StringDedupThread* G1StringDedupThread::thread() {
   return _thread;
 }
 
-void G1StringDedupThread::print_on(outputStream* st) const {
-  st->print("\"%s\" ", name());
-  Thread::print_on(st);
-  st->cr();
-}
-
 void G1StringDedupThread::run() {
   G1StringDedupStat total_stat;
 

--- a/hotspot/src/share/vm/gc_implementation/g1/g1StringDedupThread.hpp
+++ b/hotspot/src/share/vm/gc_implementation/g1/g1StringDedupThread.hpp
@@ -52,7 +52,6 @@ public:
   static G1StringDedupThread* thread();
 
   virtual void run();
-  virtual void print_on(outputStream* st) const;
 };
 
 #endif // SHARE_VM_GC_IMPLEMENTATION_G1_G1STRINGDEDUPTHREAD_HPP

--- a/hotspot/src/share/vm/gc_implementation/parallelScavenge/gcTaskThread.cpp
+++ b/hotspot/src/share/vm/gc_implementation/parallelScavenge/gcTaskThread.cpp
@@ -89,12 +89,6 @@ void GCTaskThread::print_task_time_stamps() {
   _time_stamp_index = 0;
 }
 
-void GCTaskThread::print_on(outputStream* st) const {
-  st->print("\"%s\" ", name());
-  Thread::print_on(st);
-  st->cr();
-}
-
 // GC workers get tasks from the GCTaskManager and execute
 // them in this method.  If there are no tasks to execute,
 // the GC workers wait in the GCTaskManager's get_task()

--- a/hotspot/src/share/vm/gc_implementation/parallelScavenge/gcTaskThread.hpp
+++ b/hotspot/src/share/vm/gc_implementation/parallelScavenge/gcTaskThread.hpp
@@ -69,8 +69,6 @@ private:
   void start();
 
   void print_task_time_stamps();
-  void print_on(outputStream* st) const;
-  void print() const                                { print_on(tty); }
 
 protected:
   // Constructor.  Clients use factory, but there could be subclasses.

--- a/hotspot/src/share/vm/runtime/thread.cpp
+++ b/hotspot/src/share/vm/runtime/thread.cpp
@@ -1231,6 +1231,13 @@ void NamedThread::set_name(const char* format, ...) {
   va_end(ap);
 }
 
+void NamedThread::print_on(outputStream* st) const {
+  st->print("\"%s\" ", name());
+  Thread::print_on(st);
+  st->cr();
+}
+
+
 // ======= WatcherThread ========
 
 // The watcher thread exists to simulate timer interrupts.  It should

--- a/hotspot/src/share/vm/runtime/thread.hpp
+++ b/hotspot/src/share/vm/runtime/thread.hpp
@@ -570,7 +570,7 @@ protected:
   void    set_lgrp_id(int value) { _lgrp_id = value; }
 
   // Printing
-  void print_on(outputStream* st) const;
+  virtual void print_on(outputStream* st) const;
   void print() const { print_on(tty); }
   virtual void print_on_error(outputStream* st, char* buf, int buflen) const;
 
@@ -713,6 +713,7 @@ class NamedThread: public Thread {
   virtual char* name() const { return _name == NULL ? (char*)"Unknown Thread" : _name; }
   JavaThread *processed_thread() { return _processed_thread; }
   void set_processed_thread(JavaThread *thread) { _processed_thread = thread; }
+  virtual void print_on(outputStream* st) const;
 };
 
 // Worker threads are named and have an id of an assigned work.
@@ -757,7 +758,6 @@ class WatcherThread: public Thread {
   // Printing
   char* name() const { return (char*)"VM Periodic Task Thread"; }
   void print_on(outputStream* st) const;
-  void print() const { print_on(tty); }
   void unpark();
 
   // Returns the single instance of WatcherThread
@@ -1464,7 +1464,6 @@ class JavaThread: public Thread {
   // Misc. operations
   char* name() const { return (char*)get_thread_name(); }
   void print_on(outputStream* st) const;
-  void print() const { print_on(tty); }
   void print_value();
   void print_thread_state_on(outputStream* ) const      PRODUCT_RETURN;
   void print_thread_state() const                       PRODUCT_RETURN;

--- a/hotspot/src/share/vm/runtime/vmThread.cpp
+++ b/hotspot/src/share/vm/runtime/vmThread.cpp
@@ -355,12 +355,6 @@ void VMThread::wait_for_vm_thread_exit() {
   }
 }
 
-void VMThread::print_on(outputStream* st) const {
-  st->print("\"%s\" ", name());
-  Thread::print_on(st);
-  st->cr();
-}
-
 static void post_vm_operation_event(EventExecuteVMOperation* event, VM_Operation* op) {
   assert(event != NULL, "invariant");
   assert(event->should_commit(), "invariant");

--- a/hotspot/src/share/vm/runtime/vmThread.hpp
+++ b/hotspot/src/share/vm/runtime/vmThread.hpp
@@ -131,9 +131,6 @@ class VMThread: public NamedThread {
   // GC support
   void oops_do(OopClosure* f, CLDClosure* cld_f, CodeBlobClosure* cf);
 
-  // Debugging
-  void print_on(outputStream* st) const;
-  void print() const                              { print_on(tty); }
   void verify();
 
   // Performance measurement


### PR DESCRIPTION
This is a backport of "[JDK-6885993: Named Thread: introduce print() and print_on(outputStream* st) methods](https://bugs.openjdk.org/browse/JDK-6885993)". I request the downport for parity with Oracle JDK 8 where it was backported to 8u351 (see [JDK-8285702](https://bugs.openjdk.org/browse/JDK-8285702)). The change is required as dependency of "[JDK-8073464: GC workers do not have thread names](https://bugs.openjdk.org/browse/JDK-8073464)" which I'll be requesting next ([JDK-8073464](https://bugs.openjdk.org/browse/JDK-8073464) has also been downported to Oracle jdk8u351).

Both of these changes are required to fix the native names of internal threads like for example GC threads. This does not only simplify debugging, but also helps observability tools. Finally, these two changes fix the "sun.management.HotspotInternal" MxBean which returns the "[InternalThreadCpuTimes](https://stackoverflow.com/questions/3947467/with-recent-sun-jvms-1-6-is-it-possible-to-get-gc-thread-information/4113407#4113407)". The "InternalThreadCpuTimes" attribute returns a map with a thread-name to thread-cpu-time mapping but is currently broken in JDK 8 because internal threads without native names (e.g. GC threads) are all mapped to the same entry (i.e. "Unknown").

The patch applies cleanly except for a single context mismatch in `vmThread.cpp`. I've attached a diff of this patch compared to the original JDK 9 patch to this PR for your convenience (see [6885993-jdk8-vs-jdk9.txt](https://github.com/openjdk/jdk8u-dev/files/10030290/6885993-jdk8-vs-jdk9.txt)).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-6885993](https://bugs.openjdk.org/browse/JDK-6885993): Named Thread: introduce print() and print_on(outputStream* st) methods


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/183/head:pull/183` \
`$ git checkout pull/183`

Update a local copy of the PR: \
`$ git checkout pull/183` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/183/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 183`

View PR using the GUI difftool: \
`$ git pr show -t 183`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/183.diff">https://git.openjdk.org/jdk8u-dev/pull/183.diff</a>

</details>
