### PR TITLE
8203485: [freetype] text rotated on 180 degrees is too narrow

### DIFF
--- a/jdk/src/share/native/sun/font/freetypeScaler.c
+++ b/jdk/src/share/native/sun/font/freetypeScaler.c
@@ -50,7 +50,7 @@
 #define  FloatToFTFixed(f) (FT_Fixed)((f) * (float)(ftFixed1))
 #define  FTFixedToFloat(x) ((x) / (float)(ftFixed1))
 #define  FT26Dot6ToFloat(x)  ((x) / ((float) (1<<6)))
-#define  ROUND(x) ((int) (x+0.5))
+#define  FT26Dot6ToInt(x) (((int)(x)) >> 6)
 
 typedef struct {
     /* Important note:
@@ -961,12 +961,12 @@ static jlong
     } else {
         if (!ftglyph->advance.y) {
             glyphInfo->advanceX =
-                (float) ROUND(FT26Dot6ToFloat(ftglyph->advance.x));
+                (float) FT26Dot6ToInt(ftglyph->advance.x);
             glyphInfo->advanceY = 0;
         } else if (!ftglyph->advance.x) {
             glyphInfo->advanceX = 0;
             glyphInfo->advanceY =
-                (float) ROUND(FT26Dot6ToFloat(-ftglyph->advance.y));
+                (float) FT26Dot6ToInt(-ftglyph->advance.y);
         } else {
             glyphInfo->advanceX = FT26Dot6ToFloat(ftglyph->advance.x);
             glyphInfo->advanceY = FT26Dot6ToFloat(-ftglyph->advance.y);

--- a/jdk/test/java/awt/font/Rotate/RotatedTextTest.java
+++ b/jdk/test/java/awt/font/Rotate/RotatedTextTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test RotatedTextTest
+ * @bug 8203485
+ * @summary This test verifies that rotated text preserves the width.
+ * @run main RotatedTextTest
+ */
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import javax.imageio.ImageIO;
+
+public class RotatedTextTest
+{
+    static final int size = 720;
+    static final Font fnt = new Font(Font.SERIF, Font.PLAIN, 12);
+    static final String text = "The quick brown fox jumps over the lazy dog";
+
+    static void drawRotatedText(Graphics g) {
+        Graphics2D g2d = (Graphics2D)g;
+
+        g2d.setFont(fnt);
+
+        FontMetrics metrics = g2d.getFontMetrics();
+        Rectangle2D bounds = metrics.getStringBounds(text, g2d);
+
+
+        g2d.setColor(Color.black);
+        g2d.fillRect(0, 0, size, size);
+
+        g2d.setColor(Color.white);
+
+        float[] angles = new float[] { 0, 15, 45, 60, 90, -45, -90, -135, -180, 135, };
+
+        for (float a : angles) {
+            Graphics2D rotated = (Graphics2D)g2d.create();
+
+            rotated.translate(size/2, size/2);
+            rotated.rotate(Math.toRadians(a));
+            rotated.translate(30, 0);
+
+            int width_original = metrics.stringWidth(text);
+            int width_rotated = rotated.getFontMetrics().stringWidth(text);
+
+            rotated.drawString(text, 0, 0);
+            rotated.drawString(String.format("  %.0f", a), width_original, 0);
+
+            rotated.setColor(Color.green);
+            rotated.draw(bounds);
+
+            System.out.printf("Angle: %.0f, width diff: %d\n", a, (width_rotated - width_original));
+
+            rotated.dispose();
+
+            if (width_rotated != width_original) {
+                throw new RuntimeException("Test failed for angle " + a);
+            }
+        }
+    }
+
+    public static void main(String args[])
+    {
+        final BufferedImage dst = new BufferedImage(size, size, BufferedImage.TYPE_INT_RGB);
+        Graphics g = dst.createGraphics();
+
+        try {
+            drawRotatedText(g);
+        } finally {
+            g.dispose();
+            writeToFile(dst);
+        }
+    }
+
+    static final String title;
+    static final String file;
+
+    static {
+        String vendorName = System.getProperty("java.vendor");
+        String version = System.getProperty("java.version");
+        String runtimeName = System.getProperty("java.runtime.name");
+
+
+        int index = runtimeName.indexOf(" Runtime Environment");
+        runtimeName = runtimeName.substring(0, index).trim();
+
+        title = vendorName + ", " + runtimeName + ", " + version;
+        file = "rotated-text-" + title.replace(", ", "-")
+                .replace(" ", "-") + ".png";
+    }
+
+    private static void writeToFile(final BufferedImage bi) {
+        File imageFile = new File(file);
+        FileOutputStream imageOutStream;
+        BufferedOutputStream imageBOS = null;
+        try {
+            imageOutStream = new FileOutputStream(imageFile);
+            imageBOS = new BufferedOutputStream(imageOutStream);
+
+            ImageIO.setUseCache(false);
+            ImageIO.write(bi, "png", imageBOS);
+
+            imageBOS.close();
+            imageOutStream.close();
+        }
+        catch (Exception e) {
+            System.out.println(e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
Hi,

java/awt/Graphics2D/DrawString/RotTransText.java fail:

```
STDERR:
java.lang.RuntimeException: Ratio of blue to red is too great: 0.14015748031496064
        at RotTransText.testIt(RotTransText.java:102)
        at RotTransText.main(RotTransText.java:41)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at com.sun.javatest.regtest.agent.MainWrapper$MainThread.run(MainWrapper.java:127)
        at java.lang.Thread.run(Thread.java:750)
```

And JDK-8203485: [freetype] text rotated on 180 degrees is too narrow fix the issue.

The patch applies clean except manually change the source file path:

* jdk/src/share/native/sun/font/freetypeScaler.c
* jdk/test/java/awt/font/Rotate/RotatedTextTest.java

Tested jtreg tier1~3 for fastdebug/release.

Thanks,
Leslie Zhai

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8203485](https://bugs.openjdk.org/browse/JDK-8203485): [freetype] text rotated on 180 degrees is too narrow


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/208/head:pull/208` \
`$ git checkout pull/208`

Update a local copy of the PR: \
`$ git checkout pull/208` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/208/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 208`

View PR using the GUI difftool: \
`$ git pr show -t 208`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/208.diff">https://git.openjdk.org/jdk8u-dev/pull/208.diff</a>

</details>
