### PR TITLE
8301143: [TESTBUG] jfr/event/sampling/TestNative was backported to JDK8u without proper native wrapper

### DIFF
--- a/jdk/test/jdk/jfr/event/sampling/TestNative.java
+++ b/jdk/test/jdk/jfr/event/sampling/TestNative.java
@@ -43,7 +43,7 @@ import jdk.test.lib.process.ProcessTools;
  *
  * @library /lib /
  *
- * @run main/native jdk.jfr.event.sampling.TestNative
+ * @run shell TestNative.sh
  */
 public class TestNative {
 

--- a/jdk/test/jdk/jfr/event/sampling/TestNative.sh
+++ b/jdk/test/jdk/jfr/event/sampling/TestNative.sh
@@ -29,9 +29,16 @@ fi
 JDK_TOPDIR="${TESTROOT}/.."
 JAVAC="${TESTJAVA}/bin/javac"
 JAVA="${TESTJAVA}/bin/java"
+TEST_ENV_SH="${JDK_TOPDIR}/../hotspot/test/test_env.sh"
+
+ls -l "${TEST_ENV_SH}"
+set +e
+  source "${TEST_ENV_SH}"
+set -e
 
 "${TESTGCC}" \
     -shared \
+    ${CFLAGBITS} \
     -o ${TESTCLASSES}/libTestNative.so \
     -I${JDK_TOPDIR}/src/share/bin \
     -I${JDK_TOPDIR}/src/share/javavm/export \

--- a/jdk/test/jdk/jfr/event/sampling/TestNative.sh
+++ b/jdk/test/jdk/jfr/event/sampling/TestNative.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -exo pipefail
+set -ex
 
 OS=`uname -s`
 if [  "${OS}" != "Linux" -a "${OS}" != "Darwin" ]; then

--- a/jdk/test/jdk/jfr/event/sampling/TestNative.sh
+++ b/jdk/test/jdk/jfr/event/sampling/TestNative.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -exo pipefail
+
+OS=`uname -s`
+if [  "${OS}" != "Linux" -a "${OS}" != "Darwin" ]; then
+    echo "This is a Linux/MacOSX only test"
+    exit 0;
+fi
+
+if [ "x$TESTGCC" == "x" ]; then
+  TESTGCC=$(readlink -f $(which gcc))
+fi
+
+if [ "x$TESTGCC" == "x" ]; then
+  echo "WARNING: gcc not found. Cannot execute test." 2>&1
+  exit 1;
+fi
+
+if [ "x$TESTROOT" == "x" ]; then
+  echo "TESTROOT pointintg to top level sources is not set. that is fatal"
+  exit 2;
+fi
+
+if [ "x$TESTJAVA" == "x" ]; then
+  TESTJAVA=$(dirname $(dirname $(readlink -f $(which java))))
+fi
+
+JDK_TOPDIR="${TESTROOT}/.."
+JAVAC="${TESTJAVA}/bin/javac"
+JAVA="${TESTJAVA}/bin/java"
+
+"${TESTGCC}" \
+    -shared \
+    -o ${TESTCLASSES}/libTestNative.so \
+    -I${JDK_TOPDIR}/src/share/bin \
+    -I${JDK_TOPDIR}/src/share/javavm/export \
+    -I${JDK_TOPDIR}/src/macosx/javavm/export \
+    -I${JDK_TOPDIR}/src/solaris/bin \
+    ${TESTSRC}/libTestNative.c
+
+"${JAVAC}" -d ${TESTCLASSES} \
+           ${TESTROOT}/lib/jdk/test/lib/Utils.java \
+           ${TESTROOT}/lib/jdk/test/lib/JDKToolLauncher.java \
+           ${TESTROOT}/lib/jdk/test/lib/Platform.java \
+           ${TESTROOT}/lib/jdk/test/lib/Asserts.java \
+           ${TESTROOT}/lib/jdk/test/lib/jfr/EventNames.java \
+           ${TESTROOT}/lib/jdk/test/lib/JDKToolFinder.java \
+           ${TESTROOT}/lib/jdk/test/lib/process/*.java
+
+"${JAVAC}" -cp ${TESTCLASSPATH}:${TESTCLASSES} -d ${TESTCLASSES} ${TESTSRC}/TestNative.java
+
+"${JAVA}"  -Dtest.jdk=${TESTJAVA} \
+           -Dtest.nativepath=${TESTCLASSES} \
+           -Djava.library.path=${TESTCLASSES} \
+           -cp ${TESTCLASSPATH}:${TESTCLASSES} jdk.jfr.event.sampling.TestNative

--- a/jdk/test/jdk/jfr/event/sampling/TestNative.sh
+++ b/jdk/test/jdk/jfr/event/sampling/TestNative.sh
@@ -3,26 +3,26 @@
 set -ex
 
 OS=`uname -s`
-if test  "${OS}" != "Linux" -a "${OS}" != "Darwin" ; then
+if [  "${OS}" != "Linux" -a "${OS}" != "Darwin" ]; then
     echo "This is a Linux/MacOSX only test"
     exit 0;
 fi
 
-if test "x$TESTGCC" == "x" ; then
+if [ "x$TESTGCC" == "x" ]; then
   TESTGCC=$(readlink -f $(which gcc))
 fi
 
-if test "x$TESTGCC" == "x" ; then
+if [ "x$TESTGCC" == "x" ]; then
   echo "WARNING: gcc not found. Cannot execute test." 2>&1
   exit 1;
 fi
 
-if test "x$TESTROOT" == "x" ; then
+if [ "x$TESTROOT" == "x" ]; then
   echo "TESTROOT pointintg to top level sources is not set. that is fatal"
   exit 2;
 fi
 
-if test "x$TESTJAVA" == "x" ; then
+if [ "x$TESTJAVA" == "x" ]; then
   TESTJAVA=$(dirname $(dirname $(readlink -f $(which java))))
 fi
 

--- a/jdk/test/jdk/jfr/event/sampling/TestNative.sh
+++ b/jdk/test/jdk/jfr/event/sampling/TestNative.sh
@@ -8,21 +8,21 @@ if [  "${OS}" != "Linux" -a "${OS}" != "Darwin" ]; then
     exit 0;
 fi
 
-if [ "x$TESTGCC" == "x" ]; then
+if [ "x$TESTGCC" = "x" ]; then
   TESTGCC=$(readlink -f $(which gcc))
 fi
 
-if [ "x$TESTGCC" == "x" ]; then
+if [ "x$TESTGCC" = "x" ]; then
   echo "WARNING: gcc not found. Cannot execute test." 2>&1
   exit 1;
 fi
 
-if [ "x$TESTROOT" == "x" ]; then
+if [ "x$TESTROOT" = "x" ]; then
   echo "TESTROOT pointintg to top level sources is not set. that is fatal"
   exit 2;
 fi
 
-if [ "x$TESTJAVA" == "x" ]; then
+if [ "x$TESTJAVA" = "x" ]; then
   TESTJAVA=$(dirname $(dirname $(readlink -f $(which java))))
 fi
 

--- a/jdk/test/jdk/jfr/event/sampling/TestNative.sh
+++ b/jdk/test/jdk/jfr/event/sampling/TestNative.sh
@@ -3,26 +3,26 @@
 set -ex
 
 OS=`uname -s`
-if [  "${OS}" != "Linux" -a "${OS}" != "Darwin" ]; then
+if test  "${OS}" != "Linux" -a "${OS}" != "Darwin" ; then
     echo "This is a Linux/MacOSX only test"
     exit 0;
 fi
 
-if [ "x$TESTGCC" == "x" ]; then
+if test "x$TESTGCC" == "x" ; then
   TESTGCC=$(readlink -f $(which gcc))
 fi
 
-if [ "x$TESTGCC" == "x" ]; then
+if test "x$TESTGCC" == "x" ; then
   echo "WARNING: gcc not found. Cannot execute test." 2>&1
   exit 1;
 fi
 
-if [ "x$TESTROOT" == "x" ]; then
+if test "x$TESTROOT" == "x" ; then
   echo "TESTROOT pointintg to top level sources is not set. that is fatal"
   exit 2;
 fi
 
-if [ "x$TESTJAVA" == "x" ]; then
+if test "x$TESTJAVA" == "x" ; then
   TESTJAVA=$(dirname $(dirname $(readlink -f $(which java))))
 fi
 


### PR DESCRIPTION
This test was brought in by 8223147: JFR Backport and never passed. Despite not being wrong nor having jfr broken in jdk8. jdk8 testsuite simply lacks native support cases.

This is adding the shell wrapper which is compiling and properly setting up the native longSleep  in native shared object.

This commit was tested only on linux.
After this commit whole jdk_jfr group passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301143](https://bugs.openjdk.org/browse/JDK-8301143): [TESTBUG] jfr/event/sampling/TestNative was backported to JDK8u without proper native wrapper


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/235/head:pull/235` \
`$ git checkout pull/235`

Update a local copy of the PR: \
`$ git checkout pull/235` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/235/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 235`

View PR using the GUI difftool: \
`$ git pr show -t 235`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/235.diff">https://git.openjdk.org/jdk8u-dev/pull/235.diff</a>

</details>
