### PR TITLE
8264728: When use chinese IME, the candidate box isn't moved with caret of JTextArea

### DIFF
--- a/jdk/make/mapfiles/libawt_xawt/mapfile-vers
+++ b/jdk/make/mapfiles/libawt_xawt/mapfile-vers
@@ -275,6 +275,7 @@ SUNWprivate_1.1 {
         Java_sun_awt_X11_XInputMethod_createXICNative;
         Java_sun_awt_X11_XInputMethod_setXICFocusNative;
         Java_sun_awt_X11_XInputMethod_adjustStatusWindow;
+        Java_sun_awt_X11_XInputMethod_moveCandidateWindow;
         Java_sun_awt_X11_XlibWrapper_XQueryPointer;
         Java_sun_awt_X11_XlibWrapper_XFreeCursor;
         Java_sun_awt_X11_XToolkit_getDefaultXColormap;

--- a/jdk/src/solaris/classes/sun/awt/X11/XInputMethod.java
+++ b/jdk/src/solaris/classes/sun/awt/X11/XInputMethod.java
@@ -25,10 +25,16 @@
 
 package sun.awt.X11;
 
+import java.awt.AWTEvent;
 import java.awt.AWTException;
 import java.awt.Component;
 import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.Point;
 import java.awt.Rectangle;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseEvent;
+import java.awt.font.TextHitInfo;
 import java.awt.im.spi.InputMethodContext;
 import java.awt.peer.ComponentPeer;
 import sun.awt.X11InputMethod;
@@ -43,11 +49,15 @@ import sun.util.logging.PlatformLogger;
 public class XInputMethod extends X11InputMethod {
     private static final PlatformLogger log = PlatformLogger.getLogger("sun.awt.X11.XInputMethod");
 
+    private InputMethodContext inputContext;
+
     public XInputMethod() throws AWTException {
         super();
     }
 
+    @Override
     public void setInputMethodContext(InputMethodContext context) {
+        this.inputContext = context;
         context.enableClientWindowNotification(this, true);
     }
 
@@ -56,6 +66,9 @@ public class XInputMethod extends X11InputMethod {
         if (peer != null) {
             adjustStatusWindow(peer.getContentWindow());
         }
+
+        //After window moved, this would called.
+        positionCandidateWindow();
     }
 
     protected boolean openXIM() {
@@ -141,6 +154,63 @@ public class XInputMethod extends X11InputMethod {
         return (long)((XWindow)clientComponentWindow.getPeer()).getContentWindow();
     }
 
+    @Override
+    public void dispatchEvent(AWTEvent e) {
+        switch (e.getID()) {
+            case KeyEvent.KEY_PRESSED:
+            case KeyEvent.KEY_RELEASED:
+            case MouseEvent.MOUSE_CLICKED:
+                positionCandidateWindow();
+                break;
+
+            default:
+                break;
+        }
+    }
+
+    private void positionCandidateWindow() {
+        if (this.inputContext == null) {
+            return;
+        }
+
+        Component client = getClientComponent();
+
+        if (client == null || !client.isShowing()) {
+            return;
+        }
+
+        int x = 0;
+        int y = 0;
+
+        // Get this textcomponent coordinate from root window.
+        Component temp = client;
+        while (temp != null) {
+             Component parent = temp.getParent();
+             if (parent == null) {
+                 break;
+             }
+
+             x += temp.getX();
+             y += temp.getY();
+             temp = parent;
+        }
+
+        if (haveActiveClient()) {
+            Rectangle rc = inputContext.getTextLocation(TextHitInfo.leading(0));
+            x += rc.x;
+            y += rc.y + rc.height;
+
+            Point p = client.getLocationOnScreen();
+            x -= p.x;
+            y -= p.y;
+        } else {
+            Dimension size = client.getSize();
+            y += size.height;
+        }
+
+        moveCandidateWindow(x, y);
+    }
+
     /*
      * Native methods
      */
@@ -149,4 +219,5 @@ public class XInputMethod extends X11InputMethod {
     private native void setXICFocusNative(long window,
                                     boolean value, boolean active);
     private native void adjustStatusWindow(long window);
+    private native void moveCandidateWindow(int x, int y);
 }

--- a/jdk/src/solaris/native/sun/awt/awt_InputMethod.c
+++ b/jdk/src/solaris/native/sun/awt/awt_InputMethod.c
@@ -1651,3 +1651,30 @@ JNIEXPORT void JNICALL Java_sun_awt_X11_XInputMethod_adjustStatusWindow
     AWT_UNLOCK();
 #endif
 }
+
+JNIEXPORT void JNICALL Java_sun_awt_X11_XInputMethod_moveCandidateWindow
+ (JNIEnv *env, jobject this, jint x, jint y)
+{
+    X11InputMethodData *pX11IMData;
+    XVaNestedList preedit_attr;
+    XPoint nspot;
+
+    nspot.x = x;
+    nspot.y = y;
+
+    AWT_LOCK();
+
+    pX11IMData = getX11InputMethodData(env, this);
+
+    if ((pX11IMData == NULL) || (pX11IMData->current_ic == NULL)) {
+        AWT_UNLOCK();
+        return;
+    }
+
+    preedit_attr = XVaCreateNestedList(0, XNSpotLocation, &nspot, NULL);
+    XSetICValues(pX11IMData->current_ic, XNPreeditAttributes, preedit_attr, NULL);
+
+    XFree(preedit_attr);
+
+    AWT_UNLOCK();
+}


### PR DESCRIPTION
JDK-8264728 : When use chinese IME, the candidate box isn't moved with caret of JTextArea
Type: Bug
Component: client-libs
Sub-Component: java.awt:i18n
Affected Version: 8,9,15,16
Priority: P3
Status: Open
Resolution: Unresolved
OS: linux
CPU: x86_64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8264728](https://bugs.openjdk.org/browse/JDK-8264728): When use chinese IME, the candidate box isn't moved with caret of JTextArea


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/281/head:pull/281` \
`$ git checkout pull/281`

Update a local copy of the PR: \
`$ git checkout pull/281` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/281/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 281`

View PR using the GUI difftool: \
`$ git pr show -t 281`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/281.diff">https://git.openjdk.org/jdk8u-dev/pull/281.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/281#issuecomment-1463049492)