### PR TITLE
8229182: [TESTBUG] runtime/containers/docker/TestMemoryAwareness.java test fails on SLES12

### DIFF
--- a/hotspot/test/runtime/containers/docker/TestMemoryAwareness.java
+++ b/hotspot/test/runtime/containers/docker/TestMemoryAwareness.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/hotspot/test/runtime/containers/docker/TestMemoryAwareness.java
+++ b/hotspot/test/runtime/containers/docker/TestMemoryAwareness.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -108,15 +108,26 @@ public class TestMemoryAwareness {
     private static void testOOM(String dockerMemLimit, int sizeToAllocInMb) throws Exception {
         Common.logNewTestCase("OOM");
 
+        // add "--memory-swappiness 0" so as to disable anonymous page swapping.
         DockerRunOptions opts = Common.newOpts(imageName, "AttemptOOM")
-            .addDockerOpts("--memory", dockerMemLimit, "--memory-swap", dockerMemLimit);
+            .addDockerOpts("--memory", dockerMemLimit, "--memory-swappiness", "0", "--memory-swap", dockerMemLimit);
         opts.classParams.add("" + sizeToAllocInMb);
 
-        DockerTestUtils.dockerRunJava(opts)
-            .shouldHaveExitValue(1)
-            .shouldContain("Entering AttemptOOM main")
-            .shouldNotContain("AttemptOOM allocation successful")
-            .shouldContain("java.lang.OutOfMemoryError");
+        // make sure we avoid inherited Xmx settings from the jtreg vmoptions
+        // set Xmx ourselves instead
+        System.out.println("sizeToAllocInMb is:" + sizeToAllocInMb + " sizeToAllocInMb/2 is:" + sizeToAllocInMb/2);
+        String javaHeapSize = sizeToAllocInMb/2 + "m";
+        opts.addJavaOptsAppended("-Xmx" + javaHeapSize);
+
+        OutputAnalyzer out = DockerTestUtils.dockerRunJava(opts);
+
+        if (out.getExitValue() == 0) {
+            throw new RuntimeException("We exited successfully, but we wanted to provoke an OOM inside the container");
+        }
+
+        out.shouldContain("Entering AttemptOOM main")
+           .shouldNotContain("AttemptOOM allocation successful")
+           .shouldContain("java.lang.OutOfMemoryError");
     }
 
     private static void testOperatingSystemMXBeanAwareness(String memoryAllocation, String expectedMemory,

--- a/hotspot/test/testlibrary/com/oracle/java/testlibrary/DockerRunOptions.java
+++ b/hotspot/test/testlibrary/com/oracle/java/testlibrary/DockerRunOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/hotspot/test/testlibrary/com/oracle/java/testlibrary/DockerRunOptions.java
+++ b/hotspot/test/testlibrary/com/oracle/java/testlibrary/DockerRunOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,11 +31,13 @@ import java.util.Collections;
 // in test environment.
 public class DockerRunOptions {
     public String imageNameAndTag;
-    public ArrayList<String> dockerOpts = new ArrayList<String>();
+    public ArrayList<String> dockerOpts = new ArrayList<>();
     public String command;    // normally a full path to java
-    public ArrayList<String> javaOpts = new ArrayList<String>();
+    public ArrayList<String> javaOpts = new ArrayList<>();
+    // more java options, but to be set AFTER the test Java options
+    public ArrayList<String> javaOptsAppended = new ArrayList<>();
     public String classToRun;  // class or "-version"
-    public ArrayList<String> classParams = new ArrayList<String>();
+    public ArrayList<String> classParams = new ArrayList<>();
 
     public boolean tty = true;
     public boolean removeContainerAfterUse = true;
@@ -70,4 +72,8 @@ public class DockerRunOptions {
         return this;
     }
 
+    public DockerRunOptions addJavaOptsAppended(String... opts) {
+        Collections.addAll(javaOptsAppended, opts);
+        return this;
+    }
 }

--- a/hotspot/test/testlibrary/com/oracle/java/testlibrary/DockerTestUtils.java
+++ b/hotspot/test/testlibrary/com/oracle/java/testlibrary/DockerTestUtils.java
@@ -198,6 +198,7 @@ public class DockerTestUtils {
         if (opts.appendTestJavaOptions) {
             Collections.addAll(cmd, Utils.getTestJavaOpts());
         }
+        cmd.addAll(opts.javaOptsAppended);
 
         cmd.add(opts.classToRun);
         cmd.addAll(opts.classParams);


### PR DESCRIPTION
Backporting JDK-8229182, did not apply cleanly and had to be manually fixed up.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8229182](https://bugs.openjdk.org/browse/JDK-8229182): [TESTBUG] runtime/containers/docker/TestMemoryAwareness.java test fails on SLES12


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/186/head:pull/186` \
`$ git checkout pull/186`

Update a local copy of the PR: \
`$ git checkout pull/186` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/186/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 186`

View PR using the GUI difftool: \
`$ git pr show -t 186`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/186.diff">https://git.openjdk.org/jdk8u-dev/pull/186.diff</a>

</details>
