### PR TITLE
8303408 : [AIX] Broken jdk8u build after JDK-8266391

### DIFF
--- a/jdk/src/aix/classes/jdk/internal/platform/SystemMetrics.java
+++ b/jdk/src/aix/classes/jdk/internal/platform/SystemMetrics.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.internal.platform;
+
+public class SystemMetrics {
+    public static Metrics instance() {
+        return null;
+    }
+}
+


### PR DESCRIPTION
The AIX build fails  after [JDK-8266391](https://bugs.openjdk.org/browse/JDK-8266391) was backported to jdk8. So, We added null returning SystemMetrics class an aix platform specific class that fixes the build error.

Reported Issue : [JDK-8303408](https://bugs.openjdk.org/browse/JDK-8303408)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303408](https://bugs.openjdk.org/browse/JDK-8303408): [AIX] Broken jdk8u build after JDK-8266391


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/274/head:pull/274` \
`$ git checkout pull/274`

Update a local copy of the PR: \
`$ git checkout pull/274` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/274/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 274`

View PR using the GUI difftool: \
`$ git pr show -t 274`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/274.diff">https://git.openjdk.org/jdk8u-dev/pull/274.diff</a>

</details>
