### PR TITLE
8299804: Fix non-portable code in hotspot shell tests in 8u 

### DIFF
--- a/hotspot/test/compiler/criticalnatives/argumentcorruption/Test8167409.sh
+++ b/hotspot/test/compiler/criticalnatives/argumentcorruption/Test8167409.sh
@@ -44,14 +44,14 @@ echo "Testing on " $OS
 case "$OS" in
   Linux)
     cc_cmd=`which gcc`
-    if [ "x$cc_cmd" == "x" ]; then
+    if [ "x$cc_cmd" = "x" ]; then
         echo "WARNING: gcc not found. Cannot execute test." 2>&1
         exit 0;
     fi
     ;;
   Solaris)
     cc_cmd=`which cc`
-    if [ "x$cc_cmd" == "x" ]; then
+    if [ "x$cc_cmd" = "x" ]; then
         echo "WARNING: cc not found. Cannot execute test." 2>&1
         exit 0;
     fi
@@ -63,7 +63,7 @@ case "$OS" in
 esac
 
 # CriticalJNINatives is not supported for aarch64
-if [ $VM_CPU == "aarch64" ]; then
+if [ $VM_CPU = "aarch64" ]; then
     echo "Test Passed"
     exit 0;
 fi

--- a/hotspot/test/compiler/floatingpoint/8165673/TestFloatJNIArgs.sh
+++ b/hotspot/test/compiler/floatingpoint/8165673/TestFloatJNIArgs.sh
@@ -41,10 +41,10 @@ echo "TESTSRC=${TESTSRC}"
 . ${TESTSRC}/../../../test_env.sh
 
 # set platform-dependent variables
-if [ $VM_OS == "linux" -a $VM_CPU == "aarch64" ]; then
+if [ $VM_OS = "linux" -a $VM_CPU = "aarch64" ]; then
     echo "Testing on linux-aarch64"
     gcc_cmd=`which gcc`
-    if [ "x$gcc_cmd" == "x" ]; then
+    if [ "x$gcc_cmd" = "x" ]; then
         echo "WARNING: gcc not found. Cannot execute test." 2>&1
         exit 0;
     fi

--- a/hotspot/test/compiler/floatingpoint/8207838/TestFloatSyncJNIArgs.sh
+++ b/hotspot/test/compiler/floatingpoint/8207838/TestFloatSyncJNIArgs.sh
@@ -41,10 +41,10 @@ echo "TESTSRC=${TESTSRC}"
 . ${TESTSRC}/../../../test_env.sh
 
 # set platform-dependent variables
-if [ $VM_OS == "linux" -a $VM_CPU == "aarch64" ]; then
+if [ $VM_OS = "linux" -a $VM_CPU = "aarch64" ]; then
     echo "Testing on linux-aarch64"
     gcc_cmd=`which gcc`
-    if [ "x$gcc_cmd" == "x" ]; then
+    if [ "x$gcc_cmd" = "x" ]; then
         echo "WARNING: gcc not found. Cannot execute test." 2>&1
         exit 0;
     fi

--- a/hotspot/test/runtime/7107135/Test7107135.sh
+++ b/hotspot/test/runtime/7107135/Test7107135.sh
@@ -47,7 +47,7 @@ case "$OS" in
   Linux)
     echo "Testing on Linux"
     gcc_cmd=`which gcc`
-    if [ "x$gcc_cmd" == "x" ]; then
+    if [ "x$gcc_cmd" = "x" ]; then
         echo "WARNING: gcc not found. Cannot execute test." 2>&1
         exit 0;
     fi
@@ -88,7 +88,7 @@ echo ${TESTJAVA}${FS}bin${FS}java -cp ${THIS_DIR} Test test-rwx
 ${TESTJAVA}${FS}bin${FS}java -cp ${THIS_DIR} Test test-rwx
 JAVA_RETVAL=$?
 
-if [ "$JAVA_RETVAL" == "0" ]
+if [ "$JAVA_RETVAL" = "0" ]
 then
   echo
   echo ${TESTJAVA}${FS}bin${FS}java -cp ${THIS_DIR} TestMT test-rwx

