### PR TITLE
8196196: Headful tests should not be run in headless mode

### DIFF
--- a/jdk/test/java/awt/FileDialog/FileDialogMemoryLeak/FileDialogLeakTest.java
+++ b/jdk/test/java/awt/FileDialog/FileDialogMemoryLeak/FileDialogLeakTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * @test
+ * @key headful
  * @bug 8177758
  * @requires os.family == "windows"
  * @summary Regression in java.awt.FileDialog

--- a/jdk/test/java/awt/Gtk/GtkVersionTest/GtkVersionTest.java
+++ b/jdk/test/java/awt/Gtk/GtkVersionTest/GtkVersionTest.java
@@ -22,6 +22,7 @@
  */
 
 /* @test
+ * @key headful
  * @bug 8156121 8200313
  * @summary "Fail forward" fails for GTK3 if no GTK2 available
  * @modules java.desktop/sun.awt

--- a/jdk/test/java/awt/JAWT/JAWT.sh
+++ b/jdk/test/java/awt/JAWT/JAWT.sh
@@ -22,6 +22,7 @@
 # questions.
 
 # @test JAWT.sh
+# @key headful
 # @bug 7190587
 # @summary Tests Java AWT native interface library
 # @author kshefov
@@ -107,7 +108,7 @@ case "$OS" in
     else
         ARCH="i386"
     fi
-	SYST="cygwin"	
+	SYST="cygwin"
 	MAKE="make"
     ;;
   Darwin )

--- a/jdk/test/java/awt/Toolkit/BadDisplayTest/BadDisplayTest.java
+++ b/jdk/test/java/awt/Toolkit/BadDisplayTest/BadDisplayTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,18 +24,23 @@
 
 /*
  * @test
+ * @key headful
  * @summary Test that Toolkit.getDefaultToolkit throws AWTError exception if bad DISPLAY variable was set
  * @bug 6818083
  *
  * @run shell/timeout=240 BadDisplayTest.sh
  */
 
