### PR TITLE
8283606: Tests may fail with zh locale on MacOS

### DIFF
--- a/hotspot/test/runtime/classFileParserBug/TestEmptyBootstrapMethodsAttr.java
+++ b/hotspot/test/runtime/classFileParserBug/TestEmptyBootstrapMethodsAttr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,7 +52,8 @@ public class TestEmptyBootstrapMethodsAttr {
         // ======= execute test case #1
         // Expect a lack of main method, this implies that the class loaded correctly
         // with an empty bootstrap_methods and did not generate a ClassFormatError.
-        pb = ProcessTools.createJavaProcessBuilder("-cp", ".", className);
+        pb = ProcessTools.createJavaProcessBuilder("-cp", ".",
+                "-Duser.language=en", "-Duser.country=US", className);
         output = new OutputAnalyzer(pb.start());
         output.shouldNotContain("java.lang.ClassFormatError");
         output.shouldContain("Main method not found in class " + className);
@@ -66,7 +67,8 @@ public class TestEmptyBootstrapMethodsAttr {
         // ======= execute test case #2
         // Expect a lack of main method, this implies that the class loaded correctly
         // with an empty bootstrap_methods and did not generate ClassFormatError.
-        pb = ProcessTools.createJavaProcessBuilder("-cp", ".", className);
+        pb = ProcessTools.createJavaProcessBuilder("-cp", ".",
+                "-Duser.language=en", "-Duser.country=US", className);
         output = new OutputAnalyzer(pb.start());
         output.shouldNotContain("java.lang.ClassFormatError");
         output.shouldContain("Main method not found in class " + className);

--- a/langtools/test/tools/javadoc/6964914/TestStdDoclet.java
+++ b/langtools/test/tools/javadoc/6964914/TestStdDoclet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,6 +56,8 @@ public class TestStdDoclet {
         String thisClassName = TestStdDoclet.class.getName();
         Process p = new ProcessBuilder()
             .command(javadoc.getPath(),
+                "-J-Duser.language=en",
+                "-J-Duser.country=US",
                 "-J-Xbootclasspath:" + System.getProperty("sun.boot.class.path"),
                 "-Xdoclint:none",
                 "-package",

--- a/langtools/test/tools/javadoc/6964914/TestUserDoclet.java
+++ b/langtools/test/tools/javadoc/6964914/TestUserDoclet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,6 +58,8 @@ public class TestUserDoclet extends Doclet {
         String thisClassName = TestUserDoclet.class.getName();
         Process p = new ProcessBuilder()
             .command(javadoc.getPath(),
+                "-J-Duser.language=en",
+                "-J-Duser.country=US",
                 "-J-Xbootclasspath:" + System.getProperty("sun.boot.class.path"),
                 "-doclet", thisClassName,
                 "-docletpath", testClasses.getPath(),

--- a/langtools/test/tools/javah/T6893943.java
+++ b/langtools/test/tools/javah/T6893943.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,6 +63,8 @@ public class T6893943 {
 
         List<String> command = new ArrayList<String>();
         command.add(new File(new File(javaHome, "bin"), "javah").getPath());
+        command.add("-J-Duser.language=en");
+        command.add("-J-Duser.country=US");
         command.add("-J-Xbootclasspath:" + System.getProperty("sun.boot.class.path"));
         command.addAll(Arrays.asList(args));
         //System.err.println("command: " + command);


### PR DESCRIPTION
I would like to backport JDK-8283606 to JDK8u. This fix cannot be applied cleanly.
- jdk8u contains only 1 test fixed in JDK-8283606
  (hotspot/test/runtime/classFileParserBug/TestEmptyBootstrapMethodsAttr.java)
- jdk8u contains 2 tests fixed in JDK-8299383 (backported to jdk11u)
  (langtools/test/tools/javadoc/6964914/TestStdDoclet.java, and
   langtools/test/tools/javadoc/6964914/TestUserDoclet.java)
- Need to add more tests that are removed in latest version and have same problem.
  (langtools/test/tools/javah/T6893943.java)

I tried to run these tests on Japanese Windows 10, and all tests are passed.

But, I am not a author, so need a sponsor.
Would you plese review this fix?

Thank you.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8283606](https://bugs.openjdk.org/browse/JDK-8283606): Tests may fail with zh locale on MacOS


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/223/head:pull/223` \
`$ git checkout pull/223`

Update a local copy of the PR: \
`$ git checkout pull/223` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/223/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 223`

View PR using the GUI difftool: \
`$ git pr show -t 223`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/223.diff">https://git.openjdk.org/jdk8u-dev/pull/223.diff</a>

</details>
