### PR TITLE
8297329: [8u] hotspot needs to recognise VS2019

### DIFF
--- a/hotspot/make/windows/makefiles/compile.make
+++ b/hotspot/make/windows/makefiles/compile.make
@@ -169,6 +169,9 @@ COMPILER_NAME=VS2017
 !if "$(MSC_VER)" == "1916"
 COMPILER_NAME=VS2017
 !endif
+!if "$(MSC_VER)" >= "1920" && "$(MSC_VER)" <= "1929"
+COMPILER_NAME=VS2019
+!endif
 !endif
 
 # By default, we do not want to use the debug version of the msvcrt.dll file
@@ -304,6 +307,21 @@ SAFESEH_FLAG = /SAFESEH
 !endif
 
 !if "$(COMPILER_NAME)" == "VS2017"
+PRODUCT_OPT_OPTION   = /O2 /Oy-
+FASTDEBUG_OPT_OPTION = /O2 /Oy-
+DEBUG_OPT_OPTION     = /Od
+GX_OPTION = /EHsc
+LD_FLAGS = /manifest $(LD_FLAGS)
+MP_FLAG = /MP
+# Manifest Tool - used in VS2005 and later to adjust manifests stored
+# as resources inside build artifacts.
+!if "x$(MT)" == "x"
+MT=mt.exe
+!endif
+SAFESEH_FLAG = /SAFESEH
+!endif
+
+!if "$(COMPILER_NAME)" == "VS2019"
 PRODUCT_OPT_OPTION   = /O2 /Oy-
 FASTDEBUG_OPT_OPTION = /O2 /Oy-
 DEBUG_OPT_OPTION     = /Od

--- a/hotspot/make/windows/makefiles/sanity.make
+++ b/hotspot/make/windows/makefiles/sanity.make
@@ -31,6 +31,8 @@ checkCL:
 	if "$(MSC_VER)" NEQ "1800" \
 	if "$(MSC_VER)" NEQ "1900" \
 	if "$(MSC_VER)" NEQ "1912" \
+    if "$(MSC_VER)" NEQ "1920" if "$(MSC_VER)" NEQ "1921" if "$(MSC_VER)" NEQ "1922" if "$(MSC_VER)" NEQ "1923" if "$(MSC_VER)" NEQ "1924" \
+    if "$(MSC_VER)" NEQ "1925" if "$(MSC_VER)" NEQ "1926" if "$(MSC_VER)" NEQ "1927" if "$(MSC_VER)" NEQ "1928" if "$(MSC_VER)" NEQ "1929" \
 	echo *** WARNING *** unrecognized cl.exe version $(MSC_VER) ($(RAW_MSC_VER)).  Use FORCE_MSC_VER to override automatic detection.
 
 checkLink:
@@ -39,4 +41,6 @@ checkLink:
 	if "$(LD_VER)" NEQ "1300" \
 	if "$(LD_VER)" NEQ "1400" \
 	if "$(LD_VER)" NEQ "1412" \
+	if "$(LD_VER)" NEQ "1420" if "$(LD_VER)" NEQ "1421" if "$(LD_VER)" NEQ "1422" if "$(LD_VER)" NEQ "1423" if "$(LD_VER)" NEQ "1424" \
+	if "$(LD_VER)" NEQ "1425" if "$(LD_VER)" NEQ "1426" if "$(LD_VER)" NEQ "1427" if "$(LD_VER)" NEQ "1428" if "$(LD_VER)" NEQ "1429" \
 	echo *** WARNING *** unrecognized link.exe version $(LD_VER) ($(RAW_LD_VER)).  Use FORCE_LD_VER to override automatic detection.

--- a/hotspot/make/windows/makefiles/sanity.make
+++ b/hotspot/make/windows/makefiles/sanity.make
@@ -31,8 +31,8 @@ checkCL:
 	if "$(MSC_VER)" NEQ "1800" \
 	if "$(MSC_VER)" NEQ "1900" \
 	if "$(MSC_VER)" NEQ "1912" \
