### PR TITLE
8042098: [TESTBUG] Test sun/java2d/AcceleratedXORModeTest.java fails on Windows

### DIFF
--- a/jdk/test/sun/java2d/AcceleratedXORModeTest.java
+++ b/jdk/test/sun/java2d/AcceleratedXORModeTest.java
@@ -23,7 +23,7 @@
 
 /*
 * @test
-* @bug     8024343
+* @bug     8024343 8042098
 * @summary Test verifies that accelerated pipelines
 *          correctly draws primitives in XOR mode.
 * @run main/othervm -Dsun.java2d.xrender=True AcceleratedXORModeTest
@@ -128,6 +128,7 @@ public class AcceleratedXORModeTest {
 
     void test() {
         createVImg();
+        BufferedImage bi = null;
         do {
             int valCode = vImg.validate(getDefaultGC());
             if (valCode == VolatileImage.IMAGE_INCOMPATIBLE) {
@@ -135,9 +136,11 @@ public class AcceleratedXORModeTest {
             }
             Graphics2D g = vImg.createGraphics();
             draw(g);
-            BufferedImage bi = vImg.getSnapshot();
+            bi = vImg.getSnapshot();
+        } while (vImg.contentsLost());
+        if (bi != null) {
             test(bi);
             write(bi);
-        } while (vImg.contentsLost());
+        }
     }
 }


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [b5769155](https://github.com/openjdk/jdk/commit/b5769155b4bf453d65c43921dbcae4d115f17df7) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.
The commit being backported was authored by Phil Race on 20 Jun 2014 and was reviewed by Jennifer Godinez.
Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8042098](https://bugs.openjdk.org/browse/JDK-8042098): [TESTBUG] Test sun/java2d/AcceleratedXORModeTest.java fails on Windows


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/242/head:pull/242` \
`$ git checkout pull/242`

Update a local copy of the PR: \
`$ git checkout pull/242` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/242/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 242`

View PR using the GUI difftool: \
`$ git pr show -t 242`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/242.diff">https://git.openjdk.org/jdk8u-dev/pull/242.diff</a>

</details>
