### PR TITLE
8156581: Cleanup of ProblemList.txt

### DIFF
--- a/jdk/test/ProblemList.txt
+++ b/jdk/test/ProblemList.txt
@@ -122,12 +122,6 @@ java/awt/FontMetrics/MaxAdvanceIsMax.java             solaris-all,macosx-all
 
 # jdk_beans
 
-# 8060027
-java/beans/XMLEncoder/Test4903007.java                        generic-all
-java/beans/XMLEncoder/java_awt_GridBagLayout.java             generic-all
-java/beans/XMLDecoder/8028054/TestConstructorFinder.java      generic-all
-java/beans/XMLDecoder/8028054/TestMethodFinder.java           generic-all
-
 ############################################################################
 
 # jdk_lang
@@ -337,9 +331,6 @@ javax/sound/sampled/DataLine/LongFramePosition.java    8055097 generic-all
 javax/sound/sampled/Clip/Drain/ClipDrain.java          7062792 generic-all
 
 javax/sound/sampled/Mixers/DisabledAssertionCrash.java 7067310 generic-all
-
-# 8059743
-javax/sound/midi/Gervill/SoftProvider/GetDevice.java            generic-all
 
 ############################################################################
 


### PR DESCRIPTION
This is a request to backport two updates to the ProblemList.txt.
Backport of the [JDK-8156581](https://github.com/openjdk/jdk/commit/65713ca08e5fde04a22b25314976ca364916d409):
 * The [JDK-8060027](https://bugs.openjdk.org/browse/JDK-8060027) was backported to the JDK8, so the beans tests now work fine. 
 * The [JDK-8059743](https://bugs.openjdk.org/browse/JDK-8059743) was JDK9 specific, so the sound test can be removed from the problem list.

Backport of the [JDK-8156579](https://github.com/openjdk/jdk/commit/a279dc035c2c9142928974c8d7bbc02d6092e5ab)
  * That bug was JDK9 specific, so the tests can be removed from the problem list.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8156581](https://bugs.openjdk.org/browse/JDK-8156581): Cleanup of ProblemList.txt
 * [JDK-8156579](https://bugs.openjdk.org/browse/JDK-8156579): Two JavaBeans tests failed


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/250/head:pull/250` \
`$ git checkout pull/250`

Update a local copy of the PR: \
`$ git checkout pull/250` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/250/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 250`

View PR using the GUI difftool: \
`$ git pr show -t 250`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/250.diff">https://git.openjdk.org/jdk8u-dev/pull/250.diff</a>

</details>
