### PR TITLE
8234484: Add ability to configure third port for remote JMX

### DIFF
--- a/jdk/src/share/classes/sun/management/AgentConfigurationError.java
+++ b/jdk/src/share/classes/sun/management/AgentConfigurationError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,6 +55,8 @@ public class AgentConfigurationError extends Error {
         "agent.err.invalid.jmxremote.port";
     public static final String INVALID_JMXREMOTE_RMI_PORT =
         "agent.err.invalid.jmxremote.rmi.port";
+    public static final String INVALID_JMXREMOTE_LOCAL_PORT =
+        "agent.err.invalid.jmxremote.local.port";
     public static final String PASSWORD_FILE_NOT_SET =
         "agent.err.password.file.notset";
     public static final String PASSWORD_FILE_NOT_READABLE =

--- a/jdk/src/share/classes/sun/management/jmxremote/ConnectorBootstrap.java
+++ b/jdk/src/share/classes/sun/management/jmxremote/ConnectorBootstrap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -117,6 +117,8 @@ public final class ConnectorBootstrap {
                 "com.sun.management.jmxremote.host";
         public static final String RMI_PORT =
                 "com.sun.management.jmxremote.rmi.port";
+        public static final String LOCAL_PORT =
+                "com.sun.management.jmxremote.local.port";
         public static final String CONFIG_FILE_NAME =
                 "com.sun.management.config.file";
         public static final String USE_LOCAL_ONLY =
@@ -531,13 +533,35 @@ public final class ConnectorBootstrap {
         }
 
         MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+
+        Properties props = null;
         try {
-            JMXServiceURL url = new JMXServiceURL("rmi", localhost, 0);
-            // Do we accept connections from local interfaces only?
-            Properties props = Agent.getManagementProperties();
+            props = Agent.getManagementProperties();
             if (props ==  null) {
                 props = new Properties();
             }
+        } catch (Exception e) {
+            throw new AgentConfigurationError(AGENT_EXCEPTION, e, e.toString());
+        }
+
+        // User can specify a port to be used to start local connector server.
+        // Random one will be allocated if port is not specified.
+        int localPort = 0;
+        String localPortStr = props.getProperty(PropertyNames.LOCAL_PORT);
+        try {
+            if (localPortStr != null) {
+                localPort = Integer.parseInt(localPortStr);
+            }
+        } catch (NumberFormatException x) {
+            throw new AgentConfigurationError(INVALID_JMXREMOTE_LOCAL_PORT, x, localPortStr);
+        }
+        if (localPort < 0) {
+            throw new AgentConfigurationError(INVALID_JMXREMOTE_LOCAL_PORT, localPortStr);
+        }
+
+        try {
+            JMXServiceURL url = new JMXServiceURL("rmi", localhost, localPort);
+            // Do we accept connections from local interfaces only?
             String useLocalOnlyStr = props.getProperty(
                     PropertyNames.USE_LOCAL_ONLY, DefaultValues.USE_LOCAL_ONLY);
             boolean useLocalOnly = Boolean.valueOf(useLocalOnlyStr).booleanValue();

--- a/jdk/src/share/lib/management/management.properties
+++ b/jdk/src/share/lib/management/management.properties
@@ -26,6 +26,8 @@
 # For setting the JMX RMI agent port use the following line
 # com.sun.management.jmxremote.port=<port-number>
 #
+# For setting the JMX local server port use the following line
+# com.sun.management.jmxremote.local.port=<port-number>
 # For setting the SNMP agent port use the following line
 # com.sun.management.snmp.port=<port-number>
 


### PR DESCRIPTION
Reviewed-by: ksrini
Backport-of: f129cc43283a18cb5afdd1416b09691a636a7758

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8234484](https://bugs.openjdk.org/browse/JDK-8234484): Add ability to configure third port for remote JMX


### Reviewers
 * [Kumar Srinivasan](https://openjdk.org/census#ksrini) (@kusrinivasan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/213/head:pull/213` \
`$ git checkout pull/213`

Update a local copy of the PR: \
`$ git checkout pull/213` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/213/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 213`

View PR using the GUI difftool: \
`$ git pr show -t 213`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/213.diff">https://git.openjdk.org/jdk8u-dev/pull/213.diff</a>

</details>
