### PR TITLE
8059743: Incorrect assumtion in javax\sound\midi\Gervill\SoftProvider\GetDevice.java

### DIFF
--- a/jdk/test/javax/sound/midi/Gervill/SoftProvider/GetDevice.java
+++ b/jdk/test/javax/sound/midi/Gervill/SoftProvider/GetDevice.java
@@ -25,9 +25,6 @@
    @summary Test SoftProvider getDevice method */
 
 import javax.sound.midi.MidiDevice;
-import javax.sound.midi.MidiUnavailableException;
-import javax.sound.midi.Patch;
-import javax.sound.sampled.*;
 import javax.sound.midi.MidiDevice.Info;
 
 import com.sun.media.sound.*;
@@ -46,13 +43,6 @@ public class GetDevice {
             throw new RuntimeException("assertTrue fails!");
     }
 
-
-    private static class FakeInfo extends Info {
-        public FakeInfo() {
-            super("a", "b", "c", "d");
-        }
-    }
-
     public static void main(String[] args) throws Exception {
         SoftProvider provider = new SoftProvider();
         Info[] infos = provider.getDeviceInfo();
@@ -62,7 +52,5 @@ public class GetDevice {
             MidiDevice d = provider.getDevice(infos[i]);
             assertTrue(d instanceof SoftSynthesizer);
         }
-        assertTrue(provider.getDevice(new FakeInfo()) == null);
-
     }
 }

--- a/jdk/test/javax/sound/midi/MidiDeviceProvider/FakeInfo.java
+++ b/jdk/test/javax/sound/midi/MidiDeviceProvider/FakeInfo.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.util.Collection;
+import java.util.HashSet;
+
+import javax.sound.midi.MidiDevice;
+import javax.sound.midi.MidiDevice.Info;
+import javax.sound.midi.MidiSystem;
+import javax.sound.midi.MidiUnavailableException;
+import javax.sound.midi.spi.MidiDeviceProvider;
+
+import static java.util.ServiceLoader.load;
+
+/**
+ * @test
+ * @bug 8059743
+ * @summary MidiDeviceProvider shouldn't returns incorrect results in case of
+ *          some unknown MidiDevice.Info
+ * @author Sergey Bylokhov
+ */
+public final class FakeInfo {
+
+    private static final class Fake extends Info {
+
+        Fake() {
+            super("a", "b", "c", "d");
+        }
+    }
+
+    public static void main(final String[] args) {
+        final Info fake = new Fake();
+        // MidiSystem API
+        try {
+            MidiSystem.getMidiDevice(fake);
+            throw new RuntimeException("IllegalArgumentException expected");
+        } catch (final MidiUnavailableException e) {
+            throw new RuntimeException("IllegalArgumentException expected", e);
+        } catch (final IllegalArgumentException ignored) {
+            // expected
+        }
+        // MidiDeviceProvider API
+        final Collection<String> errors = new HashSet<>();
+        for (final MidiDeviceProvider mdp : load(MidiDeviceProvider.class)) {
+            try {
+                if (mdp.isDeviceSupported(fake)) {
+                    throw new RuntimeException("fake is supported");
+                }
+                final MidiDevice device = mdp.getDevice(fake);
+                System.err.println("MidiDevice: " + device);
+                throw new RuntimeException("IllegalArgumentException expected");
+            } catch (final IllegalArgumentException e) {
+                errors.add(e.getMessage());
+            }
+        }
+        if (errors.size() != 1) {
+            throw new RuntimeException("Wrong number of messages:" + errors);
+        }
+    }
+}


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [58cd1143](https://github.com/openjdk/jdk/commit/58cd114398268be098f18e5f0aab750cee5366cf) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.
The commit being backported was authored by Sergey Bylokhov on 18 Aug 2015 and was reviewed by Alexander Scherbatiy and Alex Menkov.
Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8059743](https://bugs.openjdk.org/browse/JDK-8059743): Incorrect assumtion in javax\sound\midi\Gervill\SoftProvider\GetDevice.java


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/249/head:pull/249` \
`$ git checkout pull/249`

Update a local copy of the PR: \
`$ git checkout pull/249` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/249/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 249`

View PR using the GUI difftool: \
`$ git pr show -t 249`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/249.diff">https://git.openjdk.org/jdk8u-dev/pull/249.diff</a>

</details>
