### PR TITLE
8072770: [TESTBUG] Some Introspector tests fail with a Java heap bigger than 4GB

### DIFF
--- a/jdk/test/java/beans/Introspector/7064279/Test7064279.java
+++ b/jdk/test/java/beans/Introspector/7064279/Test7064279.java
@@ -26,6 +26,7 @@
  * @bug 7064279
  * @summary Tests that Introspector does not have strong references to context class loader
  * @author Sergey Malenkov
+ * @run main/othervm -Xmx128m Test7064279
  */
 
 import java.beans.Introspector;

--- a/jdk/test/java/beans/Introspector/Test7172865.java
+++ b/jdk/test/java/beans/Introspector/Test7172865.java
@@ -30,6 +30,7 @@ import java.beans.PropertyDescriptor;
  * @bug 7172854 7172865
  * @summary Tests that cached methods are not lost
  * @author Sergey Malenkov
+ * @run main/othervm -Xmx128m Test7172865
  */
 
 public class Test7172865 {

--- a/jdk/test/java/beans/Introspector/Test7195106.java
+++ b/jdk/test/java/beans/Introspector/Test7195106.java
@@ -26,6 +26,7 @@
  * @bug 7195106
  * @summary Tests that explicit BeanInfo is not collected
  * @author Sergey Malenkov
+ * @run main/othervm -Xmx128m Test7195106
  */
 
 import java.awt.Image;


### PR DESCRIPTION
The patch applies clean. This backport only includes test changes and fixes the test failure.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8072770](https://bugs.openjdk.org/browse/JDK-8072770): [TESTBUG] Some Introspector tests fail with a Java heap bigger than 4GB


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/209/head:pull/209` \
`$ git checkout pull/209`

Update a local copy of the PR: \
`$ git checkout pull/209` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/209/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 209`

View PR using the GUI difftool: \
`$ git pr show -t 209`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/209.diff">https://git.openjdk.org/jdk8u-dev/pull/209.diff</a>

</details>
