### PR TITLE
8253797: [cgroups v2] Account for the fact that swap accounting is disabled on some systems

### DIFF
--- a/jdk/test/lib/jdk/test/lib/containers/cgroup/MetricsTesterCgroupV2.java
+++ b/jdk/test/lib/jdk/test/lib/containers/cgroup/MetricsTesterCgroupV2.java
@@ -239,25 +239,33 @@ public class MetricsTesterCgroupV2 implements CgroupMetricsTester {
             fail("memory.stat[sock]", oldVal, newVal);
         }
 
-        oldVal = metrics.getMemoryAndSwapLimit();
-        long valSwap = getLongLimitValueFromFile("memory.swap.max");
-        long valMemory = getLongLimitValueFromFile("memory.max");
-        if (valSwap == UNLIMITED) {
-            newVal = valSwap;
+        long memAndSwapLimit = metrics.getMemoryAndSwapLimit();
+        long memLimit = metrics.getMemoryLimit();
+        // Only test swap memory limits if we can. On systems with swapaccount=0
+        // we cannot, as swap limits are disabled.
+        if (memAndSwapLimit <= memLimit) {
+            System.out.println("No swap memory limits, test case(s) skipped");
         } else {
-            assert valMemory >= 0;
-            newVal = valSwap + valMemory;
-        }
-        if (!CgroupMetricsTester.compareWithErrorMargin(oldVal, newVal)) {
-            fail("memory.swap.max", oldVal, newVal);
-        }
+            oldVal = memAndSwapLimit;
+            long valSwap = getLongLimitValueFromFile("memory.swap.max");
+            long valMemory = getLongLimitValueFromFile("memory.max");
+            if (valSwap == UNLIMITED) {
+                newVal = valSwap;
+            } else {
+                assert valMemory >= 0;
+                newVal = valSwap + valMemory;
+            }
+            if (!CgroupMetricsTester.compareWithErrorMargin(oldVal, newVal)) {
+                fail("memory.swap.max", oldVal, newVal);
+            }
 
-        oldVal = metrics.getMemoryAndSwapUsage();
-        long swapUsage = getLongValueFromFile("memory.swap.current");
-        long memUsage = getLongValueFromFile("memory.current");
-        newVal = swapUsage + memUsage;
-        if (!CgroupMetricsTester.compareWithErrorMargin(oldVal, newVal)) {
-            fail("memory.swap.current", oldVal, newVal);
+            oldVal = metrics.getMemoryAndSwapUsage();
+            long swapUsage = getLongValueFromFile("memory.swap.current");
+            long memUsage = getLongValueFromFile("memory.current");
+            newVal = swapUsage + memUsage;
+            if (!CgroupMetricsTester.compareWithErrorMargin(oldVal, newVal)) {
+                fail("memory.swap.current", oldVal, newVal);
+            }
         }
 
         oldVal = metrics.getMemorySoftLimit();


### PR DESCRIPTION
This is a clean backport of 8253797 (via 11u) for jdk8u-dev for cgroups v2 support.

The changed files are exercised by the jtreg test `TestSystemMetrics.java` which passes on my cgroups v2 system.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8253797](https://bugs.openjdk.org/browse/JDK-8253797): [cgroups v2] Account for the fact that swap accounting is disabled on some systems


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/185/head:pull/185` \
`$ git checkout pull/185`

Update a local copy of the PR: \
`$ git checkout pull/185` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/185/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 185`

View PR using the GUI difftool: \
`$ git pr show -t 185`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/185.diff">https://git.openjdk.org/jdk8u-dev/pull/185.diff</a>

</details>
