### PR TITLE
Backport 24a9e0ac188a37dc57cc4d1bb8d8635abb4c4f89

### DIFF
--- a/hotspot/test/TEST.ROOT
+++ b/hotspot/test/TEST.ROOT
@@ -34,4 +34,6 @@ groups=TEST.groups [closed/TEST.groups]
 # Source files for classes that will be used at the beginning of each test suite run,
 # to determine additional characteristics of the system for use with the @requires tag.
 requires.extraPropDefns = ../../test/jtreg-ext/requires/VMProps.java
-requires.properties=sun.arch.data.model
+requires.properties=sun.arch.data.model \
+    vm.flavor \
+    vm.bits

--- a/hotspot/test/TEST.ROOT
+++ b/hotspot/test/TEST.ROOT
@@ -30,4 +30,8 @@
 keys=cte_test jcmd nmt regression gc stress
 
 groups=TEST.groups [closed/TEST.groups]
+
+# Source files for classes that will be used at the beginning of each test suite run,
+# to determine additional characteristics of the system for use with the @requires tag.
+requires.extraPropDefns = ../../test/jtreg-ext/requires/VMProps.java
 requires.properties=sun.arch.data.model

--- a/hotspot/test/runtime/Metaspace/MaxMetaspaceSizeTest.java
+++ b/hotspot/test/runtime/Metaspace/MaxMetaspaceSizeTest.java
@@ -23,10 +23,10 @@
 
 import com.oracle.java.testlibrary.ProcessTools;
 import com.oracle.java.testlibrary.OutputAnalyzer;
-import com.oracle.java.testlibrary.Platform;
 
 /*
  * @test MaxMetaspaceSizeTest
+ * @requires vm.bits == "64"
  * @bug 8087291
  * @library /testlibrary
  * @run main/othervm MaxMetaspaceSizeTest
@@ -34,10 +34,6 @@ import com.oracle.java.testlibrary.Platform;
 
 public class MaxMetaspaceSizeTest {
     public static void main(String... args) throws Exception {
-        if (!Platform.is64bit()) {
-            System.out.println("Test requires 64-bit JVM. Skipping...");
-            return;
-        }
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
             "-Xmx1g",
             "-XX:InitialBootClassLoaderMetaspaceSize=4195328",

--- a/hotspot/test/runtime/NMT/HugeArenaTracking.java
+++ b/hotspot/test/runtime/NMT/HugeArenaTracking.java
@@ -25,6 +25,7 @@
  * @test
  * @key nmt jcmd
  * @library /testlibrary /testlibrary/whitebox
+ * @requires vm.bits == 64
  * @build HugeArenaTracking
  * @run main ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:NativeMemoryTracking=detail HugeArenaTracking
@@ -38,10 +39,6 @@ public class HugeArenaTracking {
   private static final long GB = 1024 * 1024 * 1024;
 
   public static void main(String args[]) throws Exception {
-    if (!Platform.is64bit()) {
-        System.out.println("Test requires 64-bit JVM. Skipping...");
-        return;
-    }
     OutputAnalyzer output;
     final WhiteBox wb = WhiteBox.getWhiteBox();
 

--- a/hotspot/test/runtime/SharedArchiveFile/DefaultUseWithClient.java
+++ b/hotspot/test/runtime/SharedArchiveFile/DefaultUseWithClient.java
@@ -24,8 +24,9 @@
 /*
  * @test DefaultUseWithClient
  * @summary Test default behavior of sharing with -client
+ * @requires os.family == "windows" & vm.bits == "32" & vm.flavor == "client"
  * @library /testlibrary
- * @run main/othervm -client DefaultUseWithClient
+ * @run main/othervm DefaultUseWithClient
  * @bug 8032224
  */
 
