### PR TITLE
8299548: Fix hotspot/test/runtime/Metaspace/MaxMetaspaceSizeTest.java in 8u

### DIFF
--- a/hotspot/test/runtime/Metaspace/MaxMetaspaceSizeTest.java
+++ b/hotspot/test/runtime/Metaspace/MaxMetaspaceSizeTest.java
@@ -23,10 +23,10 @@
 
 import com.oracle.java.testlibrary.ProcessTools;
 import com.oracle.java.testlibrary.OutputAnalyzer;
+import com.oracle.java.testlibrary.Platform;
 
 /*
  * @test MaxMetaspaceSizeTest
- * @requires vm.bits == "64"
  * @bug 8087291
  * @library /testlibrary
  * @run main/othervm MaxMetaspaceSizeTest
@@ -34,6 +34,10 @@ import com.oracle.java.testlibrary.OutputAnalyzer;
 
 public class MaxMetaspaceSizeTest {
     public static void main(String... args) throws Exception {
+        if (!Platform.is64bit()) {
+            System.out.println("Test requires 64-bit JVM. Skipping...");
+            return;
+        }
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
             "-Xmx1g",
             "-XX:InitialBootClassLoaderMetaspaceSize=4195328",


### PR DESCRIPTION
It was discovered [1] that following test is always skipped in 8u:
`hotspot/test/runtime/Metaspace/MaxMetaspaceSizeTest.java`

Test comes from JDK-8087291 [2] backport. Test is for 64-bit JDK only and uses following jtreg tag to test that:
`@requires vm.bits == "64"`

However `vm.bits` is not supported on 8u, where condition evaluates as always false, which results in test being skipped on all systems.

Fix:
Fixed by doing explicit check in test instead of using jtreg tag.

Testing:
Tested using github actions as test is part of hotspot/tier1.

[1] https://github.com/openjdk/jdk8u-dev/pull/182#discussion_r1024395333
[2] https://bugs.openjdk.org/browse/JDK-8087291