### PR TITLE
8142540: [TEST_BUG] Test sun/awt/dnd/8024061/bug8024061.java fails on ubuntu

### DIFF
--- a/jdk/test/sun/awt/dnd/8024061/bug8024061.java
+++ b/jdk/test/sun/awt/dnd/8024061/bug8024061.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2017 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,9 +68,14 @@ public class bug8024061 {
     private static final DataFlavor DropObjectFlavor;
     private static final int DELAY = 1000;
 
-    private final DnDPanel panel1 = new DnDPanel(Color.yellow);
-    private final DnDPanel panel2 = new DnDPanel(Color.pink);
+    static final DnDPanel panel1 = new DnDPanel(Color.yellow);
+    static final DnDPanel panel2 = new DnDPanel(Color.pink);
     private final JFrame frame;
+    static Point here;
+    static Point there;
+    static Dimension d;
+
+
 
     private static final CountDownLatch lock = new CountDownLatch(1);
     private static volatile Exception dragEnterException = null;
@@ -89,7 +94,7 @@ public class bug8024061 {
         frame = new JFrame("DnDWithRobot");
         frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
 
-        Dimension d = new Dimension(100, 100);
+        d = new Dimension(100, 100);
 
         panel1.setPreferredSize(d);
         panel2.setPreferredSize(d);
@@ -124,12 +129,15 @@ public class bug8024061 {
         final Robot robot = new Robot();
         robot.setAutoDelay(10);
         robot.waitForIdle();
+        robot.delay(200);
 
         JFrame frame = dnd[0].frame;
-        Point point = frame.getLocationOnScreen();
-        Point here = new Point(point.x + 35, point.y + 45);
-        Point there = new Point(point.x + 120, point.y + 45);
-        here.x += 25;
+        SwingUtilities.invokeAndWait(() -> {
+            here = panel1.getLocationOnScreen();
+            there = panel2.getLocationOnScreen();
+        });
+        here.translate(d.width / 2, d.height / 2);
+        there.translate(d.width / 2, d.height / 2);
         robot.mouseMove(here.x, here.y);
         robot.mousePress(InputEvent.BUTTON1_MASK);
         while (here.x < there.x) {
@@ -157,7 +165,7 @@ public class bug8024061 {
                 throw new RuntimeException("Timed out waiting for dragEnter()");
             }
         } finally {
-            frame.dispose();
+            SwingUtilities.invokeLater(frame::dispose);
         }
     }
 
@@ -218,7 +226,7 @@ public class bug8024061 {
         }
     }
 
-    class DnDPanel extends JPanel {
+    static class DnDPanel extends JPanel {
         DropObject dropObject;
         final DragSource dragSource;
         final DropTarget dropTarget;


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [84dd5699](https://github.com/openjdk/jdk/commit/84dd5699d5571e586b2763da34d2a76851695854) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.
The commit being backported was authored by Semyon Sadetsky on 13 Apr 2017 and was reviewed by Yuri Nesterenko and Sergey Bylokhov.
Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8142540](https://bugs.openjdk.org/browse/JDK-8142540): [TEST_BUG] Test sun/awt/dnd/8024061/bug8024061.java fails on ubuntu


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/266/head:pull/266` \
`$ git checkout pull/266`

Update a local copy of the PR: \
`$ git checkout pull/266` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/266/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 266`

View PR using the GUI difftool: \
`$ git pr show -t 266`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/266.diff">https://git.openjdk.org/jdk8u-dev/pull/266.diff</a>

</details>