-    if "$(MSC_VER)" NEQ "1920" if "$(MSC_VER)" NEQ "1921" if "$(MSC_VER)" NEQ "1922" if "$(MSC_VER)" NEQ "1923" if "$(MSC_VER)" NEQ "1924" \
-    if "$(MSC_VER)" NEQ "1925" if "$(MSC_VER)" NEQ "1926" if "$(MSC_VER)" NEQ "1927" if "$(MSC_VER)" NEQ "1928" if "$(MSC_VER)" NEQ "1929" \
+	if "$(MSC_VER)" NEQ "1920" if "$(MSC_VER)" NEQ "1921" if "$(MSC_VER)" NEQ "1922" if "$(MSC_VER)" NEQ "1923" if "$(MSC_VER)" NEQ "1924" \
+	if "$(MSC_VER)" NEQ "1925" if "$(MSC_VER)" NEQ "1926" if "$(MSC_VER)" NEQ "1927" if "$(MSC_VER)" NEQ "1928" if "$(MSC_VER)" NEQ "1929" \
 	echo *** WARNING *** unrecognized cl.exe version $(MSC_VER) ($(RAW_MSC_VER)).  Use FORCE_MSC_VER to override automatic detection.
 
 checkLink:

--- a/hotspot/make/windows/makefiles/vm.make
+++ b/hotspot/make/windows/makefiles/vm.make
@@ -129,7 +129,7 @@ CXX_DONT_USE_PCH=/D DONT_USE_PRECOMPILED_HEADER
 
 !if "$(USE_PRECOMPILED_HEADER)" != "0"
 CXX_USE_PCH=/Fp"vm.pch" /Yu"precompiled.hpp"
-!if "$(COMPILER_NAME)" == "VS2012" || "$(COMPILER_NAME)" == "VS2013" || "$(COMPILER_NAME)" == "VS2015" || "$(COMPILER_NAME)" == "VS2017"
+!if "$(COMPILER_NAME)" == "VS2012" || "$(COMPILER_NAME)" == "VS2013" || "$(COMPILER_NAME)" == "VS2015" || "$(COMPILER_NAME)" == "VS2017" || "$(COMPILER_NAME)" == "VS2019"
 # VS2012 and later require this object file to be listed:
 LD_FLAGS=$(LD_FLAGS) _build_pch_file.obj
 !endif


### PR DESCRIPTION
Hi!

Please review another portion of changes to add MSVS2019 support to jdk-8. This one adds recognition of MSVS2019 compiler/linker to the hotspot build scripts and applies build rules accordingly. Before the patch the scripts didn't not know how to link precompiled headers and builds failed with the error
```
ad_x86_64_pipeline.obj : error LNK2011: precompiled object not linked in; image may not run
jvm.dll : fatal error LNK1120: 1 unresolved externals
```

Verification: MSVS2019 (32/64-bits, release/debug) builds now fail with
```
awt_DCHolder.cpp
C:\PROGRA~2\MICROS~2\2019\COMMUN~1\VC\Tools\MSVC\14.29.30133\include\cstdlib(46): error C2039: 'Do_Not_Use_calloc_Use_safe_Calloc_Instead': is not a member of '`global namespace''
C:\PROGRA~2\MICROS~2\2019\COMMUN~1\VC\Tools\MSVC\14.29.30133\include\cstdlib(46): error C2873: 'Do_Not_Use_calloc_Use_safe_Calloc_Instead': symbol cannot be used in a using-declaration
C:\PROGRA~2\MICROS~2\2019\COMMUN~1\VC\Tools\MSVC\14.29.30133\include\cstdlib(52): error C2039: 'Do_Not_Use_malloc_Use_safe_Malloc_Instead': is not a member of '`global namespace''
C:\PROGRA~2\MICROS~2\2019\COMMUN~1\VC\Tools\MSVC\14.29.30133\include\cstdlib(52): error C2873: 'Do_Not_Use_malloc_Use_safe_Malloc_Instead': symbol cannot be used in a using-declaration
C:\PROGRA~2\MICROS~2\2019\COMMUN~1\VC\Tools\MSVC\14.29.30133\include\cstdlib(58): error C2039: 'Do_Not_Use_realloc_Use_safe_Realloc_Instead': is not a member of '`global namespace''
slowdebug/jdk/objs/libawt/awt_DCHolder.obj] Error 2
make[2]: *** Waiting for unfinished jobs....
```
that will be fixed by backporting of [JDK-8241087](https://bugs.openjdk.org/browse/JDK-8241087)

Regression: MSVS2017 (32/64-bits, release/debug) build - Ok

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297329](https://bugs.openjdk.org/browse/JDK-8297329): [8u] hotspot needs to recognise VS2019


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/187/head:pull/187` \
`$ git checkout pull/187`

Update a local copy of the PR: \
`$ git checkout pull/187` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/187/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 187`

View PR using the GUI difftool: \
`$ git pr show -t 187`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/187.diff">https://git.openjdk.org/jdk8u-dev/pull/187.diff</a>

</details>
