### PR TITLE
8285515: (dc) DatagramChannel.disconnect fails with "Invalid argument" on macOS 12.4

### DIFF
--- a/jdk/test/java/nio/channels/DatagramChannel/Disconnect.java
+++ b/jdk/test/java/nio/channels/DatagramChannel/Disconnect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,8 @@
  */
 
 /* @test
- * @bug 7132924
+ * @bug 7132924 8285515
+ * @key intermittent
  * @summary Test DatagramChannel.disconnect when DatagramChannel is connected to an IPv4 socket
  * @run main Disconnect
  * @run main/othervm -Djava.net.preferIPv4Stack=true Disconnect


### PR DESCRIPTION
Backport-of: 269eae61894b6bd0a7512045a369b53df747f6e5

Backport is not clean, because 8167295 has not been backported to jdk8u.

This fixes a bug in common network code with MacOS, and it is already fixed in all other JDK releases. See the [JBS issue](https://bugs.openjdk.org/browse/JDK-8285515) for more info

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285515](https://bugs.openjdk.org/browse/JDK-8285515): (dc) DatagramChannel.disconnect fails with "Invalid argument" on macOS 12.4


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/303/head:pull/303` \
`$ git checkout pull/303`

Update a local copy of the PR: \
`$ git checkout pull/303` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/303/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 303`

View PR using the GUI difftool: \
`$ git pr show -t 303`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/303.diff">https://git.openjdk.org/jdk8u-dev/pull/303.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/303#issuecomment-1507478494)