### PR TITLE
8039888: [TEST_BUG] keyboard garbage after javax/swing/plaf/windows/WindowsRootPaneUI/WrongAltProcessing/WrongAltProcessing.java

### DIFF
--- a/jdk/test/javax/swing/plaf/windows/WindowsRootPaneUI/WrongAltProcessing/WrongAltProcessing.java
+++ b/jdk/test/javax/swing/plaf/windows/WindowsRootPaneUI/WrongAltProcessing/WrongAltProcessing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 
 /* @test
-   @bug 8001633 8028271
+   @bug 8001633 8028271 8039888
    @summary Wrong alt processing during switching between windows
    @author mikhail.cherkasov@oracle.com
    @run main WrongAltProcessing
@@ -54,8 +54,8 @@ public class WrongAltProcessing {
                 createWindows();
             }
         });
-        robot.waitForIdle();
         initRobot();
+        robot.waitForIdle();
         runScript();
         SwingUtilities.invokeLater(new Runnable() {
             @Override


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [cd8cd68e](https://github.com/openjdk/jdk/commit/cd8cd68e09370fbf0c3509deaee381417dd12533) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.
The commit being backported was authored by Prasanta Sadhukhan on 28 Feb 2017 and was reviewed by Sergey Bylokhov and Alexander Scherbatiy.
Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8039888](https://bugs.openjdk.org/browse/JDK-8039888): [TEST_BUG] keyboard garbage after javax/swing/plaf/windows/WindowsRootPaneUI/WrongAltProcessing/WrongAltProcessing.java


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/239/head:pull/239` \
`$ git checkout pull/239`

Update a local copy of the PR: \
`$ git checkout pull/239` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/239/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 239`

View PR using the GUI difftool: \
`$ git pr show -t 239`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/239.diff">https://git.openjdk.org/jdk8u-dev/pull/239.diff</a>

</details>
