### PR TITLE
8289695: [TESTBUG] TestMemoryAwareness.java fails on cgroups v2 and crun

### DIFF
--- a/hotspot/test/runtime/containers/docker/TestMemoryAwareness.java
+++ b/hotspot/test/runtime/containers/docker/TestMemoryAwareness.java
@@ -133,9 +133,8 @@ public class TestMemoryAwareness {
     private static void testOOM(String dockerMemLimit, int sizeToAllocInMb) throws Exception {
         Common.logNewTestCase("OOM");
 
-        // add "--memory-swappiness 0" so as to disable anonymous page swapping.
         DockerRunOptions opts = Common.newOpts(imageName, "AttemptOOM")
-            .addDockerOpts("--memory", dockerMemLimit, "--memory-swappiness", "0", "--memory-swap", dockerMemLimit);
+            .addDockerOpts("--memory", dockerMemLimit, "--memory-swap", dockerMemLimit);
         opts.classParams.add("" + sizeToAllocInMb);
 
         // make sure we avoid inherited Xmx settings from the jtreg vmoptions


### PR DESCRIPTION
Clean backport. Fixes a test issue on cg v2 where `--memory-swappiness` is not supported.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289695](https://bugs.openjdk.org/browse/JDK-8289695): [TESTBUG] TestMemoryAwareness.java fails on cgroups v2 and crun


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/217/head:pull/217` \
`$ git checkout pull/217`

Update a local copy of the PR: \
`$ git checkout pull/217` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/217/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 217`

View PR using the GUI difftool: \
`$ git pr show -t 217`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/217.diff">https://git.openjdk.org/jdk8u-dev/pull/217.diff</a>

</details>
