### PR TITLE
8226236: win32: gc/metaspace/TestCapacityUntilGCWrapAround.java fails

### DIFF
--- a/hotspot/src/share/vm/memory/metaspace.cpp
+++ b/hotspot/src/share/vm/memory/metaspace.cpp
@@ -1438,7 +1438,7 @@ bool MetaspaceGC::inc_capacity_until_GC(size_t v, size_t* new_cap_until_GC, size
 
   if (new_value < capacity_until_GC) {
     // The addition wrapped around, set new_value to aligned max value.
-    new_value = align_size_down(max_uintx, Metaspace::commit_alignment());
+    new_value = align_size_down(max_uintx, Metaspace::reserve_alignment());
   }
 
   if (new_value > MaxMetaspaceSize) {


### PR DESCRIPTION
Following tests from hotspot/tier1 currently fails on Windows x86:
`gc/metaspace/TestCapacityUntilGCWrapAround.java` 

This backport fixes that failure.

Backport is not clear as there was some renaming done in `metaspace.cpp` file. However apart from some renames (e.g. `align_size_down` -> `align_down`, `capacity_until_GC` -> `old_capacity_until_GC`) and location of the file surrounding method looks practically the same (See original change [1]). 

Tested on branch with hotspot/tier1 testing enabled for x86 OSes [2]. Fixed that one test, caused no regressions (Compare [3][4]).

[1] https://github.com/openjdk/jdk/commit/038f58d4
[2] https://github.com/zzambers/jdk8u-dev/commits/metaspace-fix-test
[3] https://github.com/zzambers/jdk8u-dev/actions/runs/3438556844/jobs/5735312562
[4] https://github.com/zzambers/jdk8u-dev/actions/runs/3471835524/jobs/5803573225

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8226236](https://bugs.openjdk.org/browse/JDK-8226236): win32: gc/metaspace/TestCapacityUntilGCWrapAround.java fails


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/192/head:pull/192` \
`$ git checkout pull/192`

Update a local copy of the PR: \
`$ git checkout pull/192` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/192/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 192`

View PR using the GUI difftool: \
`$ git pr show -t 192`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/192.diff">https://git.openjdk.org/jdk8u-dev/pull/192.diff</a>

</details>
