### PR TITLE
8287463: JFR: Disable TestDevNull.java on Windows

### DIFF
--- a/jdk/test/jdk/jfr/api/recording/dump/TestDumpDevNull.java
+++ b/jdk/test/jdk/jfr/api/recording/dump/TestDumpDevNull.java
@@ -32,7 +32,7 @@ import jdk.jfr.Recording;
  * @summary Tests that it's possible to dump to /dev/null without a livelock
  * @key jfr
  *
- * @library /lib / /testlibrary
+ * @library /lib /
  * @run main/othervm jdk.jfr.api.recording.dump.TestDumpDevNull
  */
 public class TestDumpDevNull {

--- a/jdk/test/jdk/jfr/api/recording/dump/TestDumpDevNull.java
+++ b/jdk/test/jdk/jfr/api/recording/dump/TestDumpDevNull.java
@@ -38,6 +38,11 @@ import jdk.jfr.Recording;
 public class TestDumpDevNull {
 
     public static void main(String[] args) throws Exception {
+        String os = System.getProperty("os.name").toLowerCase();
+        if (os.startsWith("win")) {
+          System.out.println("Skipping TestDumpDevNull on windows: it uses /dev/null which is not present on windows");
+          System.exit(0);
+        }
         try (Recording r1 = new Recording()) {
             r1.setDestination(new File("/dev/null").toPath());
             r1.start();

--- a/jdk/test/jdk/jfr/api/recording/dump/TestDumpDevNull.java
+++ b/jdk/test/jdk/jfr/api/recording/dump/TestDumpDevNull.java
@@ -32,14 +32,13 @@ import jdk.jfr.Recording;
  * @summary Tests that it's possible to dump to /dev/null without a livelock
  * @key jfr
  *
- * @library /lib /
+ * @library /lib / /testlibrary
  * @run main/othervm jdk.jfr.api.recording.dump.TestDumpDevNull
  */
 public class TestDumpDevNull {
 
     public static void main(String[] args) throws Exception {
-        String os = System.getProperty("os.name").toLowerCase();
-        if (os.startsWith("win")) {
+        if (jdk.testlibrary.Platform.isWindows()) {
           System.out.println("Skipping TestDumpDevNull on windows: it uses /dev/null which is not present on windows");
           System.exit(0);
         }

--- a/jdk/test/jdk/jfr/api/recording/dump/TestDumpDevNull.java
+++ b/jdk/test/jdk/jfr/api/recording/dump/TestDumpDevNull.java
@@ -27,6 +27,8 @@ import java.io.File;
 
 import jdk.jfr.Recording;
 
+import jdk.test.lib.Platform;
+
 /**
  * @test
  * @summary Tests that it's possible to dump to /dev/null without a livelock
@@ -38,7 +40,7 @@ import jdk.jfr.Recording;
 public class TestDumpDevNull {
 
     public static void main(String[] args) throws Exception {
-        if (jdk.testlibrary.Platform.isWindows()) {
+        if (Platform.isWindows()) {
           System.out.println("Skipping TestDumpDevNull on windows: it uses /dev/null which is not present on windows");
           System.exit(0);
         }

--- a/jdk/test/jdk/jfr/api/recording/dump/TestDumpDevNull.java
+++ b/jdk/test/jdk/jfr/api/recording/dump/TestDumpDevNull.java
@@ -27,23 +27,17 @@ import java.io.File;
 
 import jdk.jfr.Recording;
 
-import jdk.test.lib.Platform;
-
 /**
  * @test
  * @summary Tests that it's possible to dump to /dev/null without a livelock
  * @key jfr
- *
+ * @requires (os.family != "windows")
  * @library /lib /
  * @run main/othervm jdk.jfr.api.recording.dump.TestDumpDevNull
  */
 public class TestDumpDevNull {
 
     public static void main(String[] args) throws Exception {
-        if (Platform.isWindows()) {
-          System.out.println("Skipping TestDumpDevNull on windows: it uses /dev/null which is not present on windows");
-          System.exit(0);
-        }
         try (Recording r1 = new Recording()) {
             r1.setDestination(new File("/dev/null").toPath());
             r1.start();


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287463](https://bugs.openjdk.org/browse/JDK-8287463): JFR: Disable TestDevNull.java on Windows


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**) ⚠️ Review applies to [4e1ca73c](https://git.openjdk.org/jdk8u-dev/pull/255/files/4e1ca73ccb304b407532ed7c5f4818c84fc724fd)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/255/head:pull/255` \
`$ git checkout pull/255`

Update a local copy of the PR: \
`$ git checkout pull/255` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/255/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 255`

View PR using the GUI difftool: \
`$ git pr show -t 255`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/255.diff">https://git.openjdk.org/jdk8u-dev/pull/255.diff</a>

</details>
