### PR TITLE
8276841: Add support for Visual Studio 2022

### DIFF
--- a/common/autoconf/generated-configure.sh
+++ b/common/autoconf/generated-configure.sh
@@ -4308,7 +4308,7 @@ TOOLCHAIN_DESCRIPTION_xlc="IBM XL C/C++"
 
 ################################################################################
 # The order of these defines the priority by which we try to find them.
-VALID_VS_VERSIONS="2010 2012 2013 2015 2017 2019"
+VALID_VS_VERSIONS="2010 2012 2013 2015 2017 2019 2022"
 
 VS_DESCRIPTION_2010="Microsoft Visual Studio 2010"
 VS_VERSION_INTERNAL_2010=100
@@ -4380,6 +4380,21 @@ VS_VS_PLATFORM_NAME_2019="v142"
 VS_SDK_PLATFORM_NAME_2019=
 VS_SUPPORTED_2019=false
 VS_TOOLSET_SUPPORTED_2019=false
+
+VS_DESCRIPTION_2022="Microsoft Visual Studio 2022"
+VS_VERSION_INTERNAL_2022=143
+VS_MSVCR_2022=vcruntime140.dll
+VS_VCRUNTIME_1_2022=vcruntime140_1.dll
+VS_MSVCP_2022=msvcp140.dll
+VS_ENVVAR_2022="VS170COMNTOOLS"
+VS_USE_UCRT_2022="true"
+VS_VS_INSTALLDIR_2022="Microsoft Visual Studio/2022"
+VS_EDITIONS_2022="BuildTools Community Professional Enterprise"
+VS_SDK_INSTALLDIR_2022=
+VS_VS_PLATFORM_NAME_2022="v143"
+VS_SDK_PLATFORM_NAME_2022=
+VS_SUPPORTED_2022=true
+VS_TOOLSET_SUPPORTED_2022=true
 
 ################################################################################
 

--- a/common/autoconf/toolchain_windows.m4
+++ b/common/autoconf/toolchain_windows.m4
@@ -25,7 +25,7 @@
 
 ################################################################################
 # The order of these defines the priority by which we try to find them.
-VALID_VS_VERSIONS="2010 2012 2013 2015 2017 2019"
+VALID_VS_VERSIONS="2010 2012 2013 2015 2017 2019 2022"
 
 VS_DESCRIPTION_2010="Microsoft Visual Studio 2010"
 VS_VERSION_INTERNAL_2010=100
@@ -97,6 +97,21 @@ VS_VS_PLATFORM_NAME_2019="v142"
 VS_SDK_PLATFORM_NAME_2019=
 VS_SUPPORTED_2019=false
 VS_TOOLSET_SUPPORTED_2019=false
+
+VS_DESCRIPTION_2022="Microsoft Visual Studio 2022"
+VS_VERSION_INTERNAL_2022=143
+VS_MSVCR_2022=vcruntime140.dll
+VS_VCRUNTIME_1_2022=vcruntime140_1.dll
+VS_MSVCP_2022=msvcp140.dll
+VS_ENVVAR_2022="VS170COMNTOOLS"
+VS_USE_UCRT_2022="true"
+VS_VS_INSTALLDIR_2022="Microsoft Visual Studio/2022"
+VS_EDITIONS_2022="BuildTools Community Professional Enterprise"
+VS_SDK_INSTALLDIR_2022=
+VS_VS_PLATFORM_NAME_2022="v143"
+VS_SDK_PLATFORM_NAME_2022=
+VS_SUPPORTED_2022=true
+VS_TOOLSET_SUPPORTED_2022=true
 
 ################################################################################
 


### PR DESCRIPTION
This is a backport of the fix from jdk11u-dev repository: https://github.com/openjdk/jdk11u-dev/commit/0ba5a81e7c0117855665a28a43f9589635e94222
The fix is a parity fix for JDK-8298996 in 8u371 from Oracle.

The fix is manually merged with jdk8u-dev because it has conflicts in lines before the fix:
jdk11u-dev: `VALID_VS_VERSIONS="2017 2019 2013 2015 2012 2010"`
jdk8u-dev: `VALID_VS_VERSIONS="2010 2012 2013 2015 2017 2019"`
The conflict is resolved so `2022` year is placed after `2019` in jdk8u-dev.

The other part is backported as is into jdk8u-dev. The `generated-configure.sh` file is updated as well.

To test the fix the jdk8u-dev was built on Windows Server 2012 R2 with:
```
* Toolchain:      microsoft (Microsoft Visual Studio 2022 17.5.2 (devkit))
* C Compiler:     Version 19.31.31107 (at /cygdrive/c/cygwin64/VS2022-17.5.2-devkit/VC/bin/x64/cl)
* C++ Compiler:   Version 19.31.31107 (at /cygdrive/c/cygwin64/VS2022-17.5.2-devkit/VC/bin/x64/cl)
```
and hotspot and compact3 tests were run. There were only 3 new failed tests comparing to the build without the fix.
 ```
jdk/internal/platform/cgroup/TestCgroupMetrics.java.TestCgroupMetrics
jdk/internal/platform/docker/TestDockerMemoryMetrics.java.TestDockerMemoryMetrics
jdk/internal/platform/docker/TestSystemMetrics.java.TestSystemMetrics
```
The first test passes after the second run. 
I rerun the tests with build without the fix and these 3 tests failed as well.
It looks like that these failures actually are not related to the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8276841](https://bugs.openjdk.org/browse/JDK-8276841): Add support for Visual Studio 2022


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**) ⚠️ Review applies to [5261d020](https://git.openjdk.org/jdk8u-dev/pull/295/files/5261d02069f03cd580753317a9fcdd2d8ffd9988)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/295/head:pull/295` \
`$ git checkout pull/295`

Update a local copy of the PR: \
`$ git checkout pull/295` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/295/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 295`

View PR using the GUI difftool: \
`$ git pr show -t 295`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/295.diff">https://git.openjdk.org/jdk8u-dev/pull/295.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/295#issuecomment-1492099776)