### PR TITLE
8075964: Test java/awt/Mouse/TitleBarDoubleClick/TitleBarDoubleClick.html fails intermittently with timeout error

### DIFF
--- a/jdk/test/java/awt/Mouse/TitleBarDoubleClick/TitleBarDoubleClick.java
+++ b/jdk/test/java/awt/Mouse/TitleBarDoubleClick/TitleBarDoubleClick.java
@@ -71,7 +71,6 @@ public class TitleBarDoubleClick extends Applet implements MouseListener,
             frame.addMouseListener(this);
             frame.addWindowListener(this);
             frame.setVisible(true);
-            Util.waitForIdle(robot);
     }// start()
 
     // Move the mouse into the title bar and double click to maximize the


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [b0fddb9f](https://github.com/openjdk/jdk/commit/b0fddb9f8045cca10b4e757d8d187af7fb117405) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.
The commit being backported was authored by Manajit Halder on 29 Jan 2016 and was reviewed by Ambarish Rapte and Semyon Sadetsky.
Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8075964](https://bugs.openjdk.org/browse/JDK-8075964): Test java/awt/Mouse/TitleBarDoubleClick/TitleBarDoubleClick.html fails intermittently with timeout error


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/245/head:pull/245` \
`$ git checkout pull/245`

Update a local copy of the PR: \
`$ git checkout pull/245` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/245/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 245`

View PR using the GUI difftool: \
`$ git pr show -t 245`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/245.diff">https://git.openjdk.org/jdk8u-dev/pull/245.diff</a>

</details>
