### PR TITLE
8301620: [8u] some shell tests are passed but have unexpected operator errors

### DIFF
--- a/hotspot/test/runtime/6929067/Test6929067.sh
+++ b/hotspot/test/runtime/6929067/Test6929067.sh
@@ -23,7 +23,7 @@ OS=`uname -s`
 case "$OS" in
   Linux)
     gcc_cmd=`which gcc`
-    if [ "x$gcc_cmd" == "x" ]; then
+    if [ "x$gcc_cmd" = "x" ]; then
         echo "WARNING: gcc not found. Cannot execute test." 2>&1
         exit 0;
     fi

--- a/hotspot/test/runtime/jsig/Test8017498.sh
+++ b/hotspot/test/runtime/jsig/Test8017498.sh
@@ -47,7 +47,7 @@ case "$OS" in
   Linux)
     echo "Testing on Linux"
     gcc_cmd=`which gcc`
-    if [ "x$gcc_cmd" == "x" ]; then
+    if [ "x$gcc_cmd" = "x" ]; then
         echo "WARNING: gcc not found. Cannot execute test." 2>&1
         exit 0;
     fi

--- a/hotspot/test/runtime/jsig/Test8017498.sh
+++ b/hotspot/test/runtime/jsig/Test8017498.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #
-#  Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+#  Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
 #  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 #  This code is free software; you can redistribute it and/or modify it

--- a/jdk/test/jdk/tools/launcher/JliLaunchTest.sh
+++ b/jdk/test/jdk/tools/launcher/JliLaunchTest.sh
@@ -13,7 +13,7 @@ if [ "${OS}" != "Darwin" ]; then
 fi
 
 gcc_cmd=`which gcc`
-if [ "x$gcc_cmd" == "x" ]; then
+if [ "x$gcc_cmd" = "x" ]; then
     echo "WARNING: gcc not found. Cannot execute test." 2>&1
     exit 0;
 fi


### PR DESCRIPTION
Some `.sh` tests are passed on Linux (with dash, like Ubuntu), but `[: ... unexpected operator` errors could be found when `-verbose:all` is used. 

For example:
```
TEST: runtime/jsig/Test8017498.sh
TEST JDK: /home/aoqi/work/theaoqi/jdk8u-dev/build/linux-x86_64-normal-server-release/images/j2sdk-image

ACTION: shell -- Failed. Execution failed: exit code 2
REASON: User specified action: run shell/timeout=30 Test8017498.sh 
TIME:   0.108 seconds
messages:
command: shell Test8017498.sh
reason: User specified action: run shell/timeout=30 Test8017498.sh 
elapsed time (seconds): 0.108
STDOUT:
TESTSRC=/home/aoqi/work/theaoqi/jdk8u-dev/hotspot/test/runtime/jsig
TESTJAVA=/home/aoqi/work/theaoqi/jdk8u-dev/build/linux-x86_64-normal-server-release/images/j2sdk-image
COMPILEJAVA=/home/aoqi/work/theaoqi/jdk8u-dev/build/linux-x86_64-normal-server-release/images/j2sdk-image
TESTCLASSES=/home/aoqi/tmp/JTwork/classes/runtime/jsig
NULL =/dev/null
PS =:
FS =/
RM =/bin/rm
CP =/bin/cp
MV =/bin/mv
CLASSPATH =.:/home/aoqi/tmp/JTwork/classes/runtime/jsig:
THIS_DIR=.
VM_TYPE=server
VM_BITS=64
VM_OS=linux
VM_CPU=amd64
Testing on Linux
STDERR:
openjdk version "1.8.0_372-internal"
OpenJDK Runtime Environment (build 1.8.0_372-internal-aoqi_2023_02_01_11_52-b00)
OpenJDK 64-Bit Server VM (build 25.372-b00, mixed mode)
/home/aoqi/work/theaoqi/jdk8u-dev/hotspot/test/runtime/jsig/Test8017498.sh: 50: [: x/usr/bin/gcc: unexpected operator
rerun:
cd /home/aoqi/tmp/JTwork/scratch && \
HOME=/home/aoqi \
LANG=zh_CN.UTF-8 \
PATH=/bin:/usr/bin:/usr/sbin \
TESTFILE=/home/aoqi/work/theaoqi/jdk8u-dev/hotspot/test/runtime/jsig/Test8017498.sh \
TESTSRC=/home/aoqi/work/theaoqi/jdk8u-dev/hotspot/test/runtime/jsig \
TESTSRCPATH=/home/aoqi/work/theaoqi/jdk8u-dev/hotspot/test/runtime/jsig \
TESTCLASSES=/home/aoqi/tmp/JTwork/classes/runtime/jsig \
TESTCLASSPATH=/home/aoqi/tmp/JTwork/classes/runtime/jsig \
COMPILEJAVA=/home/aoqi/work/theaoqi/jdk8u-dev/build/linux-x86_64-normal-server-release/images/j2sdk-image \
TESTJAVA=/home/aoqi/work/theaoqi/jdk8u-dev/build/linux-x86_64-normal-server-release/images/j2sdk-image \
TESTVMOPTS= \
```

This issue is only found in jdk8u. [JDK-8299804](https://bugs.openjdk.org/browse/JDK-8299804) did the same fix. I think three more tests also need to be fixed:

```
hotspot/test/runtime/6929067/Test6929067.sh
hotspot/test/runtime/jsig/Test8017498.sh
jdk/test/jdk/tools/launcher/JliLaunchTest.sh  => with `#!/bin/bash` in the head, but I think it's better to unify the style.
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301620](https://bugs.openjdk.org/browse/JDK-8301620): [8u] some shell tests are passed but have unexpected operator errors


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/260/head:pull/260` \
`$ git checkout pull/260`

Update a local copy of the PR: \
`$ git checkout pull/260` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/260/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 260`

View PR using the GUI difftool: \
`$ git pr show -t 260`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/260.diff">https://git.openjdk.org/jdk8u-dev/pull/260.diff</a>

</details>
