### PR TITLE
8270317: Large Allocation in CipherSuite

### DIFF
--- a/jdk/src/share/classes/sun/security/ssl/CipherSuite.java
+++ b/jdk/src/share/classes/sun/security/ssl/CipherSuite.java
@@ -35,7 +35,7 @@ import sun.security.ssl.SupportedGroupsExtension.NamedGroupType;
 import static sun.security.ssl.SupportedGroupsExtension.NamedGroupType.*;
 
 /**
- * Enum for SSL/(D)TLS cipher suites
+ * Enum for SSL/TLS cipher suites
  *
  * Please refer to the "TLS Cipher Suite Registry" section for more details
  * about each cipher suite:

--- a/jdk/src/share/classes/sun/security/ssl/CipherSuite.java
+++ b/jdk/src/share/classes/sun/security/ssl/CipherSuite.java
@@ -25,12 +25,8 @@
 
 package sun.security.ssl;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
+
 import static sun.security.ssl.CipherSuite.HashAlg.*;
 import static sun.security.ssl.CipherSuite.KeyExchange.*;
 import static sun.security.ssl.CipherSuite.MacAlg.*;
@@ -39,7 +35,7 @@ import sun.security.ssl.SupportedGroupsExtension.NamedGroupType;
 import static sun.security.ssl.SupportedGroupsExtension.NamedGroupType.*;
 
 /**
- * Enum for SSL/TLS cipher suites.
+ * Enum for SSL/(D)TLS cipher suites
  *
  * Please refer to the "TLS Cipher Suite Registry" section for more details
  * about each cipher suite:
@@ -874,6 +870,39 @@ enum CipherSuite {
 
     final boolean exportable;
 
+    private static final Map<Integer, CipherSuite> cipherSuiteIds;
+    private static final Map<String, CipherSuite> cipherSuiteNames;
+    private static final List<CipherSuite> allowedCipherSuites;
+    private static final List<CipherSuite> defaultCipherSuites;
+
+    static {
+        Map<Integer, CipherSuite> ids = new HashMap<>();
+        Map<String, CipherSuite> names = new HashMap<>();
+        List<CipherSuite> allowedCS = new ArrayList<>();
+        List<CipherSuite> defaultCS = new ArrayList<>();
+
+        for(CipherSuite cs : CipherSuite.values()) {
+            ids.put(cs.id, cs);
+            names.put(cs.name, cs);
+            for (String alias : cs.aliases) {
+                names.put(alias, cs);
+            }
+
+            if (!cs.supportedProtocols.isEmpty()) {
+                allowedCS.add(cs);
+            }
+
+            if (cs.isDefaultEnabled) {
+                defaultCS.add(cs);
+            }
+        }
+
+        cipherSuiteIds = Collections.unmodifiableMap(ids);
+        cipherSuiteNames = Collections.unmodifiableMap(names);
+        allowedCipherSuites = Collections.unmodifiableList(allowedCS);
+        defaultCipherSuites = Collections.unmodifiableList(defaultCS);
+    }
+
     // known but unsupported cipher suite
     private CipherSuite(String name, int id) {
         this(id, false, name, "",
@@ -911,62 +940,29 @@ enum CipherSuite {
     }
 
     static CipherSuite nameOf(String ciperSuiteName) {
-        for (CipherSuite cs : CipherSuite.values()) {
-            if (cs.name.equals(ciperSuiteName) ||
-                    cs.aliases.contains(ciperSuiteName)) {
-                return cs;
-            }
-        }
-
-        return null;
+        return cipherSuiteNames.get(ciperSuiteName);
     }
 
     static CipherSuite valueOf(int id) {
-        for (CipherSuite cs : CipherSuite.values()) {
-            if (cs.id == id) {
-                return cs;
-            }
-        }
-
-        return null;
+        return cipherSuiteIds.get(id);
     }
 
     static String nameOf(int id) {
-        for (CipherSuite cs : CipherSuite.values()) {
-            if (cs.id == id) {
-                return cs.name;
-            }
+        CipherSuite cs = cipherSuiteIds.get(id);
+
+        if (cs != null) {
+            return cs.name;
         }
 
         return "UNKNOWN-CIPHER-SUITE(" + Utilities.byte16HexString(id) + ")";
     }
 
     static Collection<CipherSuite> allowedCipherSuites() {
-        Collection<CipherSuite> cipherSuites = new LinkedList<>();
-        for (CipherSuite cs : CipherSuite.values()) {
-            if (!cs.supportedProtocols.isEmpty()) {
-                cipherSuites.add(cs);
-            } else {
-                // values() is ordered, remaining cipher suites are
-                // not supported.
-                break;
-            }
-        }
-        return cipherSuites;
+        return allowedCipherSuites;
     }
 
     static Collection<CipherSuite> defaultCipherSuites() {
-        Collection<CipherSuite> cipherSuites = new LinkedList<>();
-        for (CipherSuite cs : CipherSuite.values()) {
-            if (cs.isDefaultEnabled) {
-                cipherSuites.add(cs);
-            } else {
-                // values() is ordered, remaining cipher suites are
-                // not enabled.
-                break;
-            }
-        }
-        return cipherSuites;
+        return defaultCipherSuites;
     }
 
     /**
@@ -989,19 +985,11 @@ enum CipherSuite {
             }
 
             boolean found = false;
-            for (CipherSuite cs : CipherSuite.values()) {
-                if (!cs.supportedProtocols.isEmpty()) {
-                    if (cs.name.equals(name) ||
-                            cs.aliases.contains(name)) {
-                        cipherSuites.add(cs);
-                        found = true;
-                        break;
-                    }
-                } else {
-                    // values() is ordered, remaining cipher suites are
-                    // not supported.
-                    break;
-                }
+            CipherSuite cs;
+            if ((cs = cipherSuiteNames.get(name)) != null
+                    && !cs.supportedProtocols.isEmpty()) {
+                cipherSuites.add(cs);
+                found = true;
             }
             if (!found) {
                 throw new IllegalArgumentException(

--- a/jdk/src/share/classes/sun/security/ssl/CipherSuite.java
+++ b/jdk/src/share/classes/sun/security/ssl/CipherSuite.java
@@ -35,7 +35,7 @@ import sun.security.ssl.SupportedGroupsExtension.NamedGroupType;
 import static sun.security.ssl.SupportedGroupsExtension.NamedGroupType.*;
 
 /**
- * Enum for SSL/TLS cipher suites
+ * Enum for SSL/TLS cipher suites.
  *
  * Please refer to the "TLS Cipher Suite Registry" section for more details
  * about each cipher suite:


### PR DESCRIPTION
Backport for Oracle parity. Backport from 11u is not clean due to lack of CopyOf in 8u. The nearest equivalents are Collections.unmodifiableMap and Collections.unmodifiableList. Also, there is no jmh archive in 8u, so the performance test is not included.

Tier1 and all security tests pass, in production at Amazon for over a year without issues.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8270317](https://bugs.openjdk.org/browse/JDK-8270317): Large Allocation in CipherSuite


### Reviewers
 * [Volker Simonis](https://openjdk.org/census#simonis) (@simonis - **Reviewer**) ⚠️ Review applies to [c2debd86](https://git.openjdk.org/jdk8u-dev/pull/253/files/c2debd8635b676378b546e885c0d5d348a2baf65)
 * [Martin Balao](https://openjdk.org/census#mbalao) (@martinuy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/253/head:pull/253` \
`$ git checkout pull/253`

Update a local copy of the PR: \
`$ git checkout pull/253` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/253/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 253`

View PR using the GUI difftool: \
`$ git pr show -t 253`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/253.diff">https://git.openjdk.org/jdk8u-dev/pull/253.diff</a>

</details>
