### PR TITLE
8305165: [8u] ServiceThread::nmethods_do is not called to keep nmethods from being zombied while in the queue

### DIFF
--- a/hotspot/src/share/vm/runtime/thread.hpp
+++ b/hotspot/src/share/vm/runtime/thread.hpp
@@ -508,7 +508,7 @@ public:
   }
 
   // Sweeper support
-  void nmethods_do(CodeBlobClosure* cf);
+  virtual void nmethods_do(CodeBlobClosure* cf);
 
   // jvmtiRedefineClasses support
   void metadata_do(void f(Metadata*));

--- a/hotspot/src/share/vm/runtime/thread.hpp
+++ b/hotspot/src/share/vm/runtime/thread.hpp
@@ -1450,10 +1450,10 @@ class JavaThread: public Thread {
   void frames_do(void f(frame*, const RegisterMap*));
 
   // Memory operations
-  void oops_do(OopClosure* f, CLDClosure* cld_f, CodeBlobClosure* cf);
+  virtual void oops_do(OopClosure* f, CLDClosure* cld_f, CodeBlobClosure* cf);
 
   // Sweeper operations
-  void nmethods_do(CodeBlobClosure* cf);
+  virtual void nmethods_do(CodeBlobClosure* cf);
 
   // RedefineClasses Support
   void metadata_do(void f(Metadata*));


### PR DESCRIPTION
Various Crashes in JvmtiExport::post_compiled_method_load were found in
our production environment after users started to receive the JVMTI
COMPILED_METHOD_LOAD event.
ServiceThread::nmethods_do should have been called to keep nmethods from
being zombied while in the JvmtiDeferredEventQueue, but
JavaThead::nmethods_do is called at present.
Make a virtual function call to the correct method to fix this issue.
With the fix, various crashes were gone.
This issue only exists in 8u.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305165](https://bugs.openjdk.org/browse/JDK-8305165): [8u] ServiceThread::nmethods_do is not called to keep nmethods from being zombied while in the queue


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/293/head:pull/293` \
`$ git checkout pull/293`

Update a local copy of the PR: \
`$ git checkout pull/293` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/293/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 293`

View PR using the GUI difftool: \
`$ git pr show -t 293`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/293.diff">https://git.openjdk.org/jdk8u-dev/pull/293.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/293#issuecomment-1488298944)