### PR TITLE
8284977: MetricsTesterCgroupV2.getLongValueEntryFromFile fails when named value doesn't exist

### DIFF
--- a/jdk/test/lib/jdk/test/lib/containers/cgroup/MetricsTesterCgroupV2.java
+++ b/jdk/test/lib/jdk/test/lib/containers/cgroup/MetricsTesterCgroupV2.java
@@ -121,6 +121,11 @@ public class MetricsTesterCgroupV2 implements CgroupMetricsTester {
         Path filePath = Paths.get(UNIFIED.getPath(), file);
         try {
             String strVal = Files.lines(filePath).filter(l -> l.startsWith(metric)).collect(Collectors.joining());
+            if (strVal.isEmpty()) {
+                // sometimes the match for the metric does not exist, e.g. cpu.stat's nr_periods iff the controller
+                // is not enabled
+                return UNLIMITED;
+            }
             String[] keyValues = strVal.split("\\s+");
             String value = keyValues[1];
             return convertStringToLong(value);


### PR DESCRIPTION
Hi all,

I'd like to backport this to jdk8u-dev.
It fixes a test failure caused by cgroups virtual files (nr_periods etc) not existing in some circumstances.

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284977](https://bugs.openjdk.org/browse/JDK-8284977): MetricsTesterCgroupV2.getLongValueEntryFromFile fails when named value doesn't exist


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/215/head:pull/215` \
`$ git checkout pull/215`

Update a local copy of the PR: \
`$ git checkout pull/215` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/215/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 215`

View PR using the GUI difftool: \
`$ git pr show -t 215`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/215.diff">https://git.openjdk.org/jdk8u-dev/pull/215.diff</a>

</details>
