### PR TITLE
8254717: isAssignableFrom checks in KeyFactorySpi.engineGetKeySpec appear to be backwards

### DIFF
--- a/jdk/src/share/classes/com/sun/crypto/provider/DESKeyFactory.java
+++ b/jdk/src/share/classes/com/sun/crypto/provider/DESKeyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -106,7 +106,7 @@ public final class DESKeyFactory extends SecretKeyFactorySpi {
 
                 // Check if requested key spec is amongst the valid ones
                 if ((keySpec != null) &&
-                    DESKeySpec.class.isAssignableFrom(keySpec)) {
+                    keySpec.isAssignableFrom(DESKeySpec.class)) {
                     return new DESKeySpec(key.getEncoded());
 
                 } else {

--- a/jdk/src/share/classes/com/sun/crypto/provider/DESedeKeyFactory.java
+++ b/jdk/src/share/classes/com/sun/crypto/provider/DESedeKeyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -102,7 +102,7 @@ public final class DESedeKeyFactory extends SecretKeyFactorySpi {
                 && (key.getFormat().equalsIgnoreCase("RAW"))) {
 
                 // Check if requested key spec is amongst the valid ones
-                if (DESedeKeySpec.class.isAssignableFrom(keySpec)) {
+                if (keySpec.isAssignableFrom(DESedeKeySpec.class)) {
                     return new DESedeKeySpec(key.getEncoded());
 
                 } else {

--- a/jdk/src/share/classes/com/sun/crypto/provider/DHKeyFactory.java
+++ b/jdk/src/share/classes/com/sun/crypto/provider/DHKeyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -145,7 +145,7 @@ public final class DHKeyFactory extends KeyFactorySpi {
 
         if (key instanceof javax.crypto.interfaces.DHPublicKey) {
 
-            if (DHPublicKeySpec.class.isAssignableFrom(keySpec)) {
+            if (keySpec.isAssignableFrom(DHPublicKeySpec.class)) {
                 javax.crypto.interfaces.DHPublicKey dhPubKey
                     = (javax.crypto.interfaces.DHPublicKey) key;
                 params = dhPubKey.getParams();
@@ -153,7 +153,7 @@ public final class DHKeyFactory extends KeyFactorySpi {
                                                         params.getP(),
                                                         params.getG()));
 
-            } else if (X509EncodedKeySpec.class.isAssignableFrom(keySpec)) {
+            } else if (keySpec.isAssignableFrom(X509EncodedKeySpec.class)) {
                 return keySpec.cast(new X509EncodedKeySpec(key.getEncoded()));
 
             } else {
@@ -163,7 +163,7 @@ public final class DHKeyFactory extends KeyFactorySpi {
 
         } else if (key instanceof javax.crypto.interfaces.DHPrivateKey) {
 
-            if (DHPrivateKeySpec.class.isAssignableFrom(keySpec)) {
+            if (keySpec.isAssignableFrom(DHPrivateKeySpec.class)) {
                 javax.crypto.interfaces.DHPrivateKey dhPrivKey
                     = (javax.crypto.interfaces.DHPrivateKey)key;
                 params = dhPrivKey.getParams();
@@ -171,7 +171,7 @@ public final class DHKeyFactory extends KeyFactorySpi {
                                                          params.getP(),
                                                          params.getG()));
 
-            } else if (PKCS8EncodedKeySpec.class.isAssignableFrom(keySpec)) {
+            } else if (keySpec.isAssignableFrom(PKCS8EncodedKeySpec.class)) {
                 return keySpec.cast(new PKCS8EncodedKeySpec(key.getEncoded()));
 
             } else {

--- a/jdk/src/share/classes/sun/security/ec/ECKeyFactory.java
+++ b/jdk/src/share/classes/sun/security/ec/ECKeyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -256,12 +256,12 @@ public final class ECKeyFactory extends KeyFactorySpi {
         }
         if (key instanceof ECPublicKey) {
             ECPublicKey ecKey = (ECPublicKey)key;
-            if (ECPublicKeySpec.class.isAssignableFrom(keySpec)) {
+            if (keySpec.isAssignableFrom(ECPublicKeySpec.class)) {
                 return keySpec.cast(new ECPublicKeySpec(
                     ecKey.getW(),
                     ecKey.getParams()
                 ));
-            } else if (X509EncodedKeySpec.class.isAssignableFrom(keySpec)) {
+            } else if (keySpec.isAssignableFrom(X509EncodedKeySpec.class)) {
                 return keySpec.cast(new X509EncodedKeySpec(key.getEncoded()));
             } else {
                 throw new InvalidKeySpecException
@@ -269,9 +269,9 @@ public final class ECKeyFactory extends KeyFactorySpi {
                         + "X509EncodedKeySpec for EC public keys");
             }
         } else if (key instanceof ECPrivateKey) {
-            if (PKCS8EncodedKeySpec.class.isAssignableFrom(keySpec)) {
+            if (keySpec.isAssignableFrom(PKCS8EncodedKeySpec.class)) {
                 return keySpec.cast(new PKCS8EncodedKeySpec(key.getEncoded()));
-            } else if (ECPrivateKeySpec.class.isAssignableFrom(keySpec)) {
+            } else if (keySpec.isAssignableFrom(ECPrivateKeySpec.class)) {
                 ECPrivateKey ecKey = (ECPrivateKey)key;
                 return keySpec.cast(new ECPrivateKeySpec(
                     ecKey.getS(),

--- a/jdk/src/share/classes/sun/security/pkcs11/P11DHKeyFactory.java
+++ b/jdk/src/share/classes/sun/security/pkcs11/P11DHKeyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -214,7 +214,7 @@ final class P11DHKeyFactory extends P11KeyFactory {
 
     <T extends KeySpec> T implGetPublicKeySpec(P11Key key, Class<T> keySpec,
             Session[] session) throws PKCS11Exception, InvalidKeySpecException {
-        if (DHPublicKeySpec.class.isAssignableFrom(keySpec)) {
+        if (keySpec.isAssignableFrom(DHPublicKeySpec.class)) {
             session[0] = token.getObjSession();
             CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
                 new CK_ATTRIBUTE(CKA_VALUE),
@@ -241,7 +241,7 @@ final class P11DHKeyFactory extends P11KeyFactory {
 
     <T extends KeySpec> T implGetPrivateKeySpec(P11Key key, Class<T> keySpec,
             Session[] session) throws PKCS11Exception, InvalidKeySpecException {
-        if (DHPrivateKeySpec.class.isAssignableFrom(keySpec)) {
+        if (keySpec.isAssignableFrom(DHPrivateKeySpec.class)) {
             session[0] = token.getObjSession();
             CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
                 new CK_ATTRIBUTE(CKA_VALUE),

--- a/jdk/src/share/classes/sun/security/pkcs11/P11DSAKeyFactory.java
+++ b/jdk/src/share/classes/sun/security/pkcs11/P11DSAKeyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -210,7 +210,7 @@ final class P11DSAKeyFactory extends P11KeyFactory {
 
     <T extends KeySpec> T implGetPublicKeySpec(P11Key key, Class<T> keySpec,
             Session[] session) throws PKCS11Exception, InvalidKeySpecException {
-        if (DSAPublicKeySpec.class.isAssignableFrom(keySpec)) {
+        if (keySpec.isAssignableFrom(DSAPublicKeySpec.class)) {
             session[0] = token.getObjSession();
             CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
                 new CK_ATTRIBUTE(CKA_VALUE),
@@ -239,7 +239,7 @@ final class P11DSAKeyFactory extends P11KeyFactory {
 
     <T extends KeySpec> T implGetPrivateKeySpec(P11Key key, Class<T> keySpec,
             Session[] session) throws PKCS11Exception, InvalidKeySpecException {
-        if (DSAPrivateKeySpec.class.isAssignableFrom(keySpec)) {
+        if (keySpec.isAssignableFrom(DSAPrivateKeySpec.class)) {
             session[0] = token.getObjSession();
             CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
                 new CK_ATTRIBUTE(CKA_VALUE),

--- a/jdk/src/share/classes/sun/security/pkcs11/P11ECKeyFactory.java
+++ b/jdk/src/share/classes/sun/security/pkcs11/P11ECKeyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -284,7 +284,7 @@ final class P11ECKeyFactory extends P11KeyFactory {
 
     <T extends KeySpec> T implGetPublicKeySpec(P11Key key, Class<T> keySpec,
             Session[] session) throws PKCS11Exception, InvalidKeySpecException {
-        if (ECPublicKeySpec.class.isAssignableFrom(keySpec)) {
+        if (keySpec.isAssignableFrom(ECPublicKeySpec.class)) {
             session[0] = token.getObjSession();
             CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
                 new CK_ATTRIBUTE(CKA_EC_POINT),
@@ -309,7 +309,7 @@ final class P11ECKeyFactory extends P11KeyFactory {
 
     <T extends KeySpec> T implGetPrivateKeySpec(P11Key key, Class<T> keySpec,
             Session[] session) throws PKCS11Exception, InvalidKeySpecException {
-        if (ECPrivateKeySpec.class.isAssignableFrom(keySpec)) {
+        if (keySpec.isAssignableFrom(ECPrivateKeySpec.class)) {
             session[0] = token.getObjSession();
             CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
                 new CK_ATTRIBUTE(CKA_VALUE),

--- a/jdk/src/share/classes/sun/security/pkcs11/P11KeyFactory.java
+++ b/jdk/src/share/classes/sun/security/pkcs11/P11KeyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,8 +73,8 @@ abstract class P11KeyFactory extends KeyFactorySpi {
                 ("key and keySpec must not be null");
         }
         // delegate to our Java based providers for PKCS#8 and X.509
-        if (PKCS8EncodedKeySpec.class.isAssignableFrom(keySpec)
-                || X509EncodedKeySpec.class.isAssignableFrom(keySpec)) {
+        if (keySpec.isAssignableFrom(PKCS8EncodedKeySpec.class)
+                || keySpec.isAssignableFrom(X509EncodedKeySpec.class)) {
             try {
                 return implGetSoftwareFactory().getKeySpec(key, keySpec);
             } catch (GeneralSecurityException e) {

--- a/jdk/src/share/classes/sun/security/pkcs11/P11RSAKeyFactory.java
+++ b/jdk/src/share/classes/sun/security/pkcs11/P11RSAKeyFactory.java
@@ -257,7 +257,7 @@ final class P11RSAKeyFactory extends P11KeyFactory {
 
     <T extends KeySpec> T implGetPublicKeySpec(P11Key key, Class<T> keySpec,
             Session[] session) throws PKCS11Exception, InvalidKeySpecException {
-        if (RSAPublicKeySpec.class.isAssignableFrom(keySpec)) {
+        if (keySpec.isAssignableFrom(RSAPublicKeySpec.class)) {
             session[0] = token.getObjSession();
             CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
                 new CK_ATTRIBUTE(CKA_MODULUS),
@@ -282,7 +282,7 @@ final class P11RSAKeyFactory extends P11KeyFactory {
 
     <T extends KeySpec> T implGetPrivateKeySpec(P11Key key, Class<T> keySpec,
             Session[] session) throws PKCS11Exception, InvalidKeySpecException {
-        if (RSAPrivateCrtKeySpec.class.isAssignableFrom(keySpec)) {
+        if (keySpec.isAssignableFrom(RSAPrivateCrtKeySpec.class)) {
             session[0] = token.getObjSession();
             CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
                 new CK_ATTRIBUTE(CKA_MODULUS),
@@ -312,7 +312,7 @@ final class P11RSAKeyFactory extends P11KeyFactory {
                 attributes[7].getBigInteger()
             );
             return keySpec.cast(spec);
-        } else if (RSAPrivateKeySpec.class.isAssignableFrom(keySpec)) {
+        } else if (keySpec.isAssignableFrom(RSAPrivateKeySpec.class)) {
             session[0] = token.getObjSession();
             CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
                 new CK_ATTRIBUTE(CKA_MODULUS),

--- a/jdk/src/share/classes/sun/security/pkcs11/P11SecretKeyFactory.java
+++ b/jdk/src/share/classes/sun/security/pkcs11/P11SecretKeyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -330,11 +330,11 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
             throw new InvalidKeySpecException
                 ("key and keySpec must not be null");
         }
-        if (SecretKeySpec.class.isAssignableFrom(keySpec)) {
+        if (keySpec.isAssignableFrom(SecretKeySpec.class)) {
             return new SecretKeySpec(getKeyBytes(key), algorithm);
         } else if (algorithm.equalsIgnoreCase("DES")) {
             try {
-                if (DESKeySpec.class.isAssignableFrom(keySpec)) {
+                if (keySpec.isAssignableFrom(DESKeySpec.class)) {
                     return new DESKeySpec(getKeyBytes(key));
                 }
             } catch (InvalidKeyException e) {
@@ -342,7 +342,7 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
             }
         } else if (algorithm.equalsIgnoreCase("DESede")) {
             try {
-                if (DESedeKeySpec.class.isAssignableFrom(keySpec)) {
+                if (keySpec.isAssignableFrom(DESedeKeySpec.class)) {
                     return new DESedeKeySpec(getKeyBytes(key));
                 }
             } catch (InvalidKeyException e) {

--- a/jdk/src/share/classes/sun/security/provider/DSAKeyFactory.java
+++ b/jdk/src/share/classes/sun/security/provider/DSAKeyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -187,7 +187,7 @@ public class DSAKeyFactory extends KeyFactorySpi {
                 Class<?> x509KeySpec = Class.forName
                     ("java.security.spec.X509EncodedKeySpec");
 
-                if (dsaPubKeySpec.isAssignableFrom(keySpec)) {
+                if (keySpec.isAssignableFrom(dsaPubKeySpec)) {
                     java.security.interfaces.DSAPublicKey dsaPubKey
                         = (java.security.interfaces.DSAPublicKey)key;
                     params = dsaPubKey.getParams();
@@ -196,7 +196,7 @@ public class DSAKeyFactory extends KeyFactorySpi {
                                                              params.getQ(),
                                                              params.getG()));
 
-                } else if (x509KeySpec.isAssignableFrom(keySpec)) {
+                } else if (keySpec.isAssignableFrom(x509KeySpec)) {
                     return keySpec.cast(new X509EncodedKeySpec(key.getEncoded()));
 
                 } else {
@@ -212,7 +212,7 @@ public class DSAKeyFactory extends KeyFactorySpi {
                 Class<?> pkcs8KeySpec = Class.forName
                     ("java.security.spec.PKCS8EncodedKeySpec");
 
-                if (dsaPrivKeySpec.isAssignableFrom(keySpec)) {
+                if (keySpec.isAssignableFrom(dsaPrivKeySpec)) {
                     java.security.interfaces.DSAPrivateKey dsaPrivKey
                         = (java.security.interfaces.DSAPrivateKey)key;
                     params = dsaPrivKey.getParams();
@@ -221,7 +221,7 @@ public class DSAKeyFactory extends KeyFactorySpi {
                                                               params.getQ(),
                                                               params.getG()));
 
-                } else if (pkcs8KeySpec.isAssignableFrom(keySpec)) {
+                } else if (keySpec.isAssignableFrom(pkcs8KeySpec)) {
                     return keySpec.cast(new PKCS8EncodedKeySpec(key.getEncoded()));
 
                 } else {

--- a/jdk/src/share/classes/sun/security/rsa/RSAKeyFactory.java
+++ b/jdk/src/share/classes/sun/security/rsa/RSAKeyFactory.java
@@ -404,13 +404,13 @@ public class RSAKeyFactory extends KeyFactorySpi {
         }
         if (key instanceof RSAPublicKey) {
             RSAPublicKey rsaKey = (RSAPublicKey)key;
-            if (RSA_PUB_KEYSPEC_CLS.isAssignableFrom(keySpec)) {
+            if (keySpec.isAssignableFrom(RSA_PUB_KEYSPEC_CLS)) {
                 return keySpec.cast(new RSAPublicKeySpec(
                     rsaKey.getModulus(),
                     rsaKey.getPublicExponent(),
                     rsaKey.getParams()
                 ));
-            } else if (X509_KEYSPEC_CLS.isAssignableFrom(keySpec)) {
+            } else if (keySpec.isAssignableFrom(X509_KEYSPEC_CLS)) {
                 return keySpec.cast(new X509EncodedKeySpec(key.getEncoded()));
             } else {
                 throw new InvalidKeySpecException
@@ -418,9 +418,9 @@ public class RSAKeyFactory extends KeyFactorySpi {
                         + "X509EncodedKeySpec for RSA public keys");
             }
         } else if (key instanceof RSAPrivateKey) {
-            if (PKCS8_KEYSPEC_CLS.isAssignableFrom(keySpec)) {
+            if (keySpec.isAssignableFrom(PKCS8_KEYSPEC_CLS)) {
                 return keySpec.cast(new PKCS8EncodedKeySpec(key.getEncoded()));
-            } else if (RSA_PRIVCRT_KEYSPEC_CLS.isAssignableFrom(keySpec)) {
+            } else if (keySpec.isAssignableFrom(RSA_PRIVCRT_KEYSPEC_CLS)) {
                 if (key instanceof RSAPrivateCrtKey) {
                     RSAPrivateCrtKey crtKey = (RSAPrivateCrtKey)key;
                     return keySpec.cast(new RSAPrivateCrtKeySpec(
@@ -438,7 +438,7 @@ public class RSAKeyFactory extends KeyFactorySpi {
                     throw new InvalidKeySpecException
                     ("RSAPrivateCrtKeySpec can only be used with CRT keys");
                 }
-            } else if (RSA_PRIV_KEYSPEC_CLS.isAssignableFrom(keySpec)) {
+            } else if (keySpec.isAssignableFrom(RSA_PRIV_KEYSPEC_CLS)) {
                 RSAPrivateKey rsaKey = (RSAPrivateKey)key;
                 return keySpec.cast(new RSAPrivateKeySpec(
                     rsaKey.getModulus(),

--- a/jdk/test/java/security/KeyFactory/KeyFactoryGetKeySpecForInvalidSpec.java
+++ b/jdk/test/java/security/KeyFactory/KeyFactoryGetKeySpecForInvalidSpec.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021, Amazon.com, Inc. or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8254717
+ * @summary isAssignableFrom checks in KeyFactorySpi.engineGetKeySpec appear to be backwards.
+ * @author Greg Rubin, Ziyi Luo
+ */
+
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.spec.*;
+
+public class KeyFactoryGetKeySpecForInvalidSpec {
+    public static void main(String[] args) throws Exception {
+        KeyPairGenerator kg = KeyPairGenerator.getInstance("RSA");
+        kg.initialize(2048);
+        KeyPair pair = kg.generateKeyPair();
+
+        KeyFactory factory = KeyFactory.getInstance("RSA");
+
+        // Since RSAPrivateCrtKeySpec inherits from RSAPrivateKeySpec, we'd expect this next line to return an instance of RSAPrivateKeySpec
+        // (because the private key has CRT parts).
+        KeySpec spec = factory.getKeySpec(pair.getPrivate(), RSAPrivateKeySpec.class);
+        if (!(spec instanceof RSAPrivateCrtKeySpec)) {
+            throw new Exception("Spec should be an instance of RSAPrivateCrtKeySpec");
+        }
+
+        // This next line should give an InvalidKeySpec exception
+        try {
+            spec = factory.getKeySpec(pair.getPublic(), FakeX509Spec.class);
+            throw new Exception("InvalidKeySpecException is expected but not thrown");
+        } catch (final ClassCastException ex) {
+            throw new Exception("InvalidKeySpecException is expected ClassCastException is thrown", ex);
+        } catch (final InvalidKeySpecException ex) {
+            // Pass
+        }
+    }
+
+    public static class FakeX509Spec extends X509EncodedKeySpec {
+        public FakeX509Spec(byte[] encodedKey) {
+            super(encodedKey);
+        }
+    }
+}

--- a/jdk/test/sun/security/rsa/TestKeyFactory.java
+++ b/jdk/test/sun/security/rsa/TestKeyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 4853305
+ * @bug 4853305 8254717
  * @summary Test KeyFactory of the new RSA provider
  * @author Andreas Sterbenz
  */
@@ -107,11 +107,15 @@ public class TestKeyFactory {
 
         KeySpec rsaSpec2 = kf.getKeySpec(key, RSAPrivateKeySpec.class);
         PrivateKey key6 = kf.generatePrivate(rsaSpec2);
-        RSAPrivateKey rsaKey = (RSAPrivateKey)key;
-        KeySpec rsaSpec3 = new RSAPrivateKeySpec(rsaKey.getModulus(), rsaKey.getPrivateExponent());
-        PrivateKey key7 = kf.generatePrivate(rsaSpec3);
         testKey(key6, key6);
-        testKey(key6, key7);
+        if (key instanceof RSAPrivateCrtKey) {
+            RSAPrivateCrtKey rsaKey = (RSAPrivateCrtKey)key;
+            KeySpec rsaSpec3 = new RSAPrivateCrtKeySpec(rsaKey.getModulus(),
+                    rsaKey.getPublicExponent(), rsaKey.getPrivateExponent(), rsaKey.getPrimeP(), rsaKey.getPrimeQ(),
+                    rsaKey.getPrimeExponentP(), rsaKey.getPrimeExponentQ(), rsaKey.getCrtCoefficient(), rsaKey.getParams());
+            PrivateKey key7 = kf.generatePrivate(rsaSpec3);
+            testKey(key6, key7);
+        }
     }
 
     private static void test(KeyFactory kf, Key key) throws Exception {

--- a/jdk/test/sun/security/rsa/pss/TestPSSKeySupport.java
+++ b/jdk/test/sun/security/rsa/pss/TestPSSKeySupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8146293 8242556
+ * @bug 8146293 8242556 8254717
  * @summary Test RSASSA-PSS Key related support such as KeyPairGenerator
  * and KeyFactory of the SunRsaSign provider
  */
@@ -98,9 +98,10 @@ public class TestPSSKeySupport {
 
         KeySpec rsaSpec2 = kf.getKeySpec(key, RSAPrivateKeySpec.class);
         PrivateKey key6 = kf.generatePrivate(rsaSpec2);
-        RSAPrivateKey rsaKey = (RSAPrivateKey)key;
-        KeySpec rsaSpec3 = new RSAPrivateKeySpec(rsaKey.getModulus(),
-            rsaKey.getPrivateExponent(), rsaKey.getParams());
+        RSAPrivateCrtKey rsaKey = (RSAPrivateCrtKey)key;
+        KeySpec rsaSpec3 = new RSAPrivateCrtKeySpec(rsaKey.getModulus(),
+                rsaKey.getPublicExponent(), rsaKey.getPrivateExponent(), rsaKey.getPrimeP(), rsaKey.getPrimeQ(),
+                rsaKey.getPrimeExponentP(), rsaKey.getPrimeExponentQ(), rsaKey.getCrtCoefficient(), rsaKey.getParams());
         PrivateKey key7 = kf.generatePrivate(rsaSpec3);
         testKey(key6, key6);
         testKey(key6, key7);


### PR DESCRIPTION
Backport for Oracle parity from 11u is not clean.

1.  Copyright date mismatch in P11SecretKeyFactory.java.
2. XDHKeyFactory.java does not exist in 8u.
3. In KeyFactoryGetKeySpecForInvalidSpec.java, class FakeX509Spec does not include a (byte[], String) constructor since in 8u, X509EncodedKeySpec does not.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8254717](https://bugs.openjdk.org/browse/JDK-8254717): isAssignableFrom checks in KeyFactorySpi.engineGetKeySpec appear to be backwards


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/211/head:pull/211` \
`$ git checkout pull/211`

Update a local copy of the PR: \
`$ git checkout pull/211` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/211/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 211`

View PR using the GUI difftool: \
`$ git pr show -t 211`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/211.diff">https://git.openjdk.org/jdk8u-dev/pull/211.diff</a>

</details>
