### PR TITLE
8298307: Enable hotspot/tier1 for 32-bit builds in GHA for 8u

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -558,14 +558,14 @@ jobs:
         test:
           - jdk/tier1
           - langtools/tier1
-#          - hotspot/tier1
+          - hotspot/tier1
         include:
           - test: jdk/tier1
             suites: jdk_tier1
           - test: langtools/tier1
             suites: langtools_tier1
-#          - test: hotspot/tier1
-#            suites: hotspot_tier1
+          - test: hotspot/tier1
+            suites: hotspot_tier1
 
     # Reduced 32-bit build uses the same boot JDK as 64-bit build
     env:
@@ -609,12 +609,20 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install openjdk-8-jdk
+          sudo apt-get install openjdk-8-jdk gcc-9-multilib g++-9-multilib
 
       - name: Unpack jdk
         run: |
           mkdir -p "${HOME}/jdk-linux-x86${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x86_bin${{ matrix.artifact }}"
           tar -xf "${HOME}/jdk-linux-x86${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x86_bin${{ matrix.artifact }}.tar.gz" -C "${HOME}/jdk-linux-x86${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x86_bin${{ matrix.artifact }}"
+
+      - name: Build multilib docker image
+        if: matrix.test == 'hotspot/tier1'
+        run: >
+          printf '%s\n%s\n'
+          'FROM ubuntu:latest'
+          'RUN dpkg --add-architecture i386 && apt-get update && apt-get -y install libc6:i386'
+          | docker build -t 'ubuntu-multilib:latest' -
 
       - name: Run tests
         run: >
@@ -624,7 +632,7 @@ jobs:
           PRODUCT_HOME="${HOME}/jdk-linux-x86${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x86_bin${{ matrix.artifact }}/j2sdk-image"
           JT_HOME="${HOME}/jtreg"
           ALT_OUTPUTDIR="${GITHUB_WORKSPACE}/test-results"
-          JAVA_ARGS="-Djdk.test.docker.image.name=ubuntu -Djdk.test.docker.image.version=latest"
+          JAVA_ARGS="-Djdk.test.docker.image.name=ubuntu-multilib -Djdk.test.docker.image.version=latest"
           JTREG_TIMEOUT_FACTOR="4"
           make
           "${{ matrix.suites }}"
@@ -1177,14 +1185,14 @@ jobs:
         test:
           - jdk/tier1
           - langtools/tier1
-#          - hotspot/tier1
+          - hotspot/tier1
         include:
           - test: jdk/tier1
             suites: jdk_tier1
           - test: langtools/tier1
             suites: langtools_tier1
-#          - test: hotspot/tier1
-#            suites: hotspot_tier1
+          - test: hotspot/tier1
+            suites: hotspot_tier1
 
     env:
       JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).JDK_MAJOR_VERSION }}.${{ fromJson(needs.prerequisites.outputs.dependencies).JDK_MINOR_VERSION }}.${{ fromJson(needs.prerequisites.outputs.dependencies).JDK_MICRO_VERSION }}"


### PR DESCRIPTION
All issues in hotspot/tier1 affecting 32-bit builds are now resolved so these configurations can now be enabled in GHA. This is the last piece to have full tier1 testing on all platforms we have in GHA.

Notes:
- hotspot/tier1 on linux requires working C/C++ compiler for some tests (gcc multilib packages are required for linux-x86)
- hotspot/tier1 contains some container tests, but ubuntu:latest does not include 32-bit libs by default. Multilib image needs to be created.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298307](https://bugs.openjdk.org/browse/JDK-8298307): Enable hotspot/tier1 for 32-bit builds in GHA for 8u


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/204/head:pull/204` \
`$ git checkout pull/204`

Update a local copy of the PR: \
`$ git checkout pull/204` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/204/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 204`

View PR using the GUI difftool: \
`$ git pr show -t 204`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/204.diff">https://git.openjdk.org/jdk8u-dev/pull/204.diff</a>

</details>
