### PR TITLE
8301246: NPE in FcFontManager.getDefaultPlatformFont() on Linux without installed fontconfig

### DIFF
--- a/jdk/src/solaris/classes/sun/awt/FcFontManager.java
+++ b/jdk/src/solaris/classes/sun/awt/FcFontManager.java
@@ -73,12 +73,14 @@ public class FcFontManager extends SunFontManager {
         getFontConfigManager().initFontConfigFonts(false);
         FontConfigManager.FcCompFont[] fontConfigFonts =
             getFontConfigManager().getFontConfigFonts();
-        for (int i=0; i<fontConfigFonts.length; i++) {
-            if ("sans".equals(fontConfigFonts[i].fcFamily) &&
-                0 == fontConfigFonts[i].style) {
-                info[0] = fontConfigFonts[i].firstFont.familyName;
-                info[1] = fontConfigFonts[i].firstFont.fontFile;
-                break;
+        if (fontConfigFonts != null) {
+            for (int i = 0; i < fontConfigFonts.length; i++) {
+                if ("sans".equals(fontConfigFonts[i].fcFamily) &&
+                        0 == fontConfigFonts[i].style) {
+                    info[0] = fontConfigFonts[i].firstFont.familyName;
+                    info[1] = fontConfigFonts[i].firstFont.fontFile;
+                    break;
+                }
             }
         }
         /* Absolute last ditch attempt in the face of fontconfig problems.
@@ -86,7 +88,7 @@ public class FcFontManager extends SunFontManager {
          * up so we don't NPE.
          */
         if (info[0] == null) {
-            if (fontConfigFonts.length > 0 &&
+            if (fontConfigFonts != null && fontConfigFonts.length > 0 &&
                 fontConfigFonts[0].firstFont.fontFile != null) {
                 info[0] = fontConfigFonts[0].firstFont.familyName;
                 info[1] = fontConfigFonts[0].firstFont.fontFile;


### PR DESCRIPTION
The issues is reproduced only with OpenJDK. Oracle 1.8.0_351 does not throw the NPE.

OpenJDK 8u built from sources with custom fontconfig.properties file throws NPE  
`at sun.awt.FcFontManager.getDefaultPlatformFont(FcFontManager.java:76)` 
on Linux where fontconfig is not installed.

The fix allows to return a default font info from  FcFontManager.getDefaultPlatformFont() method even FontConfigManager.getFontConfigFonts() returns null.

The issue has been already fixed in JDK 11 as part of the fix `8191522: Remove Bigelow&Holmes Lucida fonts from JDK sources` https://github.com/openjdk/jdk/commit/9a9dad8b63e6234829132d5557fbd412d295bb26

This is a backport of only small part of the fix `8191522` related to NPE in FcFontManager.getDefaultPlatformFont() method.

Steps to reproduce:
- Build jdk8u from sources: https://github.com/openjdk/jdk8u-dev/
- Copy custom [fontconfig.properties](https://bugs.openjdk.org/secure/attachment/102432/fontconfig.properties) file to build/linux-x86_64-normal-server-release/images/j2sdk-image/jre/lib directory
- Run docker with ubuntu 20.04, install dejavu fonts, and freetype (do not install fontconfig)
```
docker run -it ubuntu:20.04 bash
apt update
apt install -y fonts-dejavu
apt install -y libfreetype6
```
- Run HelloImage java sample in the docker with the built jdk
```
import javax.imageio.ImageIO;
import java.awt.*;
import java.awt.image.BufferedImage;
import java.io.File;

public class HelloImage {

    public static void main(String[] args) throws Exception {

        BufferedImage buff = new BufferedImage(300, 200, BufferedImage.TYPE_INT_RGB);
        Graphics2D g = buff.createGraphics();
        g.setColor(Color.WHITE);
        g.fillRect(0, 0, buff.getWidth(), buff.getHeight());

        g.setColor(Color.BLUE);
        g.setFont(g.getFont().deriveFont(32f));
        g.drawString("Hello, Image!", 50, 50);
        g.dispose();

        File file = new File("hello-image.png");
        ImageIO.write(buff, "png", file);
    }
}
```

```
build/linux-x86_64-normal-server-release/images/j2sdk-image/bin/javac HelloImage.java
build/linux-x86_64-normal-server-release/images/j2sdk-image/bin/java HelloImage      
Exception in thread "main" java.lang.NullPointerException
	at sun.awt.FcFontManager.getDefaultPlatformFont(FcFontManager.java:76)
	at sun.font.SunFontManager$2.run(SunFontManager.java:443)
	at java.security.AccessController.doPrivileged(Native Method)
	at sun.font.SunFontManager.<init>(SunFontManager.java:386)
	at sun.awt.FcFontManager.<init>(FcFontManager.java:35)
	at sun.awt.X11FontManager.<init>(X11FontManager.java:57)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at java.lang.Class.newInstance(Class.java:442)
	at sun.font.FontManagerFactory$1.run(FontManagerFactory.java:83)
	at java.security.AccessController.doPrivileged(Native Method)
	at sun.font.FontManagerFactory.getInstance(FontManagerFactory.java:74)
	at java.awt.Font.getFont2D(Font.java:491)
	at java.awt.Font.access$000(Font.java:224)
	at java.awt.Font$FontAccessImpl.getFont2D(Font.java:228)
	at sun.font.FontUtilities.getFont2D(FontUtilities.java:200)
	at sun.java2d.SunGraphics2D.checkFontInfo(SunGraphics2D.java:669)
	at sun.java2d.SunGraphics2D.getFontInfo(SunGraphics2D.java:835)
	at sun.java2d.pipe.GlyphListPipe.drawString(GlyphListPipe.java:50)
	at sun.java2d.SunGraphics2D.drawString(SunGraphics2D.java:2933)
	at HelloImage.main(HelloImage.java:17)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301246](https://bugs.openjdk.org/browse/JDK-8301246): NPE in FcFontManager.getDefaultPlatformFont() on Linux without installed fontconfig


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/246/head:pull/246` \
`$ git checkout pull/246`

Update a local copy of the PR: \
`$ git checkout pull/246` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/246/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 246`

View PR using the GUI difftool: \
`$ git pr show -t 246`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/246.diff">https://git.openjdk.org/jdk8u-dev/pull/246.diff</a>

</details>