--- a/hotspot/test/runtime/jni/CallWithJNIWeak/test.sh
+++ b/hotspot/test/runtime/jni/CallWithJNIWeak/test.sh
@@ -45,14 +45,14 @@ echo "Testing on " $OS
 case "$OS" in
   Linux)
     cc_cmd=`which gcc`
-    if [ "x$cc_cmd" == "x" ]; then
+    if [ "x$cc_cmd" = "x" ]; then
         echo "WARNING: gcc not found. Cannot execute test." 2>&1
         exit 0;
     fi
     ;;
   Solaris)
     cc_cmd=`which cc`
-    if [ "x$cc_cmd" == "x" ]; then
+    if [ "x$cc_cmd" = "x" ]; then
         echo "WARNING: cc not found. Cannot execute test." 2>&1
         exit 0;
     fi
@@ -81,7 +81,7 @@ echo ${TESTJAVA}${FS}bin${FS}java -cp ${THIS_DIR} -Xint CallWithJNIWeak
 ${TESTJAVA}${FS}bin${FS}java -cp ${THIS_DIR} -Xint CallWithJNIWeak
 JAVA_RETVAL=$?
 
-if [ "$JAVA_RETVAL" == "0" ]
+if [ "$JAVA_RETVAL" = "0" ]
 then
   echo
   echo ${TESTJAVA}${FS}bin${FS}java -cp ${THIS_DIR} -Xcomp CallWithJNIWeak

--- a/hotspot/test/runtime/jni/ReturnJNIWeak/test.sh
+++ b/hotspot/test/runtime/jni/ReturnJNIWeak/test.sh
@@ -45,14 +45,14 @@ echo "Testing on " $OS
 case "$OS" in
   Linux)
     cc_cmd=`which gcc`
-    if [ "x$cc_cmd" == "x" ]; then
+    if [ "x$cc_cmd" = "x" ]; then
         echo "WARNING: gcc not found. Cannot execute test." 2>&1
         exit 0;
     fi
     ;;
   Solaris)
     cc_cmd=`which cc`
-    if [ "x$cc_cmd" == "x" ]; then
+    if [ "x$cc_cmd" = "x" ]; then
         echo "WARNING: cc not found. Cannot execute test." 2>&1
         exit 0;
     fi
@@ -81,7 +81,7 @@ echo ${TESTJAVA}${FS}bin${FS}java -cp ${THIS_DIR} -Xint ReturnJNIWeak
 ${TESTJAVA}${FS}bin${FS}java -cp ${THIS_DIR} -Xint ReturnJNIWeak
 JAVA_RETVAL=$?
 
-if [ "$JAVA_RETVAL" == "0" ]
+if [ "$JAVA_RETVAL" = "0" ]
 then
   echo
   echo ${TESTJAVA}${FS}bin${FS}java -cp ${THIS_DIR} -Xcomp ReturnJNIWeak


### PR DESCRIPTION
Some hotspot shell tests use `==` for comparison inside of `[ ]`. However this is bash extension and it is not portable (posix test command only knows single `=`, see: [1]).

This results in errors on systems where default shell is not bash, such as Ubuntu used in GHA (which defaults to "Dash" shell). E.g.:
`Test7107135.sh: 50: [: x/bin/gcc: unexpected operator`
Expressions are then treated as always false.

Problem is only present on 8u as newer jdks use different approach for shell/jni tests and no longer have these shell tests.

Testing:
Tests passed in GHA, logs no longer contain these errors. (Affected tests passed even before, as problematic comparisons happen to have such form and placement, that they did not cause test failures, but logs contained error messages.)

[1] https://pubs.opengroup.org/onlinepubs/9699919799/utilities/test.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299804](https://bugs.openjdk.org/browse/JDK-8299804): Fix non-portable code in hotspot shell tests in 8u


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/227/head:pull/227` \
`$ git checkout pull/227`

Update a local copy of the PR: \
`$ git checkout pull/227` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/227/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 227`

View PR using the GUI difftool: \
`$ git pr show -t 227`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/227.diff">https://git.openjdk.org/jdk8u-dev/pull/227.diff</a>

</details>