-import java.awt.*;
+import java.awt.AWTError;
+import java.awt.Toolkit;
 
 public class BadDisplayTest{
    public static void main(String[] args) {
+       if (Boolean.getBoolean("java.awt.headless")) {
+           return;
+       }
 
-        Throwable th = null;
+       Throwable th = null;
         try {
             Toolkit.getDefaultToolkit();
         } catch (Throwable x) {

--- a/jdk/test/java/awt/Toolkit/DesktopProperties/rfe4758438.java
+++ b/jdk/test/java/awt/Toolkit/DesktopProperties/rfe4758438.java
@@ -28,6 +28,7 @@ import java.io.InputStream;
 
 /*
  * @test
+ * @key headful
  * @bug 4758438
  * @summary Testcase to check the implementation of RFE 4758438
  *          The RFE suggests that the GNOME desktop properties

--- a/jdk/test/java/awt/TrayIcon/SystemTrayInstance/SystemTrayInstanceTest.java
+++ b/jdk/test/java/awt/TrayIcon/SystemTrayInstance/SystemTrayInstanceTest.java
@@ -25,6 +25,7 @@ import java.awt.*;
 
 /*
  * @test
+ * @key headful
  * @summary Check the getSystemTray method of the SystemTray. Checks if
  *          a proper instance is returned in supported platforms and a proper
  *          exception is thrown in unsupported platforms

--- a/jdk/test/java/awt/print/PrinterJob/PrintCrashTest.java
+++ b/jdk/test/java/awt/print/PrinterJob/PrintCrashTest.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8163889
  * @summary Printing crashes on OSX.
  * @run main PrintCrashTest

--- a/jdk/test/javax/swing/GroupLayout/7071166/bug7071166.java
+++ b/jdk/test/javax/swing/GroupLayout/7071166/bug7071166.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,9 +28,22 @@
  * @author Pavel Porvatov
  */
 
-import javax.swing.*;
-import static javax.swing.SwingConstants.*;
-import java.awt.*;
+import java.awt.Container;
+
+import javax.swing.JButton;
+import javax.swing.LayoutStyle;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+
+import static javax.swing.SwingConstants.EAST;
+import static javax.swing.SwingConstants.NORTH;
+import static javax.swing.SwingConstants.NORTH_EAST;
+import static javax.swing.SwingConstants.NORTH_WEST;
+import static javax.swing.SwingConstants.SOUTH;
+import static javax.swing.SwingConstants.SOUTH_EAST;
+import static javax.swing.SwingConstants.SOUTH_WEST;
+import static javax.swing.SwingConstants.WEST;
 
 public class bug7071166 {
     private static final int[] POSITIONS = {NORTH, EAST, SOUTH, WEST, // valid positions
@@ -38,8 +51,11 @@ public class bug7071166 {
 
     public static void main(String[] args) throws Exception {
         for (UIManager.LookAndFeelInfo lookAndFeelInfo : UIManager.getInstalledLookAndFeels()) {
-            UIManager.setLookAndFeel(lookAndFeelInfo.getClassName());
-
+            try {
+                UIManager.setLookAndFeel(lookAndFeelInfo.getClassName());
+            } catch (final UnsupportedLookAndFeelException ignored) {
+                continue;
+            }
             System.out.println("LookAndFeel: " + lookAndFeelInfo.getName());
 
             SwingUtilities.invokeAndWait(new Runnable() {

--- a/jdk/test/javax/swing/JComboBox/6632953/bug6632953.java
+++ b/jdk/test/javax/swing/JComboBox/6632953/bug6632953.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@
 import javax.swing.JComboBox;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
 import javax.swing.plaf.metal.MetalComboBoxUI;
 
 public class bug6632953 {
@@ -43,6 +44,8 @@ public class bug6632953 {
                         : UIManager.getInstalledLookAndFeels()) {
                     try {
                         UIManager.setLookAndFeel(lafInfo.getClassName());
+                    } catch (final UnsupportedLookAndFeelException ignored) {
+                        continue;
                     } catch (Exception e) {
                         throw new RuntimeException(e);
                     }

--- a/jdk/test/javax/swing/JComboBox/6632953/bug6632953.java
+++ b/jdk/test/javax/swing/JComboBox/6632953/bug6632953.java
@@ -44,7 +44,7 @@ public class bug6632953 {
                         : UIManager.getInstalledLookAndFeels()) {
                     try {
                         UIManager.setLookAndFeel(lafInfo.getClassName());
-                    } catch (final UnsupportedLookAndFeelException ignored) {
+                    } catch (UnsupportedLookAndFeelException ignored) {
                         continue;
                     } catch (Exception e) {
                         throw new RuntimeException(e);

--- a/jdk/test/javax/swing/JComboBox/7082443/bug7082443.java
+++ b/jdk/test/javax/swing/JComboBox/7082443/bug7082443.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,11 @@ public class bug7082443 {
     public static void main(String[] args) throws Exception {
         for (UIManager.LookAndFeelInfo lookAndFeelInfo : UIManager.getInstalledLookAndFeels()) {
             if (lookAndFeelInfo.getClassName().contains(GTK_LAF_CLASS)) {
-                UIManager.setLookAndFeel(lookAndFeelInfo.getClassName());
+                try {
+                    UIManager.setLookAndFeel(lookAndFeelInfo.getClassName());
+                } catch (final UnsupportedLookAndFeelException ignored) {
+                    continue;
+                }
 
                 SwingUtilities.invokeAndWait(new Runnable() {
                     @Override

--- a/jdk/test/javax/swing/JFileChooser/6489130/bug6489130.java
+++ b/jdk/test/javax/swing/JFileChooser/6489130/bug6489130.java
@@ -22,6 +22,7 @@
  */
 
 /* @test
+ * @key headful
  * @bug 6489130
  * @summary FileChooserDemo hung by keeping pressing Enter key
  * @author Pavel Porvatov

--- a/jdk/test/javax/swing/JFileChooser/8080628/bug8080628.java
+++ b/jdk/test/javax/swing/JFileChooser/8080628/bug8080628.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ import java.util.Locale;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.UIManager.LookAndFeelInfo;
+import javax.swing.UnsupportedLookAndFeelException;
 
 import sun.swing.SwingUtilities2;
 
@@ -76,7 +77,11 @@ public class bug8080628 {
         try {
             LookAndFeelInfo[] lafInfo = UIManager.getInstalledLookAndFeels();
             for (LookAndFeelInfo info : lafInfo) {
-                UIManager.setLookAndFeel(info.getClassName());
+                try {
+                    UIManager.setLookAndFeel(info.getClassName());
+                } catch (final UnsupportedLookAndFeelException ignored) {
+                    continue;
+                }
 
                 for (Locale locale : LOCALES) {
                     for (String key : MNEMONIC_KEYS) {

--- a/jdk/test/javax/swing/Security/6657138/bug6657138.java
+++ b/jdk/test/javax/swing/Security/6657138/bug6657138.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,7 +67,11 @@ public class bug6657138 implements Runnable {
                     continue;
                 }
                 String className = laf.getClassName();
-                UIManager.setLookAndFeel(className);
+                try {
+                    UIManager.setLookAndFeel(className);
+                } catch (final UnsupportedLookAndFeelException ignored) {
+                    continue;
+                }
                 ComponentUI ui = UIManager.getUI(c);
                 if (ui == null) {
                     throw new RuntimeException("UI is null for " + c);

--- a/jdk/test/javax/swing/plaf/metal/MetalUtils/bug6190373.java
+++ b/jdk/test/javax/swing/plaf/metal/MetalUtils/bug6190373.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -102,8 +102,10 @@ public final class bug6190373 {
         try {
             UIManager.setLookAndFeel(laf.getClassName());
             System.out.println("LookAndFeel: " + laf.getClassName());
+        } catch (final UnsupportedLookAndFeelException ignored){
+            System.out.println("Unsupported LookAndFeel: " + laf.getClassName());
         } catch (ClassNotFoundException | InstantiationException |
-                UnsupportedLookAndFeelException | IllegalAccessException e) {
+                IllegalAccessException e) {
             throw new RuntimeException(e);
         }
     }


### PR DESCRIPTION
Hi,

javax/swing/GroupLayout/7071166/bug7071166.java fail due to TESTBUG.

The patch applies clean except manually change the source file path.

Tested jtreg tier1~3 for fastdebug/release. This backport is only a test change and fixes the test failure.

Thanks,
Leslie Zhai

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8196196](https://bugs.openjdk.org/browse/JDK-8196196): Headful tests should not be run in headless mode


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/210/head:pull/210` \
`$ git checkout pull/210`

Update a local copy of the PR: \
`$ git checkout pull/210` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/210/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 210`

View PR using the GUI difftool: \
`$ git pr show -t 210`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/210.diff">https://git.openjdk.org/jdk8u-dev/pull/210.diff</a>

</details>