@@ -38,11 +39,6 @@ public class DefaultUseWithClient {
 
         // On 32-bit windows CDS should be on by default in "-client" config
         // Skip this test on any other platform
-        boolean is32BitWindowsClient = (Platform.isWindows() && Platform.is32bit() && Platform.isClient());
-        if (!is32BitWindowsClient) {
-            System.out.println("Test only applicable on 32-bit Windows Client VM. Skipping");
-            return;
-        }
 
         // create the archive
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package requires;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * The Class to be invoked by jtreg prior Test Suite execution to
+ * collect information about VM.
+ * Properties set by this Class will be available in the @requires expressions.
+ */
+public class VMProps implements Callable<Map<String, String>> {
+
+    /**
+     * Collects information about VM properties.
+     * This method will be invoked by jtreg.
+     *
+     * @return Map of property-value pairs.
+     */
+    @Override
+    public Map<String, String> call() {
+        Map<String, String> map = new HashMap<>();
+        map.put("vm.flavor", vmFlavor());
+        map.put("vm.compMode", vmCompMode());
+        map.put("vm.bits", vmBits());
+        dump(map);
+        return map;
+    }
+
+    /**
+     * @return VM type value extracted from the "java.vm.name" property.
+     */
+    protected String vmFlavor() {
+        // E.g. "Java HotSpot(TM) 64-Bit Server VM"
+        String vmName = System.getProperty("java.vm.name");
+        if (vmName == null) {
+            return null;
+        }
+
+        Pattern startP = Pattern.compile(".* (\\S+) VM");
+        Matcher m = startP.matcher(vmName);
+        if (m.matches()) {
+            return m.group(1).toLowerCase();
+        }
+        return null;
+    }
+
+    /**
+     * @return VM compilation mode extracted from the "java.vm.info" property.
+     */
+    protected String vmCompMode() {
+        // E.g. "mixed mode"
+        String vmInfo = System.getProperty("java.vm.info");
+        if (vmInfo == null) {
+            return null;
+        }
+        int k = vmInfo.toLowerCase().indexOf(" mode");
+        if (k < 0) {
+            return null;
+        }
+        vmInfo = vmInfo.substring(0, k);
+        switch (vmInfo) {
+            case "mixed" : return "Xmixed";
+            case "compiled" : return "Xcomp";
+            case "interpreted" : return "Xint";
+            default: return null;
+        }
+    }
+
+    /**
+     * @return VM bitness, the value of the "sun.arch.data.model" property.
+     */
+    protected String vmBits() {
+        return System.getProperty("sun.arch.data.model");
+    }
+
+    /**
+     * Dumps the map to the file if the file name is given as the property.
+     * This functionality could be helpful to know context in the real
+     * execution.
+     *
+     * @param map
+     */
+    protected void dump(Map<String, String> map) {
+        String dumpFileName = System.getProperty("vmprops.dump");
+        if (dumpFileName == null) {
+            return;
+        }
+        List<String> lines = new ArrayList<>();
+        map.forEach((k,v) -> lines.add(k + ":" + v));
+        try {
+             Files.write(Paths.get(dumpFileName), lines);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to dump properties into '"
+                    + dumpFileName + "'", e);
+        }
+    }
+
+    /**
+     * This method is for the testing purpose only.
+     * @param args
+     */
+    public static void main(String args[]) {
+        Map<String, String> map = new VMProps().call();
+        map.forEach((k,v) -> System.out.println(k + ": '" + v + "'"));
+    }
+}


### PR DESCRIPTION
This is backport[1][2] of code adds support for jtreg vm properties (`vm.flavor`, `vm.compMode`, `vm.bits`) for use in `@requires` 

First commit is backport Itself.

Second commit switches some tests back to use `@requires` (2 are basically reverts [3][4] of jdk8u specific changes, 3rd updated test is not present in newer jdks [5][6])
These updated tests were used to test new properties, so I included them here. (However I can exclude them if requested)

Testing:
Updated tests are part of hotspot tier1, which is executed in GitHub (Which confirms it works).

[1] https://github.com/openjdk/jdk9u/commit/24a9e0ac188a37dc57cc4d1bb8d8635abb4c4f89
[2] https://github.com/openjdk/jdk9u/commit/2b7a70a9d3d9b4ca94605d22d3d4f3c78a5c8d8b
[3] https://github.com/openjdk/jdk8u-dev/pull/222
[4] https://github.com/openjdk/jdk8u-dev/pull/182
[5] https://bugs.openjdk.org/browse/JDK-8154204
[6] https://github.com/openjdk/jdk8u-dev/pull/181