### PR TITLE
8033936: java.awt.List events are not sent properly to handleEvent or ItemListener

### DIFF
--- a/jdk/src/windows/native/sun/windows/awt_List.h
+++ b/jdk/src/windows/native/sun/windows/awt_List.h
@@ -56,6 +56,7 @@ public:
     }
     INLINE void Deselect(int pos) {
         if (isMultiSelect) {
+            SendListMessage(LB_SETCARETINDEX, pos, FALSE);
             SendListMessage(LB_SETSEL, FALSE, pos);
         }
         else {

--- a/jdk/test/java/awt/List/ItemEventTest/ItemEventTest.java
+++ b/jdk/test/java/awt/List/ItemEventTest/ItemEventTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ *  @test
+ *  @bug 8033936
+ *  @summary Verify that correct ItemEvent is received while selection &
+ *           deselection of multi select List items.
+ */
+
+import java.awt.AWTException;
+import java.awt.Event;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.List;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
+import java.awt.event.InputEvent;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+
+public class ItemEventTest extends Frame
+{
+    List list;
+    final String expectedSelectionOrder;
+    StringBuilder actualSelectionOrder;
+    Robot robot;
+
+    public ItemEventTest()
+    {
+        try {
+            robot = new Robot();
+        } catch(AWTException e) {
+            throw new RuntimeException(e.getMessage());
+        }
+        expectedSelectionOrder = "01230123";
+
+        list = new List(4, true);
+        list.add("0");
+        list.add("1");
+        list.add("2");
+        list.add("3");
+
+        add(list);
+        setSize(400,400);
+        setLayout(new FlowLayout());
+        pack();
+        setVisible(true);
+        robot.waitForIdle();
+    }
+
+    @Override
+    public boolean handleEvent(Event e) {
+        if (e.target instanceof List) {
+            if (e.id == Event.LIST_DESELECT || e.id == Event.LIST_SELECT) {
+                actualSelectionOrder.append(e.arg);
+            }
+        }
+        return true;
+    }
+
+    void testHandleEvent() {
+        // When no ItemListener is added to List, parent's handleEvent is
+        // called with ItemEvent.
+        performTest();
+    }
+
+    void testItemListener() {
+        list.addItemListener(new ItemListener() {
+            @Override
+            public void itemStateChanged(ItemEvent ie) {
+                actualSelectionOrder.append(ie.getItem());
+            }
+        });
+        performTest();
+    }
+
+    void performTest() {
+        actualSelectionOrder = new StringBuilder();
+        Point loc = list.getLocationOnScreen();
+        Rectangle rect = list.getBounds();
+        int dY = rect.height / list.getItemCount();
+        loc = new Point(loc.x + 10, loc.y + 5);
+
+        String osName = System.getProperty("os.name");
+        boolean isMac = osName.contains("Mac") || osName.contains("mac");
+        if(isMac) {
+            robot.keyPress(KeyEvent.VK_META);
+        }
+
+        // First loop to select & Second loop to deselect the list items.
+        for (int j = 0; j < 2; ++j) {
+            for (int i = 0; i < list.getItemCount(); ++i) {
+                robot.mouseMove(loc.x, loc.y + i * dY);
+                robot.mousePress(InputEvent.BUTTON1_MASK);
+                robot.delay(100);
+                robot.mouseRelease(InputEvent.BUTTON1_MASK);
+                robot.waitForIdle();
+            }
+        }
+
+        if(isMac) {
+            robot.keyRelease(KeyEvent.VK_META);
+        }
+
+        if (!expectedSelectionOrder.equals(actualSelectionOrder.toString())) {
+            dispose();
+            throw new RuntimeException("ItemEvent for selection & deselection"
+                + " of multi select List's item is not correct"
+                + " Expected : " + expectedSelectionOrder
+                + " Actual : " + actualSelectionOrder);
+        }
+    }
+
+    public static void main(String args[]) {
+       ItemEventTest test = new ItemEventTest();
+       test.testHandleEvent();
+       test.testItemListener();
+       test.dispose();
+    }
+}


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [8543426a](https://github.com/openjdk/jdk/commit/8543426a278f7d168c1985827a5bb49597080ab5) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.
The commit being backported was authored by Ambarish Rapte on 30 Mar 2016 and was reviewed by Sergey Bylokhov and Prasanta Sadhukhan.
Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8033936](https://bugs.openjdk.org/browse/JDK-8033936): java.awt.List events are not sent properly to handleEvent or ItemListener


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/261/head:pull/261` \
`$ git checkout pull/261`

Update a local copy of the PR: \
`$ git checkout pull/261` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/261/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 261`

View PR using the GUI difftool: \
`$ git pr show -t 261`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/261.diff">https://git.openjdk.org/jdk8u-dev/pull/261.diff</a>

</details>
