### PR TITLE
8301760: Fix possible leak in SpNegoContext dispose

### DIFF
--- a/jdk/src/share/classes/sun/security/jgss/spnego/SpNegoContext.java
+++ b/jdk/src/share/classes/sun/security/jgss/spnego/SpNegoContext.java
@@ -244,8 +244,11 @@ public class SpNegoContext implements GSSContextSpi {
     }
 
     public final void dispose() throws GSSException {
-        mechContext = null;
         state = STATE_DELETED;
+        if (mechContext != null) {
+            mechContext.dispose();
+            mechContext = null;
+        }
     }
 
     /**


### PR DESCRIPTION
This is a small change fixing not very common but still existing in the wild issue in the stable code. Should not be risky.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301760](https://bugs.openjdk.org/browse/JDK-8301760): Fix possible leak in SpNegoContext dispose


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**) ⚠️ Review applies to [b3d9a388](https://git.openjdk.org/jdk8u-dev/pull/265/files/b3d9a3886c947611373f75d4e7b761fc472ca197)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/265/head:pull/265` \
`$ git checkout pull/265`

Update a local copy of the PR: \
`$ git checkout pull/265` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/265/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 265`

View PR using the GUI difftool: \
`$ git pr show -t 265`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/265.diff">https://git.openjdk.org/jdk8u-dev/pull/265.diff</a>

</details>
