### PR TITLE
8302791: Add specific ClassLoader object to Proxy IllegalArgumentException message

### DIFF
--- a/jdk/src/share/classes/java/lang/reflect/Proxy.java
+++ b/jdk/src/share/classes/java/lang/reflect/Proxy.java
@@ -579,7 +579,7 @@ public class Proxy implements java.io.Serializable {
                 }
                 if (interfaceClass != intf) {
                     throw new IllegalArgumentException(
-                        intf + " is not visible from class loader");
+                        intf + " is not visible from class loader: " + loader);
                 }
                 /*
                  * Verify that the Class object actually represents an


### PR DESCRIPTION
Added specific class loader object to proxy IllegalArgumentException from which the class was not visible

The bug report for the same: https://bugs.openjdk.org/browse/JDK-8302791

OpenJDK PR: https://github.com/openjdk/jdk/pull/12641

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302791](https://bugs.openjdk.org/browse/JDK-8302791): Add specific ClassLoader object to Proxy IllegalArgumentException message


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev pull/290/head:pull/290` \
`$ git checkout pull/290`

Update a local copy of the PR: \
`$ git checkout pull/290` \
`$ git pull https://git.openjdk.org/jdk8u-dev pull/290/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 290`

View PR using the GUI difftool: \
`$ git pr show -t 290`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/290.diff">https://git.openjdk.org/jdk8u-dev/pull/290.diff</a>

</details>
