### PR TITLE
8289549: ISO 4217 Amendment 172 Update

### DIFF
--- a/jdk/src/share/classes/java/util/CurrencyData.properties
+++ b/jdk/src/share/classes/java/util/CurrencyData.properties
@@ -31,7 +31,7 @@ formatVersion=2
 # Version of the currency code information in this class.
 # It is a serial number that accompanies with each amendment.
 
-dataVersion=171
+dataVersion=172
 
 # List of all valid ISO 4217 currency codes.
 # To ensure compatibility, do not remove codes.

--- a/jdk/test/java/util/Currency/tablea1.txt
+++ b/jdk/test/java/util/Currency/tablea1.txt
@@ -1,12 +1,12 @@
 #
 #
-# Amendments up until ISO 4217 AMENDMENT NUMBER 171
-#   (As of 16 Mar 2022)
+# Amendments up until ISO 4217 AMENDMENT NUMBER 172
+#   (As of 27 June 2022)
 #
 
 # Version
 FILEVERSION=2
-DATAVERSION=171
+DATAVERSION=172
 
 # ISO 4217 currency data
 AF	AFN	971	2


### PR DESCRIPTION
Mostly clean backport of the next ISO 4217 update. Manual resolution was required on `tablea1.txt` as 8u is still using the older `FILEVERSION` at present.

No data changes due to the last update already having the Sierra Leone changes, so this one is just a `dataversion` bump.

Tests in `jdk/test/java/util/Currency` all pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289549](https://bugs.openjdk.org/browse/JDK-8289549): ISO 4217 Amendment 172 Update


### Reviewers
 * [Dmitry Cherepanov](https://openjdk.org/census#dcherepanov) (@dimitryc - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/224/head:pull/224` \
`$ git checkout pull/224`

Update a local copy of the PR: \
`$ git checkout pull/224` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/224/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 224`

View PR using the GUI difftool: \
`$ git pr show -t 224`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/224.diff">https://git.openjdk.org/jdk8u-dev/pull/224.diff</a>

</details>
