### PR TITLE
8298108: Add a regression test for JDK-8297684

### DIFF
--- a/jdk/test/java/security/SignedJar/spi-calendar-provider/TestSPISigned.java
+++ b/jdk/test/java/security/SignedJar/spi-calendar-provider/TestSPISigned.java
@@ -105,7 +105,7 @@ public class TestSPISigned {
             // run test, which must not throw a NPE
             List<String> testRun = new ArrayList<>();
             String extDir = System.getProperty("java.home") + File.separator + "lib" + File.separator + "ext";
-            testRun.add("-Djava.ext.dirs=" + System.getProperty("java.home") + extDir + File.pathSeparator + MODS_DIR.toAbsolutePath().toString());
+            testRun.add("-Djava.ext.dirs=" + extDir + File.pathSeparator + MODS_DIR.toAbsolutePath().toString());
             testRun.add("-cp");
             String classPath = System.getProperty("java.class.path");
             testRun.add(classPath);

--- a/jdk/test/java/security/SignedJar/spi-calendar-provider/TestSPISigned.java
+++ b/jdk/test/java/security/SignedJar/spi-calendar-provider/TestSPISigned.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.testlibrary.JarUtils;
+import jdk.testlibrary.SecurityTools;
+import jdk.testlibrary.Asserts;
+import jdk.testlibrary.ProcessTools;
+import jdk.testlibrary.OutputAnalyzer;
+import java.util.Calendar;
+import java.util.Locale;
+import java.util.List;
+import java.util.ArrayList;
+import java.nio.file.Paths;
+import java.nio.file.Path;
+import java.nio.file.Files;
+import java.io.File;
+import static java.util.Calendar.WEDNESDAY;
+
+/*
+ * @test
+ * @bug 8297684 8269039
+ * @summary Checking custom CalendarDataProvider with SPI contained in signed jar does
+ *          not produce NPE.
+ * @library /lib/testlibrary
+ * @library provider
+ * @build baz.CalendarDataProviderImpl
+ * @run main/timeout=600 TestSPISigned
+ */
+public class TestSPISigned {
+
+    private static final String TEST_CLASSES = System.getProperty("test.classes", ".");
+    private static final String TEST_SRC = System.getProperty("test.src", ".");
+
+    private static final Path META_INF_DIR = Paths.get(TEST_SRC, "provider", "meta");
+    private static final Path META_INF_DIR_SOURCE = META_INF_DIR.resolve("META-INF");
+    private static final Path SERVICES_DIR_SOURCE = META_INF_DIR_SOURCE.resolve("services");
+    private static final Path PROVIDER_SOURCE = SERVICES_DIR_SOURCE.resolve("java.util.spi.CalendarDataProvider");
+    private static final Path PROVIDER_PARENT = Paths.get(TEST_CLASSES);
+    private static final Path PROVIDER_DIR = PROVIDER_PARENT.resolve("provider");
+    private static final Path META_INF_DIR_TARGET = PROVIDER_DIR.resolve("META-INF");
+    private static final Path SERVICES_DIR_TARGET = META_INF_DIR_TARGET.resolve("services");
+    private static final Path PROVIDER_TARGET = SERVICES_DIR_TARGET.resolve("java.util.spi.CalendarDataProvider");
+    private static final Path MODS_DIR = Paths.get("mods");
+    private static final Path UNSIGNED_JAR = MODS_DIR.resolve("unsigned-with-locale.jar");
+    private static final Path SIGNED_JAR = MODS_DIR.resolve("signed-with-locale.jar");
+
+    public static void main(String[] args) throws Throwable {
+        if (args.length == 1) {
+            String arg = args[0];
+            if ("run-test".equals(arg)) {
+                System.out.println("Debug: Running test");
+                String provProp = System.getProperty("java.ext.dirs");
+                String[] extDirs = provProp.split(File.pathSeparator);
+                boolean extDirFound = false;
+                for (int i = 0; i < extDirs.length; i++) {
+                    if (extDirs[i].equals(MODS_DIR.toAbsolutePath().toString())) {
+                        extDirFound = true;
+                        break;
+                    }
+                }
+                if (!extDirFound) {
+                   throw new RuntimeException("Test failed! Expected -Djava.ext.dirs to include CalendarDataProvider jar");
+                }
+                doRunTest();
+            } else {
+               throw new RuntimeException("Test failed! Expected 'run-test' arg for test run");
+            }
+        } else {
+            // Set up signed jar with custom calendar data provider
+            //
+            // 1. Create jar with custom CalendarDataProvider
+            Files.createDirectory(META_INF_DIR_TARGET);
+            Files.createDirectory(SERVICES_DIR_TARGET);
+            Files.copy(PROVIDER_SOURCE, PROVIDER_TARGET);
+            JarUtils.createJarFile(UNSIGNED_JAR, PROVIDER_DIR);
+
+            // create signer's keypair
+            SecurityTools.keytool("-genkeypair -keyalg RSA -keystore ks " +
+                                  "-storepass changeit -dname CN=test -alias test")
+                     .shouldHaveExitValue(0);
+            // sign jar
+            SecurityTools.jarsigner("-keystore ks -storepass changeit " +
+                                "-signedjar " + SIGNED_JAR + " " + UNSIGNED_JAR + " test")
+                     .shouldHaveExitValue(0);
+            // run test, which must not throw a NPE
+            List<String> testRun = new ArrayList<>();
+            String extDir = System.getProperty("java.home") + File.separator + "lib" + File.separator + "ext";
+            testRun.add("-Djava.ext.dirs=" + System.getProperty("java.home") + extDir + File.pathSeparator + MODS_DIR.toAbsolutePath().toString());
+            testRun.add("-cp");
+            String classPath = System.getProperty("java.class.path");
+            testRun.add(classPath);
+            testRun.add(TestSPISigned.class.getSimpleName());
+            testRun.add("run-test");
+            OutputAnalyzer out = ProcessTools.executeTestJvm(testRun.toArray(new String[]{}));
+            out.shouldHaveExitValue(0);
+            out.shouldContain("DEBUG: Getting xx language");
+        }
+    }
+
+    private static void doRunTest() {
+        Locale locale = new Locale("xx", "YY");
+        Calendar kcal = Calendar.getInstance(locale);
+        try {
+            check(WEDNESDAY, kcal.getFirstDayOfWeek());
+            check(7, kcal.getMinimalDaysInFirstWeek());
+        } catch (Throwable ex) {
+            throw new RuntimeException("Test failed with signed jar and " +
+                    " argument java.locale.providers=SPI", ex);
+        }
+    }
+
+    private static <T> void check(T expected, T actual) {
+        Asserts.assertEquals(expected, actual, "Expected calendar from SPI to be in effect");
+    }
+
+}

--- a/jdk/test/java/security/SignedJar/spi-calendar-provider/provider/baz/CalendarDataProviderImpl.java
+++ b/jdk/test/java/security/SignedJar/spi-calendar-provider/provider/baz/CalendarDataProviderImpl.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package baz;
+
+import static java.util.Calendar.*;
+import java.util.Locale;
+import java.util.spi.CalendarDataProvider;
+
+public class CalendarDataProviderImpl extends CalendarDataProvider {
+    private static final Locale[] locales = { new Locale("xx", "YY") };
+
+    @Override
+    public int getFirstDayOfWeek(Locale locale) {
+        return WEDNESDAY;
+    }
+
+    @Override
+    public int getMinimalDaysInFirstWeek(Locale locale) {
+        if (locale.getLanguage().equals("xx")) {
+            System.out.println("DEBUG: Getting xx language");
+        }
+        return 7;
+    }
+
+    @Override
+    public Locale[] getAvailableLocales() {
+        return locales;
+    }
+}

--- a/jdk/test/java/security/SignedJar/spi-calendar-provider/provider/meta/META-INF/services/java.util.spi.CalendarDataProvider
+++ b/jdk/test/java/security/SignedJar/spi-calendar-provider/provider/meta/META-INF/services/java.util.spi.CalendarDataProvider
@@ -1,0 +1,7 @@
+#
+#
+#
+# fully-qualified name of the java.util.spi.CalendarDataProvider
+# implementation class
+#
+baz.CalendarDataProviderImpl


### PR DESCRIPTION
Please review this backport of the regression test for a critical fix which we've included with the January CPU update. The fix was https://bugs.openjdk.org/browse/JDK-8280890

This patch adds an additional regression test which was seen in the wild with JDK 17. The patch isn't clean since the test library in jdk8u is different so needed a bit of a different setup routine for getting the jar with the provider created. Additionally, in jdk 8 the property to add providers is setting `java.ext.dirs=...` over `java.locale.providers=SPI` in later JDKs.

Testing: The test passes for me on the current dev tree and fails with the fix from JDK-8280890 reverted.

Thoughts?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8298108](https://bugs.openjdk.org/browse/JDK-8298108): Add a regression test for JDK-8297684
 * [JDK-8298271](https://bugs.openjdk.org/browse/JDK-8298271): java/security/SignedJar/spi-calendar-provider/TestSPISigned.java failing on Windows


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**) ⚠️ Review applies to [2e937ca2](https://git.openjdk.org/jdk8u-dev/pull/269/files/2e937ca2e1508acf39e56fb6a4836dac7f8679f9)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/269/head:pull/269` \
`$ git checkout pull/269`

Update a local copy of the PR: \
`$ git checkout pull/269` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/269/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 269`

View PR using the GUI difftool: \
`$ git pr show -t 269`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/269.diff">https://git.openjdk.org/jdk8u-dev/pull/269.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/269#issuecomment-1446944011)