### PR TITLE
8205959: Do not restart close if errno is EINTR

### DIFF
--- a/jdk/src/solaris/native/java/net/linux_close.c
+++ b/jdk/src/solaris/native/java/net/linux_close.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -288,13 +288,13 @@ static int closefd(int fd1, int fd2) {
          * And close/dup the file descriptor
          * (restart if interrupted by signal)
          */
-        do {
-            if (fd1 < 0) {
-                rv = close(fd2);
-            } else {
+        if (fd1 < 0) {
+            rv = close(fd2);
+        } else {
+            do {
                 rv = dup2(fd1, fd2);
-            }
-        } while (rv == -1 && errno == EINTR);
+            } while (rv == -1 && errno == EINTR);
+        }
 
         /*
          * Send a wakeup signal to all threads blocked on this


### PR DESCRIPTION
Bug fix avoiding misuse of `close()`

Code changes backport cleanly. The copyright header had to be adjusted as the 8u header was still 2016, not 2017.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8205959](https://bugs.openjdk.org/browse/JDK-8205959): Do not restart close if errno is EINTR


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/267/head:pull/267` \
`$ git checkout pull/267`

Update a local copy of the PR: \
`$ git checkout pull/267` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/267/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 267`

View PR using the GUI difftool: \
`$ git pr show -t 267`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/267.diff">https://git.openjdk.org/jdk8u-dev/pull/267.diff</a>

</details>
