### PR TITLE
8275650: Problemlist java/io/File/createTempFile/SpecialTempFile.java for Windows 11

### DIFF
--- a/jdk/test/ProblemList.txt
+++ b/jdk/test/ProblemList.txt
@@ -208,6 +208,9 @@ sun/net/www/http/HttpClient/B8025710.java			generic-all
 # 8169774
 java/io/File/WinSpecialFiles.java                               windows-all
 
+# 8274122
+java/io/File/createTempFile/SpecialTempFile.java                windows11
+
 ############################################################################
 
 # jdk_nio


### PR DESCRIPTION
This is a backport of JDK-8275650: Problemlist java/io/File/createTempFile/SpecialTempFile.java for Windows 11.
The original patch accidentally added "out", but it was removed in JDK-8276623.
This PR backports 8275650 without "out".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8275650](https://bugs.openjdk.org/browse/JDK-8275650): Problemlist java/io/File/createTempFile/SpecialTempFile.java for Windows 11


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/244/head:pull/244` \
`$ git checkout pull/244`

Update a local copy of the PR: \
`$ git checkout pull/244` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/244/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 244`

View PR using the GUI difftool: \
`$ git pr show -t 244`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/244.diff">https://git.openjdk.org/jdk8u-dev/pull/244.diff</a>

</details>
