### PR TITLE
8298027: Remove SCCS id's from awt jtreg tests

### DIFF
--- a/jdk/test/java/awt/font/TextLayout/TestOldHangul.java
+++ b/jdk/test/java/awt/font/TextLayout/TestOldHangul.java
@@ -21,7 +21,7 @@
  *
  */
 
-/* @test @(#)TestOldHangul.java
+/* @test
  * @summary Verify Old Hangul display
  * @bug 6886358
  * @ignore Requires a special font installed.
@@ -80,4 +80,3 @@ public class TestOldHangul {
         frame.setVisible(true);
     }
 }
-

--- a/jdk/test/java/awt/font/TextLayout/TestTibetan.java
+++ b/jdk/test/java/awt/font/TextLayout/TestTibetan.java
@@ -21,7 +21,7 @@
  *
  */
 
-/* @test @(#)TestTibetan.java
+/* @test
  * @summary verify tibetan output
  * @bug 6886358
  * @ignore Requires a special font installed
@@ -84,4 +84,3 @@ public class TestTibetan {
         frame.setVisible(true);
     }
 }
-


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [ba2d28e9](https://github.com/openjdk/jdk/commit/ba2d28e911f4f523334f98fd0186680acafb6f0a) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.
The commit being backported was authored by Jayathirth D V on 6 Dec 2022 and was reviewed by Alexey Ivanov.
Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298027](https://bugs.openjdk.org/browse/JDK-8298027): Remove SCCS id's from awt jtreg tests


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/264/head:pull/264` \
`$ git checkout pull/264`

Update a local copy of the PR: \
`$ git checkout pull/264` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/264/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 264`

View PR using the GUI difftool: \
`$ git pr show -t 264`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/264.diff">https://git.openjdk.org/jdk8u-dev/pull/264.diff</a>

</details>
