### PR TITLE
8292541: [Metrics] Reported memory limit may exceed physical machine memory

### DIFF
--- a/hotspot/test/runtime/containers/docker/TestMemoryAwareness.java
+++ b/hotspot/test/runtime/containers/docker/TestMemoryAwareness.java
@@ -42,6 +42,13 @@ import com.oracle.java.testlibrary.Asserts;
 public class TestMemoryAwareness {
     private static final String imageName = Common.imageName("memory");
 
+    private static String getHostMaxMemory() throws Exception {
+        DockerRunOptions opts = Common.newOpts(imageName);
+        String goodMem = Common.run(opts).firstMatch("total physical memory: (\\d+)", 1);
+        assertNotNull(goodMem, "no match for 'total physical memory' in trace output");
+        return goodMem;
+    }
+
     public static void main(String[] args) throws Exception {
         if (!DockerTestUtils.canTestDocker()) {
             return;
@@ -74,7 +81,10 @@ public class TestMemoryAwareness {
                 "1G", Integer.toString(((int) Math.pow(2, 20)) * 1024),
                 "1500M", Integer.toString(((int) Math.pow(2, 20)) * (1500 - 1024))
             );
-            testContainerMemExceedsPhysical();
+            final String hostMaxMem = getHostMaxMemory();
+            testOperatingSystemMXBeanIgnoresMemLimitExceedingPhysicalMemory(hostMaxMem);
+            testMetricsIgnoresMemLimitExceedingPhysicalMemory(hostMaxMem);
+            testContainerMemExceedsPhysical(hostMaxMem);
         } finally {
             DockerTestUtils.removeDockerImage(imageName);
         }
@@ -95,24 +105,16 @@ public class TestMemoryAwareness {
 
     // JDK-8292083
     // Ensure that Java ignores container memory limit values above the host's physical memory.
-    private static void testContainerMemExceedsPhysical()
+    private static void testContainerMemExceedsPhysical(final String hostMaxMem)
             throws Exception {
-
         Common.logNewTestCase("container memory limit exceeds physical memory");
-
-        DockerRunOptions opts = Common.newOpts(imageName);
-
-        // first run: establish physical memory in test environment and derive
-        // a bad value one power of ten larger
-        String goodMem = Common.run(opts).firstMatch("total physical memory: (\\d+)", 1);
-        Asserts.assertNotNull(goodMem, "no match for 'total physical memory' in trace output");
-        String badMem = goodMem + "0";
-
-        // second run: set a container memory limit to the bad value
-        opts = Common.newOpts(imageName)
+        String badMem = hostMaxMem + "0";
+        // set a container memory limit to the bad value
+        DockerRunOptions opts = Common.newOpts(imageName)
             .addDockerOpts("--memory", badMem);
+
         Common.run(opts)
-            .shouldMatch("container memory limit (ignored: " + badMem + "|unlimited: -1), using host value " + goodMem);
+            .shouldMatch("container memory limit (ignored: " + badMem + "|unlimited: -1), using host value " + hostMaxMem);
     }
 
 
@@ -187,4 +189,23 @@ public class TestMemoryAwareness {
         }
     }
 
+
+    // JDK-8292541: Ensure OperatingSystemMXBean ignores container memory limits above the host's physical memory.
+    private static void testOperatingSystemMXBeanIgnoresMemLimitExceedingPhysicalMemory(final String hostMaxMem)
+            throws Exception {
+        String badMem = hostMaxMem + "0";
+        testOperatingSystemMXBeanAwareness(badMem, hostMaxMem, badMem, hostMaxMem);
+    }
+
+    // JDK-8292541: Ensure Metrics ignores container memory limits above the host's physical memory.
+    private static void testMetricsIgnoresMemLimitExceedingPhysicalMemory(final String hostMaxMem)
+            throws Exception {
+        Common.logNewTestCase("Metrics ignore container memory limit exceeding physical memory");
+        String badMem = hostMaxMem + "0";
+        DockerRunOptions opts = Common.newOpts(imageName)
+            .addJavaOpts("-XshowSettings:system")
+            .addDockerOpts("--memory", badMem);
+
+        DockerTestUtils.dockerRunJava(opts).shouldMatch("Memory Limit: Unlimited");
+    }
 }

--- a/hotspot/test/runtime/containers/docker/TestMemoryAwareness.java
+++ b/hotspot/test/runtime/containers/docker/TestMemoryAwareness.java
@@ -45,7 +45,7 @@ public class TestMemoryAwareness {
     private static String getHostMaxMemory() throws Exception {
         DockerRunOptions opts = Common.newOpts(imageName);
         String goodMem = Common.run(opts).firstMatch("total physical memory: (\\d+)", 1);
-        assertNotNull(goodMem, "no match for 'total physical memory' in trace output");
+        Asserts.assertNotNull(goodMem, "no match for 'total physical memory' in trace output");
         return goodMem;
     }
 

--- a/jdk/make/mapfiles/libjava/mapfile-linux
+++ b/jdk/make/mapfiles/libjava/mapfile-linux
@@ -279,6 +279,7 @@ SUNWprivate_1.1 {
 		Java_sun_misc_VMSupport_initAgentProperties;
 		Java_sun_misc_VMSupport_getVMTemporaryDirectory;
 		Java_jdk_internal_platform_CgroupMetrics_isUseContainerSupport;
+		Java_jdk_internal_platform_CgroupMetrics_getTotalMemorySize0;
 
                 # ZipFile.c needs this one
 		throwFileNotFoundException;

--- a/jdk/src/linux/classes/jdk/internal/platform/CgroupMetrics.java
+++ b/jdk/src/linux/classes/jdk/internal/platform/CgroupMetrics.java
@@ -121,7 +121,13 @@ public class CgroupMetrics implements Metrics {
 
     @Override
     public long getMemoryLimit() {
-        return subsystem.getMemoryLimit();
+        long subsMem = subsystem.getMemoryLimit();
+        // Catch the cgroup memory limit exceeding host physical memory.
+        // Treat this as unlimited.
+        if (subsMem >= getTotalMemorySize0()) {
+            return CgroupSubsystem.LONG_RETVAL_UNLIMITED;
+        }
+        return subsMem;
     }
 
     @Override
@@ -168,5 +174,6 @@ public class CgroupMetrics implements Metrics {
     }
 
     private static native boolean isUseContainerSupport();
+    private static native long getTotalMemorySize0();
 
 }

--- a/jdk/src/linux/native/jdk/internal/platform/cgroupv1/CgroupMetrics.c
+++ b/jdk/src/linux/native/jdk/internal/platform/cgroupv1/CgroupMetrics.c
@@ -22,6 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+#include <unistd.h>
 
 #include "jni.h"
 #include "jvm.h"
@@ -32,4 +33,11 @@ JNIEXPORT jboolean JNICALL
 Java_jdk_internal_platform_CgroupMetrics_isUseContainerSupport(JNIEnv *env, jclass ignored)
 {
     return JVM_IsUseContainerSupport();
+}
+
+JNIEXPORT jlong JNICALL
+Java_jdk_internal_platform_CgroupMetrics_getTotalMemorySize0
+  (JNIEnv *env, jclass ignored)
+{
+    return sysconf(_SC_PHYS_PAGES) * sysconf(_SC_PAGESIZE);
 }

--- a/jdk/src/linux/native/jdk/internal/platform/cgroupv1/CgroupMetrics.c
+++ b/jdk/src/linux/native/jdk/internal/platform/cgroupv1/CgroupMetrics.c
@@ -39,5 +39,7 @@ JNIEXPORT jlong JNICALL
 Java_jdk_internal_platform_CgroupMetrics_getTotalMemorySize0
   (JNIEnv *env, jclass ignored)
 {
-    return sysconf(_SC_PHYS_PAGES) * sysconf(_SC_PAGESIZE);
+    jlong pages = sysconf(_SC_PHYS_PAGES);
+    jlong page_size = sysconf(_SC_PAGESIZE);
+    return pages * page_size;
 }


### PR DESCRIPTION
This is a backport of JDK-8292541 to jdk8u-dev as part of cgroups v2 support.

It's not clean: two separate fix ups were needed for 8u which are broken out in separate commits: add the new JNI method name to a mapfile; fully qualify the use of a method name in the test.

the edited test passes for me.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8292541](https://bugs.openjdk.org/browse/JDK-8292541): [Metrics] Reported memory limit may exceed physical machine memory
 * [JDK-8300119](https://bugs.openjdk.org/browse/JDK-8300119): CgroupMetrics.getTotalMemorySize0() can report invalid results on 32 bit systems


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/220/head:pull/220` \
`$ git checkout pull/220`

Update a local copy of the PR: \
`$ git checkout pull/220` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/220/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 220`

View PR using the GUI difftool: \
`$ git pr show -t 220`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/220.diff">https://git.openjdk.org/jdk8u-dev/pull/220.diff</a>

</details>
