### PR TITLE
8282600: SSLSocketImpl should not use user_canceled workaround when not necessary

### DIFF
--- a/jdk/src/share/classes/sun/security/ssl/SSLSocketImpl.java
+++ b/jdk/src/share/classes/sun/security/ssl/SSLSocketImpl.java
@@ -615,8 +615,12 @@ public final class SSLSocketImpl
             if (!conContext.protocolVersion.useTLS13PlusSpec()) {
                 hasCloseReceipt = true;
             } else {
-                // Use a user_canceled alert for TLS 1.3 duplex close.
-                useUserCanceled = true;
+                // Do not use user_canceled workaround if the other side has
+                // already half-closed the connection
+                if (!conContext.isInboundClosed()) {
+                    // Use a user_canceled alert for TLS 1.3 duplex close.
+                    useUserCanceled = true;
+                }
             }
         } else if (conContext.handshakeContext != null) {   // initial handshake
             // Use user_canceled alert regardless the protocol versions.


### PR DESCRIPTION
Backport from [jdk11u-dev](https://github.com/openjdk/jdk11u-dev/commit/e80528bf2bd1c87fc1394dd32015281ac6652363#commitcomment-104263811) fixing SSLSocket, not to use workaround with user_canceled alert for TLS 1.3 close, when not necessary, as it causes problems with gnutls client.

Testing:
[jdk_security](https://github.com/zzambers/jdk-tester/actions/runs/4408247017/jobs/7723001910) OK (no regressions to [master](https://github.com/zzambers/jdk-tester/actions/runs/4407115132/jobs/7720330395)).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282600](https://bugs.openjdk.org/browse/JDK-8282600): SSLSocketImpl should not use user_canceled workaround when not necessary


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/284/head:pull/284` \
`$ git checkout pull/284`

Update a local copy of the PR: \
`$ git checkout pull/284` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/284/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 284`

View PR using the GUI difftool: \
`$ git pr show -t 284`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/284.diff">https://git.openjdk.org/jdk8u-dev/pull/284.diff</a>

</details>
