### PR TITLE
8294307: ISO 4217 Amendment 173 Update

### DIFF
--- a/jdk/src/share/classes/java/util/CurrencyData.properties
+++ b/jdk/src/share/classes/java/util/CurrencyData.properties
@@ -31,7 +31,7 @@ formatVersion=2
 # Version of the currency code information in this class.
 # It is a serial number that accompanies with each amendment.
 
-dataVersion=172
+dataVersion=173
 
 # List of all valid ISO 4217 currency codes.
 # To ensure compatibility, do not remove codes.

--- a/jdk/test/java/util/Currency/tablea1.txt
+++ b/jdk/test/java/util/Currency/tablea1.txt
@@ -1,12 +1,12 @@
 #
 #
-# Amendments up until ISO 4217 AMENDMENT NUMBER 172
-#   (As of 27 June 2022)
+# Amendments up until ISO 4217 AMENDMENT NUMBER 173
+#   (As of 23 September 2022)
 #
 
 # Version
 FILEVERSION=2
-DATAVERSION=172
+DATAVERSION=173
 
 # ISO 4217 currency data
 AF	AFN	971	2


### PR DESCRIPTION
Mostly clean backport of the next ISO 4217 update. Manual resolution was required on `tablea1.txt` as 8u is still using the older `FILEVERSION` at present.

No data changes due to the 171 update already having the Sierra Leone changes, so this one is just another `dataversion` bump.

Tests in `jdk/test/java/util/Currency` all pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294307](https://bugs.openjdk.org/browse/JDK-8294307): ISO 4217 Amendment 173 Update


### Reviewers
 * [Dmitry Cherepanov](https://openjdk.org/census#dcherepanov) (@dimitryc - **Reviewer**) ⚠️ Review applies to [12e5b182](https://git.openjdk.org/jdk8u-dev/pull/225/files/12e5b1828ee8ac3c0046df9cec2e611cfb1bd45c)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/225/head:pull/225` \
`$ git checkout pull/225`

Update a local copy of the PR: \
`$ git checkout pull/225` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/225/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 225`

View PR using the GUI difftool: \
`$ git pr show -t 225`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/225.diff">https://git.openjdk.org/jdk8u-dev/pull/225.diff</a>

</details>
