### PR TITLE
Backport 939741c0a0a4a5ce2c68d14b15e1f42563bc653d

### DIFF
--- a/jdk/src/share/classes/sun/security/pkcs11/SessionManager.java
+++ b/jdk/src/share/classes/sun/security/pkcs11/SessionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -202,7 +202,12 @@ final class SessionManager {
             // will be added to correct pool on release, nothing to do now
             return;
         }
-        opSessions.release(session);
+        // Objects could have been added to this session by other thread between
+        // check in Session.removeObject method and objSessions.remove call
+        // higher. Therefore releaseSession method, which performs additional
+        // check for objects, is used here to avoid placing this session
+        // in wrong pool due to race condition.
+        releaseSession(session);
     }
 
     private Session openSession() throws PKCS11Exception {


### PR DESCRIPTION
Backport from [jdk11u-dev](https://github.com/openjdk/jdk11u-dev/commit/939741c0a0a4a5ce2c68d14b15e1f42563bc653d) - fix for race condition in pkcs11 SessionManager.

Clean except for copyright date.

Testing:
[jdk_security](https://github.com/zzambers/jdk-tester/actions/runs/4427088716/jobs/7764206204) OK (no regressions to [master](https://github.com/zzambers/jdk-tester/actions/runs/4407115132/jobs/7720330395)).