### PR TITLE
8280048: Missing comma in copyright header

### DIFF
--- a/jdk/test/sun/java2d/OpenGL/CopyAreaOOB.java
+++ b/jdk/test/sun/java2d/OpenGL/CopyAreaOOB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [9a18190a](https://github.com/openjdk/jdk/commit/9a18190a4f8e31801d1442d97f247f074a3fd5c0) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.
The commit being backported was authored by Mikael Vidstedt on 15 Jan 2022 and was reviewed by Phil Race.
Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280048](https://bugs.openjdk.org/browse/JDK-8280048): Missing comma in copyright header


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/248/head:pull/248` \
`$ git checkout pull/248`

Update a local copy of the PR: \
`$ git checkout pull/248` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/248/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 248`

View PR using the GUI difftool: \
`$ git pr show -t 248`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/248.diff">https://git.openjdk.org/jdk8u-dev/pull/248.diff</a>

</details>
