### PR TITLE
8282345: handle latest VS2022 in abstract_vm_version

### DIFF
--- a/hotspot/src/share/vm/runtime/vm_version.cpp
+++ b/hotspot/src/share/vm/runtime/vm_version.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -263,6 +263,10 @@ const char* Abstract_VM_Version::internal_vm_info_string() {
         #define HOTSPOT_BUILD_COMPILER "MS VC++ 16.8 / 16.9 (VS2019)"
       #elif _MSC_VER == 1929
         #define HOTSPOT_BUILD_COMPILER "MS VC++ 16.10 / 16.11 (VS2019)"
+      #elif _MSC_VER == 1930
+        #define HOTSPOT_BUILD_COMPILER "MS VC++ 17.0 (VS2022)"
+      #elif _MSC_VER == 1931
+        #define HOTSPOT_BUILD_COMPILER "MS VC++ 17.1 (VS2022)"
       #else
         #define HOTSPOT_BUILD_COMPILER "unknown MS VC++:" XSTR(_MSC_VER)
       #endif


### PR DESCRIPTION
This is a backport of the [JDK-8282345 handle latest VS2022 in abstract_vm_version](https://bugs.openjdk.org/browse/JDK-8282345) from jdk11u-dev repository.

It is a parity fix for [JDK-8299000 handle latest VS2022 in abstract_vm_version](https://bugs.openjdk.org/browse/JDK-8299000) in Oracle 8u371

There is only one conflict resolved with the copyright year.
jdk11u-dev:
```
- * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
```
jdk8u-dev:
```
- * Copyright (c) 1998, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
```

I would like to backport it as additional fix for the https://github.com/openjdk/jdk8u-dev/pull/295 `8276841: Add support for Visual Studio 2022`

Both backports the current one and  the `8276841` were built on  Windows Server 2012 R2 with:
```
* Toolchain:      microsoft (Microsoft Visual Studio 2022 17.5.2 (devkit))
* C Compiler:     Version 19.31.31107 (at /cygdrive/c/cygwin64/VS2022-17.5.2-devkit/VC/bin/x64/cl)
* C++ Compiler:   Version 19.31.31107 (at /cygdrive/c/cygwin64/VS2022-17.5.2-devkit/VC/bin/x64/cl)
```
and hotspot and compact3 tests were run. There were no failed tests comparing to the build without the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282345](https://bugs.openjdk.org/browse/JDK-8282345): handle latest VS2022 in abstract_vm_version


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**) ⚠️ Review applies to [d9408dcb](https://git.openjdk.org/jdk8u-dev/pull/299/files/d9408dcbd88c1be733c96bb16f0eff3ddec7f136)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/299/head:pull/299` \
`$ git checkout pull/299`

Update a local copy of the PR: \
`$ git checkout pull/299` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/299/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 299`

View PR using the GUI difftool: \
`$ git pr show -t 299`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/299.diff">https://git.openjdk.org/jdk8u-dev/pull/299.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/299#issuecomment-1502137926)