### PR TITLE
8177560: @headful key can be removed from the tests for JavaSound

### DIFF
--- a/jdk/test/javax/sound/midi/Devices/InitializationHang.java
+++ b/jdk/test/javax/sound/midi/Devices/InitializationHang.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,18 +24,21 @@
 import java.awt.Toolkit;
 
 import javax.sound.midi.MidiSystem;
+import javax.sound.midi.MidiUnavailableException;
 
 /**
  * @test
  * @bug 8068412
- * @key headful
- * @author Sergey Bylokhov
  */
 public final class InitializationHang {
 
-    public static void main(final String[] argv) throws Exception {
-        MidiSystem.getReceiver();
-        Toolkit.getDefaultToolkit();
+    public static void main(final String[] argv) {
+        try {
+            MidiSystem.getReceiver();
+            Toolkit.getDefaultToolkit();
+        } catch (final MidiUnavailableException ignored) {
+            // the test is not applicable
+        }
     }
 }
 

--- a/jdk/test/javax/sound/midi/Sequencer/SeqRecordDoesNotCopy.java
+++ b/jdk/test/javax/sound/midi/Sequencer/SeqRecordDoesNotCopy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 import javax.sound.midi.MidiEvent;
 import javax.sound.midi.MidiMessage;
 import javax.sound.midi.MidiSystem;
+import javax.sound.midi.MidiUnavailableException;
 import javax.sound.midi.Receiver;
 import javax.sound.midi.Sequence;
 import javax.sound.midi.Sequencer;
@@ -34,12 +35,18 @@ import javax.sound.midi.Track;
  * @test
  * @bug 5048381
  * @summary Sequencer doesn't create distinct messages when recording events.
- * @key headful
  */
 public class SeqRecordDoesNotCopy {
-    public static void main(String argv[]) throws Exception {
-        Sequencer s = MidiSystem.getSequencer();
-        s.open();
+
+    public static void main(String argv[]) {
+        Sequencer s = null;
+        try {
+            s = MidiSystem.getSequencer();
+            s.open();
+        } catch (final MidiUnavailableException ignored) {
+            // the test is not applicable
+            return;
+        }
         try {
             Sequence seq = new Sequence(Sequence.PPQ, 384, 2);
             s.setSequence(seq);
@@ -86,7 +93,7 @@ public class SeqRecordDoesNotCopy {
         } catch (Exception e) {
             System.out.println("Unexpected Exception: "+e);
             //e.printStackTrace();
-            throw new Exception("Test FAILED!");
+            throw new RuntimeException("Test FAILED!");
         } finally {
             s.close();
         }

--- a/jdk/test/javax/sound/midi/Sequencer/SeqRecordsRealTimeEvents.java
+++ b/jdk/test/javax/sound/midi/Sequencer/SeqRecordsRealTimeEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 import javax.sound.midi.MidiEvent;
 import javax.sound.midi.MidiMessage;
 import javax.sound.midi.MidiSystem;
+import javax.sound.midi.MidiUnavailableException;
 import javax.sound.midi.Receiver;
 import javax.sound.midi.Sequence;
 import javax.sound.midi.Sequencer;
@@ -34,12 +35,18 @@ import javax.sound.midi.Track;
  * @test
  * @bug 5048381
  * @summary Sequencer records real time messages into the sequence
- * @key headful
  */
 public class SeqRecordsRealTimeEvents {
-    public static void main(String argv[]) throws Exception {
-        Sequencer s = MidiSystem.getSequencer();
-        s.open();
+
+    public static void main(String argv[]) {
+        Sequencer s = null;
+        try {
+            s = MidiSystem.getSequencer();
+            s.open();
+        } catch (final MidiUnavailableException ignored) {
+            // the test is not applicable
+            return;
+        }
         try {
             Sequence seq = new Sequence(Sequence.PPQ, 384, 2);
             s.setSequence(seq);
@@ -90,7 +97,7 @@ public class SeqRecordsRealTimeEvents {
         } catch (Exception e) {
             System.out.println("Unexpected Exception: "+e);
             //e.printStackTrace();
-            throw new Exception("Test FAILED!");
+            throw new RuntimeException("Test FAILED!");
         } finally {
             s.close();
         }

--- a/jdk/test/javax/sound/midi/Sequencer/SeqStartRecording.java
+++ b/jdk/test/javax/sound/midi/Sequencer/SeqStartRecording.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,25 +22,32 @@
  */
 
 import javax.sound.midi.MidiSystem;
+import javax.sound.midi.MidiUnavailableException;
 import javax.sound.midi.Sequencer;
 
 /**
  * @test
  * @bug 5001943
  * @summary Sequencer.startRecording throws unexpected NPE
- * @key headful
  */
 public class SeqStartRecording {
-    public static void main(String argv[]) throws Exception {
-        Sequencer seq = MidiSystem.getSequencer();
-        seq.open();
+
+    public static void main(String argv[]) {
+        Sequencer seq = null;
+        try {
+            seq = MidiSystem.getSequencer();
+            seq.open();
+        } catch (final MidiUnavailableException ignored) {
+            // the test is not applicable
+            return;
+        }
         try {
             seq.startRecording();
             System.out.println("Test passed.");
         } catch (NullPointerException npe) {
             System.out.println("Caught NPE: "+npe);
             npe.printStackTrace();
-            throw new Exception("Test FAILED!");
+            throw new RuntimeException("Test FAILED!");
         } catch (Exception e) {
             System.out.println("Unexpected Exception: "+e);
             e.printStackTrace();

--- a/jdk/test/javax/sound/midi/Synthesizer/bug4685396.java
+++ b/jdk/test/javax/sound/midi/Synthesizer/bug4685396.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 import javax.sound.midi.Instrument;
 import javax.sound.midi.MidiSystem;
+import javax.sound.midi.MidiUnavailableException;
 import javax.sound.midi.Soundbank;
 import javax.sound.midi.Synthesizer;
 
@@ -31,7 +32,6 @@ import javax.sound.midi.Synthesizer;
  * @bug 4685396
  * @summary Tests that Synthesizer.remapInstrument works
  * @run main bug4685396
- * @key headful
  */
 public class bug4685396 {
 
@@ -49,8 +49,7 @@ public class bug4685396 {
             boolean reloadInstr,    // reload all instruments?
             boolean unloadFrom,     // unload "from" instrument?
             boolean unloadTo        // unload "to" instrument?
-            ) throws Exception
-    {
+            ) throws MidiUnavailableException {
         log("Starting test: reloadInstr=" + reloadInstr
                 + ", unloadFrom=" + unloadFrom
                 + ", unloadTo=" + unloadTo
@@ -164,6 +163,9 @@ public class bug4685396 {
         boolean success = false;
         try {
             success = test(reloadInstr, unloadFrom, unloadTo);
+        } catch (final MidiUnavailableException ignored) {
+            // the test is not applicable
+            success = true;
         } catch (Exception ex) {
             log("Exception: " + ex.toString());
         }
@@ -171,7 +173,7 @@ public class bug4685396 {
         return success;
     }
 
-    public static void main(String args[]) throws Exception {
+    public static void main(String args[]) {
         boolean failed = false;
         if (!runTest(true, false, false))
             failed = true;

--- a/jdk/test/javax/sound/sampled/Clip/ClipCloseLoss.java
+++ b/jdk/test/javax/sound/sampled/Clip/ClipCloseLoss.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,6 @@ import javax.sound.sampled.Mixer;
  * @bug 4946913 8178403
  * @summary DirectClip doesn't kill the thread correctly, sometimes
  * @run main/othervm ClipCloseLoss
- * @key headful
  */
 public class ClipCloseLoss {
     static int frameCount = 441000; // lets say 10 seconds

--- a/jdk/test/javax/sound/sampled/Clip/bug5070081.java
+++ b/jdk/test/javax/sound/sampled/Clip/bug5070081.java
@@ -27,13 +27,13 @@ import javax.sound.sampled.AudioFormat;
 import javax.sound.sampled.AudioSystem;
 import javax.sound.sampled.Clip;
 import javax.sound.sampled.DataLine;
+import javax.sound.sampled.LineUnavailableException;
 
 /*
  * @test
  * @bug 5070081
  * @summary Tests that javax.sound.sampled.Clip does not loses position through
  *          stop/start
- * @key headful
  */
 public class bug5070081 {
 
@@ -45,10 +45,15 @@ public class bug5070081 {
 
     static boolean test() throws Exception {
         DataLine.Info info = new DataLine.Info(Clip.class, format);
-        Clip clip = (Clip)AudioSystem.getLine(info);
-        clip.open(format, soundData, 0, soundData.length);
-
+        Clip clip = null;
         boolean bSuccess = true;
+        try {
+            clip = (Clip) AudioSystem.getLine(info);
+            clip.open(format, soundData, 0, soundData.length);
+        } catch (LineUnavailableException | IllegalArgumentException ignored) {
+            // the test is not applicable
+            return bSuccess;
+        }
 
         long nLengthMS = clip.getMicrosecondLength()/1000;
 

--- a/jdk/test/javax/sound/sampled/DataLine/LongFramePosition.java
+++ b/jdk/test/javax/sound/sampled/DataLine/LongFramePosition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@ import javax.sound.sampled.SourceDataLine;
  * @test
  * @bug 5049129
  * @summary DataLine.getLongFramePosition
- * @key headful
  */
 public class LongFramePosition {
 
@@ -59,12 +58,12 @@ public class LongFramePosition {
             } finally {
                 sdl.close();
             }
-        } catch(LineUnavailableException e){
+        } catch (LineUnavailableException | IllegalArgumentException e) {
             System.out.println(e);
             System.out.println("Cannot execute test.");
             return;
         }
-        if (failed) throw new Exception("Test FAILED!");
+        if (failed) throw new RuntimeException("Test FAILED!");
         System.out.println("Test Passed.");
     }
 }

--- a/jdk/test/javax/sound/sampled/DirectAudio/bug6372428.java
+++ b/jdk/test/javax/sound/sampled/DirectAudio/bug6372428.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,6 @@ import javax.sound.sampled.TargetDataLine;
  * @summary playback and capture doesn't interrupt after terminating thread that
  *          calls start()
  * @run main bug6372428
- * @key headful
  */
 public class bug6372428 {
     public bug6372428() {


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [0b9c38fa](https://github.com/openjdk/jdk/commit/0b9c38fa6ec2a64d00d244cbe161feb29963ab11) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.
The commit being backported was authored by Sergey Bylokhov on 31 Mar 2017 and was reviewed by Phil Race.
Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8177560](https://bugs.openjdk.org/browse/JDK-8177560): @headful key can be removed from the tests for JavaSound


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/251/head:pull/251` \
`$ git checkout pull/251`

Update a local copy of the PR: \
`$ git checkout pull/251` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/251/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 251`

View PR using the GUI difftool: \
`$ git pr show -t 251`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/251.diff">https://git.openjdk.org/jdk8u-dev/pull/251.diff</a>

</details>
