### PR TITLE
Backport d30aeec30c3832b2514a6f06451897afdaf52fb3

### DIFF
--- a/hotspot/test/gc/metaspace/TestMetaspacePerfCounters.java
+++ b/hotspot/test/gc/metaspace/TestMetaspacePerfCounters.java
@@ -81,6 +81,9 @@ public class TestMetaspacePerfCounters {
     }
 
     private static void checkUsedIncreasesWhenLoadingClass(String ns) throws Exception {
+        // Need to ensure that used is up to date and that all unreachable
+        // classes are unloaded before doing this check.
+        System.gc();
         long before = getUsed(ns);
         fooClass = compileAndLoad("Foo", "public class Foo { }");
         System.gc();

--- a/hotspot/test/gc/metaspace/TestPerfCountersAndMemoryPools.java
+++ b/hotspot/test/gc/metaspace/TestPerfCountersAndMemoryPools.java
@@ -61,14 +61,18 @@ public class TestPerfCountersAndMemoryPools {
         throws Exception {
         MemoryPoolMXBean pool = getMemoryPool(memoryPoolName);
 
+        // First, call all the methods to let them allocate their own slab of metadata
+        getMinCapacity(perfNS);
+        getCapacity(perfNS);
+        getUsed(perfNS);
+        pool.getUsage().getInit();
+        pool.getUsage().getUsed();
+        pool.getUsage().getCommitted();
+        assertEQ(1L, 1L);
+
         // Must do a GC to update performance counters
         System.gc();
         assertEQ(getMinCapacity(perfNS), pool.getUsage().getInit());
-
-        // Must do a second GC to update the perfomance counters again, since
-        // the call pool.getUsage().getInit() could have allocated some
-        // metadata.
-        System.gc();
         assertEQ(getUsed(perfNS), pool.getUsage().getUsed());
         assertEQ(getCapacity(perfNS), pool.getUsage().getCommitted());
     }

--- a/hotspot/test/gc/metaspace/TestPerfCountersAndMemoryPools.java
+++ b/hotspot/test/gc/metaspace/TestPerfCountersAndMemoryPools.java
@@ -33,14 +33,14 @@ import static com.oracle.java.testlibrary.Asserts.*;
  * @requires vm.gc=="Serial" | vm.gc=="null"
  * @summary Tests that a MemoryPoolMXBeans and PerfCounters for metaspace
  *          report the same data.
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-UseCompressedOops -XX:-UseCompressedKlassPointers -XX:+UseSerialGC -XX:+UsePerfData -Xint TestPerfCountersAndMemoryPools
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UseCompressedOops -XX:+UseCompressedKlassPointers -XX:+UseSerialGC -XX:+UsePerfData -Xint TestPerfCountersAndMemoryPools
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-UseCompressedOops -XX:-UseCompressedClassPointers -XX:+UseSerialGC -XX:+UsePerfData -Xint TestPerfCountersAndMemoryPools
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UseCompressedOops -XX:+UseCompressedClassPointers -XX:+UseSerialGC -XX:+UsePerfData -Xint TestPerfCountersAndMemoryPools
  */
 public class TestPerfCountersAndMemoryPools {
     public static void main(String[] args) throws Exception {
         checkMemoryUsage("Metaspace", "sun.gc.metaspace");
 
-        if (InputArguments.contains("-XX:+UseCompressedKlassPointers") && Platform.is64bit()) {
+        if (InputArguments.contains("-XX:+UseCompressedClassPointers") && Platform.is64bit()) {
             checkMemoryUsage("Compressed Class Space", "sun.gc.compressedclassspace");
         }
     }
@@ -68,13 +68,17 @@ public class TestPerfCountersAndMemoryPools {
         pool.getUsage().getInit();
         pool.getUsage().getUsed();
         pool.getUsage().getCommitted();
-        assertEQ(1L, 1L);
+        assertEQ(1L, 1L, "Make assert load");
 
         // Must do a GC to update performance counters
         System.gc();
-        assertEQ(getMinCapacity(perfNS), pool.getUsage().getInit());
-        assertEQ(getUsed(perfNS), pool.getUsage().getUsed());
-        assertEQ(getCapacity(perfNS), pool.getUsage().getCommitted());
+        assertEQ(getMinCapacity(perfNS), pool.getUsage().getInit(), "MinCapacity out of sync");
+
+        // Adding a second GC due to metadata allocations caused by getting the
+        // initial size from the pool. This is needed when running with -Xcomp.
+        System.gc();
+        assertEQ(getUsed(perfNS), pool.getUsage().getUsed(), "Used out of sync");
+        assertEQ(getCapacity(perfNS), pool.getUsage().getCommitted(), "Committed out of sync");
     }
 
     private static long getMinCapacity(String ns) throws Exception {


### PR DESCRIPTION
To reduce intermittent errors from TestPerfCountersAndMemoryPools, I'd like to backport "8151460: Metaspace counters can have inconsistent values".

This does not backport cleanly since JEP 280 [1] modified the test, and I won't backport that one of course. Therefore I also added the test-specific fix JEP 280 did (https://github.com/openjdk/jdk8u-dev/commit/24773b47512b522c9bfa346559a34138d900b77e).

Tests: I manually ran gc/metaspace jtreg tests on Linux x64 with fastdebug and release builds.

[1] https://bugs.openjdk.org/browse/JDK-8148483