### PR TITLE
8048076: [TESTBUG] runtime/Unsafe/RangeCheck.java fails with -Xcomp

### DIFF
--- a/hotspot/test/runtime/Unsafe/RangeCheck.java
+++ b/hotspot/test/runtime/Unsafe/RangeCheck.java
@@ -43,6 +43,7 @@ public class RangeCheck {
                 true,
                 "-Xmx32m",
                 "-XX:-TransmitErrorReport",
+                "-XX:-InlineUnsafeOps", // The compiler intrinsics doesn't have the assert
                 DummyClassWithMainRangeCheck.class.getName());
 
         OutputAnalyzer output = new OutputAnalyzer(pb.start());


### PR DESCRIPTION
Backport from https://hg.openjdk.org/jdk9/jdk9/hotspot/rev/51b82a72aafb

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8048076](https://bugs.openjdk.org/browse/JDK-8048076): [TESTBUG] runtime/Unsafe/RangeCheck.java fails with -Xcomp


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/289/head:pull/289` \
`$ git checkout pull/289`

Update a local copy of the PR: \
`$ git checkout pull/289` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/289/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 289`

View PR using the GUI difftool: \
`$ git pr show -t 289`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/289.diff">https://git.openjdk.org/jdk8u-dev/pull/289.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/289#issuecomment-1471742335)