### PR TITLE
8196467: javax/swing/JInternalFrame/Test6325652.java fails

### DIFF
--- a/jdk/test/javax/swing/JInternalFrame/Test6325652.java
+++ b/jdk/test/javax/swing/JInternalFrame/Test6325652.java
@@ -63,6 +63,7 @@ public class Test6325652 {
 
     public static void stepFirst() throws AWTException {
         robot = new Robot(); // initialize shared static field first time
+        robot.setAutoDelay(50);
         click(KeyEvent.VK_CONTROL, KeyEvent.VK_F9); // iconify internal frame
     }
 


### PR DESCRIPTION
The fix for a test issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8196467](https://bugs.openjdk.org/browse/JDK-8196467): javax/swing/JInternalFrame/Test6325652.java fails


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/238/head:pull/238` \
`$ git checkout pull/238`

Update a local copy of the PR: \
`$ git checkout pull/238` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/238/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 238`

View PR using the GUI difftool: \
`$ git pr show -t 238`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/238.diff">https://git.openjdk.org/jdk8u-dev/pull/238.diff</a>

</details>
