### PR TITLE
8301122: [8u] Fix unreliable vs2010 download link

### DIFF
--- a/make/conf/test-dependencies
+++ b/make/conf/test-dependencies
@@ -31,7 +31,7 @@ JTREG_BUILD=b01
 
 VS2010_FILENAME=VS2010Express1.iso
 VS2010_DIR=VS2010Express1
-VS2010_URL=https://web.archive.org/web/20140227220734if_/http://download.microsoft.com/download/1/E/5/1E5F1C0A-0D5B-426A-A603-1798B951DDAE/VS2010Express1.iso
+VS2010_URL=https://debian.fmi.uni-sofia.bg/~aangelov/VS2010Express1.iso
 VS2010_SHA256=a9d5dcdf55e539a06547a8ebbc63d55dc167113e09ee9e42096ab9098313039b
 
 VS2017_FILENAME=vs2017.exe


### PR DESCRIPTION
**Problem:**
Link to web.archive.org is currently used to download vs2010, since original download link for vs2010 from Microsoft is dead. Even though it usually works, download from web.archive.org fails from time to time, causing windows x86 build failures in github CI.

**Fix:**
Switch to more reliable download link for vs2010. Use download link used by winetricks project instead. (As they also switched away from web.archive.org link, when they faced the same problem in the past. [1]) Test code already does fingerprint check of downloaded file, so changing download link should be safe.

[1] https://github.com/Winetricks/winetricks/pull/952

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301122](https://bugs.openjdk.org/browse/JDK-8301122): [8u] Fix unreliable vs2010 download link


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/240/head:pull/240` \
`$ git checkout pull/240`

Update a local copy of the PR: \
`$ git checkout pull/240` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/240/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 240`

View PR using the GUI difftool: \
`$ git pr show -t 240`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/240.diff">https://git.openjdk.org/jdk8u-dev/pull/240.diff</a>

</details>
