### PR TITLE
8233570: [TESTBUG] HTMLEditorKit test bug5043626.java is failing on macos

### DIFF
--- a/jdk/test/javax/swing/text/html/HTMLEditorKit/5043626/bug5043626.java
+++ b/jdk/test/javax/swing/text/html/HTMLEditorKit/5043626/bug5043626.java
@@ -25,9 +25,6 @@
  * @test
  * @bug 5043626
  * @summary  Tests pressing Home or Ctrl+Home set cursor to invisible element <head>
- * @author Alexander Potochkin
- * @library ../../../../regtesthelpers
- * @build Util
  * @run main bug5043626
  */
 
@@ -42,38 +39,51 @@ public class bug5043626 {
 
     private static Document doc;
     private static Robot robot;
+    private static JFrame frame;
 
     public static void main(String[] args) throws Exception {
-        robot = new Robot();
+        try {
+            robot = new Robot();
+            robot.setAutoDelay(100);
 
-        SwingUtilities.invokeAndWait(new Runnable() {
-            public void run() {
-                createAndShowGUI();
+            SwingUtilities.invokeAndWait(new Runnable() {
+                public void run() {
+                    createAndShowGUI();
+                }
+            });
+
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            robot.keyPress(KeyEvent.VK_HOME);
+            robot.keyRelease(KeyEvent.VK_HOME);
+            robot.keyPress(KeyEvent.VK_1);
+            robot.keyRelease(KeyEvent.VK_1);
+
+            robot.waitForIdle();
+
+            String test = getText();
+
+            if (!"1test".equals(test)) {
+                throw new RuntimeException("Begin line action set cursor inside <head> tag");
             }
-        });
 
-        robot.waitForIdle();
+            robot.keyPress(KeyEvent.VK_HOME);
+            robot.keyRelease(KeyEvent.VK_HOME);
+            robot.keyPress(KeyEvent.VK_2);
+            robot.keyRelease(KeyEvent.VK_2);
 
-        Util.hitKeys(robot, KeyEvent.VK_HOME);
-        Util.hitKeys(robot, KeyEvent.VK_1);
+            robot.waitForIdle();
 
-        robot.waitForIdle();
+            test = getText();
 
-        String test = getText();
-
-        if (!"1test".equals(test)) {
-            throw new RuntimeException("Begin line action set cursor inside <head> tag");
-        }
-
-        Util.hitKeys(robot, KeyEvent.VK_HOME);
-        Util.hitKeys(robot, KeyEvent.VK_2);
-
-        robot.waitForIdle();
-
-        test = getText();
-
-        if (!"21test".equals(test)) {
-            throw new RuntimeException("Begin action set cursor inside <head> tag");
+            if (!"21test".equals(test)) {
+                throw new RuntimeException("Begin action set cursor inside <head> tag");
+            }
+        } finally {
+            if (frame != null) {
+                SwingUtilities.invokeAndWait(frame::dispose);
+            }
         }
     }
 
@@ -94,7 +104,7 @@ public class bug5043626 {
     }
 
     private static void createAndShowGUI() {
-        JFrame frame = new JFrame();
+        frame = new JFrame();
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 
         JEditorPane editorPane = new JEditorPane();
@@ -103,6 +113,7 @@ public class bug5043626 {
         editorPane.setEditable(true);
         frame.add(editorPane);
         frame.pack();
+        frame.setLocationRelativeTo(null);
         frame.setVisible(true);
         doc = editorPane.getDocument();
         editorPane.setCaretPosition(doc.getLength());


### PR DESCRIPTION
Backport to fix a test bug.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8233570](https://bugs.openjdk.org/browse/JDK-8233570): [TESTBUG] HTMLEditorKit test bug5043626.java is failing on macos


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/247/head:pull/247` \
`$ git checkout pull/247`

Update a local copy of the PR: \
`$ git checkout pull/247` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/247/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 247`

View PR using the GUI difftool: \
`$ git pr show -t 247`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/247.diff">https://git.openjdk.org/jdk8u-dev/pull/247.diff</a>

</details>
