### PR TITLE
8159690: [TESTBUG] Mark headful tests with @key headful.

### DIFF
--- a/jdk/test/com/sun/awt/SecurityWarning/GetSizeShouldNotReturnZero.java
+++ b/jdk/test/com/sun/awt/SecurityWarning/GetSizeShouldNotReturnZero.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test %W% %E%
+  @key headful
   @bug 6818312
   @summary The size returned by SecurityWarning.getSize() should not be zero
   @author anthony.petrov@sun.com: area=awt.toplevel

--- a/jdk/test/com/sun/awt/Translucency/WindowOpacity.java
+++ b/jdk/test/com/sun/awt/Translucency/WindowOpacity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test %W% %E%
+  @key headful
   @bug 6594131
   @summary Tests the AWTUtilities.get/setWindowOpacity() methods
   @author anthony.petrov@...: area=awt.toplevel

--- a/jdk/test/java/awt/Choice/ChoiceKeyEventReaction/ChoiceKeyEventReaction.html
+++ b/jdk/test/java/awt/Choice/ChoiceKeyEventReaction/ChoiceKeyEventReaction.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--  
   @test
+  @key headful
   @bug 6252982
   @summary PIT: Keyboard FocusTraversal not working when choice's drop-down is visible, on XToolkit
   @author andrei.dmitriev : area=awt.choice

--- a/jdk/test/java/awt/Choice/ChoiceMouseWheelTest/ChoiceMouseWheelTest.java
+++ b/jdk/test/java/awt/Choice/ChoiceMouseWheelTest/ChoiceMouseWheelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 7050935
   @summary closed/java/awt/Choice/WheelEventsConsumed/WheelEventsConsumed.html fails on win32
   @library ../../regtesthelpers

--- a/jdk/test/java/awt/Choice/GrabLockTest/GrabLockTest.java
+++ b/jdk/test/java/awt/Choice/GrabLockTest/GrabLockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  */
 /*
   @test
+  @key headful
   @bug 4800638
   @summary Tests that Choice does not lock the Desktop
   @run main GrabLockTest

--- a/jdk/test/java/awt/Choice/ItemStateChangeTest/ItemStateChangeTest.java
+++ b/jdk/test/java/awt/Choice/ItemStateChangeTest/ItemStateChangeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 7171412
   @summary awt Choice doesn't fire ItemStateChange when selecting item after select() call
   @author Oleg Pekhovskiy: area=awt-choice

--- a/jdk/test/java/awt/Choice/PopdownGeneratesMouseEvents/PopdownGeneratesMouseEvents.html
+++ b/jdk/test/java/awt/Choice/PopdownGeneratesMouseEvents/PopdownGeneratesMouseEvents.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2011, 2014, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 <html>
 <!--
   @test
+  @key headful
   @bug 6200670
   @summary MouseMoved events are triggered by Choice when mouse is moved outside the component, XToolkit
   @library ../../regtesthelpers/

--- a/jdk/test/java/awt/Choice/PopupPosTest/PopupPosTest.html
+++ b/jdk/test/java/awt/Choice/PopupPosTest/PopupPosTest.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2004, 2014, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2004, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--  
   @test
+  @key headful
   @bug 5044150
   @summary Tests that pupup doesn't popdown if no space to display under 
   @author ssi@sparc.spb.su

--- a/jdk/test/java/awt/Choice/RemoveAllShrinkTest/RemoveAllShrinkTest.java
+++ b/jdk/test/java/awt/Choice/RemoveAllShrinkTest/RemoveAllShrinkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 4851798 8041896
   @summary Tests Choice List shrinks after removeAll
   @run main RemoveAllShrinkTest

--- a/jdk/test/java/awt/Choice/SelectCurrentItemTest/SelectCurrentItemTest.html
+++ b/jdk/test/java/awt/Choice/SelectCurrentItemTest/SelectCurrentItemTest.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2002, 2014, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2002, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--  
   @test 1.2 01/02/10
+  @key headful
   @bug 4902933
   @summary Test that selecting the current item sends an ItemEvent
   @author bchristi : area= Choice

--- a/jdk/test/java/awt/Component/7097771/bug7097771.java
+++ b/jdk/test/java/awt/Component/7097771/bug7097771.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import java.awt.event.ActionListener;
 
 /*
   @test
+  @key headful
   @bug 7097771
   @summary setEnabled does not work for components in disabled containers.
   @author sergey.bylokhov@oracle.com: area=awt.component

--- a/jdk/test/java/awt/Component/CompEventOnHiddenComponent/CompEventOnHiddenComponent.java
+++ b/jdk/test/java/awt/Component/CompEventOnHiddenComponent/CompEventOnHiddenComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 /*
   @test
+  @key headful
   @bug 6383903
   @summary REGRESSION: componentMoved is now getting called for some hidden components
   @author andrei.dmitriev: area=awt.component

--- a/jdk/test/java/awt/Component/F10TopToplevel/F10TopToplevel.html
+++ b/jdk/test/java/awt/Component/F10TopToplevel/F10TopToplevel.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2007, 2013, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--  
   @test
+  @key headful
   @bug 6533175
   @summary Block F10 if closest toplevel to keystroke target is not a Frame.
   @author yuri nesterenko : area= awt.toplevel

--- a/jdk/test/java/awt/Component/NativeInLightShow/NativeInLightShow.java
+++ b/jdk/test/java/awt/Component/NativeInLightShow/NativeInLightShow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test 1.0 04/05/20
+  @key headful
   @bug 4140484
   @summary Heavyweight components inside invisible lightweight containers still show
   @author Your Name: art@sparc.spb.su

--- a/jdk/test/java/awt/Component/NoUpdateUponShow/NoUpdateUponShow.java
+++ b/jdk/test/java/awt/Component/NoUpdateUponShow/NoUpdateUponShow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6774258
   @summary  api/java_awt/Component/index.html#PaintUpdate fails randomly
   @author dmitry.cherepanov@...: area=awt.painting

--- a/jdk/test/java/awt/Component/PrintAllXcheckJNI/PrintAllXcheckJNI.java
+++ b/jdk/test/java/awt/Component/PrintAllXcheckJNI/PrintAllXcheckJNI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6736247
   @summary Component.printAll Invalid local JNI handle
   @author Dmitry Cherepanov: area=awt.component

--- a/jdk/test/java/awt/Component/TreeLockDeadlock/TreeLockDeadlock.java
+++ b/jdk/test/java/awt/Component/TreeLockDeadlock/TreeLockDeadlock.java
@@ -30,6 +30,7 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 /**
  * @test
+ * @key headful
  * @bug 8138764
  */
 public final class TreeLockDeadlock extends Frame {

--- a/jdk/test/java/awt/Component/isLightweightCrash/IsLightweightCrash.java
+++ b/jdk/test/java/awt/Component/isLightweightCrash/IsLightweightCrash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6255653
   @summary REGRESSION: Override isLightweight() causes access violation in awt.dll
   @author Andrei Dmitriev: area=awt-component

--- a/jdk/test/java/awt/ComponentOrientation/BorderTest.java
+++ b/jdk/test/java/awt/ComponentOrientation/BorderTest.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug     4108453
  * @summary Test ComponentOrientation (Bidi) support in BorderLayout
  */

--- a/jdk/test/java/awt/ComponentOrientation/FlowTest.java
+++ b/jdk/test/java/awt/ComponentOrientation/FlowTest.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug     4108453
  * @summary Test ComponentOrientation (Bidi) support in FlowLayout
  */

--- a/jdk/test/java/awt/ComponentOrientation/WindowTest.java
+++ b/jdk/test/java/awt/ComponentOrientation/WindowTest.java
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key headful
  * @bug     4108453 4778440 6304785
  * @summary Test Window.applyResourceBundle orientation support
  *

--- a/jdk/test/java/awt/Container/ContainerAIOOBE/ContainerAIOOBE.java
+++ b/jdk/test/java/awt/Container/ContainerAIOOBE/ContainerAIOOBE.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import java.io.ObjectOutputStream;
 
 /**
  * @test
+ * @key headful
  * @bug 8059590
  * @summary ArrayIndexOutOfBoundsException occurs when Container with overridden getComponents() is deserialized.
  * @author Alexey Ivanov

--- a/jdk/test/java/awt/Container/isRemoveNotifyNeeded/JInternalFrameTest.java
+++ b/jdk/test/java/awt/Container/isRemoveNotifyNeeded/JInternalFrameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6552803
   @summary moveToFront shouldn't remove peers of HW components
   @author anthony.petrov@...: area=awt.container

--- a/jdk/test/java/awt/Dialog/CrashXCheckJni/CrashXCheckJni.java
+++ b/jdk/test/java/awt/Dialog/CrashXCheckJni/CrashXCheckJni.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6610244
   @library ../../regtesthelpers
   @build Util Sysout AbstractTest

--- a/jdk/test/java/awt/Dialog/DialogOverflowSizeTest/DialogSizeOverflowTest.java
+++ b/jdk/test/java/awt/Dialog/DialogOverflowSizeTest/DialogSizeOverflowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,14 +22,15 @@
  */
 
 /*
-   @test
-   @bug 4904961
-   @summary Test that Dialog with zero sizes won't be created with negative sizes due to overflow in peer code
-   @author Andrei Dmitriev: area=awt.toplevel
-   @library ../../regtesthelpers
-   @build Util
-   @run main DialogSizeOverflowTest
-*/
+ * @test
+ * @key headful
+ * @bug 4904961
+ * @summary Test that Dialog with zero sizes won't be created with negative sizes due to overflow in peer code
+ * @author Andrei Dmitriev: area=awt.toplevel
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main DialogSizeOverflowTest
+ */
 
 import java.awt.*;
 import java.awt.event.*;

--- a/jdk/test/java/awt/Dialog/ModalDialogPermission/ModalDialogPermission.java
+++ b/jdk/test/java/awt/Dialog/ModalDialogPermission/ModalDialogPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ import java.util.TimerTask;
 
 /*
   @test
+  @key headful
   @bug 7080109
   @summary Dialog.show() lacks doPrivileged() to access system event queue.
   @author sergey.bylokhov@oracle.com: area=awt.dialog

--- a/jdk/test/java/awt/Dialog/NonResizableDialogSysMenuResize/NonResizableDialogSysMenuResize.java
+++ b/jdk/test/java/awt/Dialog/NonResizableDialogSysMenuResize/NonResizableDialogSysMenuResize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6494016
   @summary Nonresizable dialogs should not be resized using the Size SystemMenu command
   @author anthony.petrov@...: area=awt.toplevel

--- a/jdk/test/java/awt/EventDispatchThread/HandleExceptionOnEDT/HandleExceptionOnEDT.java
+++ b/jdk/test/java/awt/EventDispatchThread/HandleExceptionOnEDT/HandleExceptionOnEDT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6304473 6727884
   @summary Tests that an exception on EDT is handled with ThreadGroup.uncaughtException()
   @author artem.ananiev: area=awt.eventdispatching

--- a/jdk/test/java/awt/EventDispatchThread/PreserveDispathThread/PreserveDispatchThread.java
+++ b/jdk/test/java/awt/EventDispatchThread/PreserveDispathThread/PreserveDispatchThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6424157
   @author Artem Ananiev: area=eventqueue
   @run main PreserveDispatchThread

--- a/jdk/test/java/awt/EventQueue/PushPopDeadlock2/PushPopTest.java
+++ b/jdk/test/java/awt/EventQueue/PushPopDeadlock2/PushPopTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 4913324
   @author Oleg Sukhodolsky: area=eventqueue
   @run main/timeout=30 PushPopTest

--- a/jdk/test/java/awt/FileDialog/FilenameFilterTest/FilenameFilterTest.html
+++ b/jdk/test/java/awt/FileDialog/FilenameFilterTest/FilenameFilterTest.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2006, 2013, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--  
   @test
+  @key headful
   @bug 6448069
   @summary namefilter is not called for file dialog on windows
   @author oleg.sukhodolsky: area= awt.filedialog

--- a/jdk/test/java/awt/Focus/6378278/InputVerifierTest.java
+++ b/jdk/test/java/awt/Focus/6378278/InputVerifierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6378278
   @summary Apparent missing key events causing Bugster to break
   @author oleg.sukhodolsky: area=awt.focus

--- a/jdk/test/java/awt/Focus/6382144/EndlessLoopTest.java
+++ b/jdk/test/java/awt/Focus/6382144/EndlessLoopTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6382144
   @summary REGRESSION: InputVerifier and JOptionPane
   @author oleg.sukhodolsky: area=awt.focus

--- a/jdk/test/java/awt/Focus/6401036/InputVerifierTest2.java
+++ b/jdk/test/java/awt/Focus/6401036/InputVerifierTest2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6401036
   @summary  InputVerifier shouldn't be called when requestFocus() is called on comp from another toplevel
   @author oleg.sukhodolsky: area=awt.focus

--- a/jdk/test/java/awt/Focus/ActualFocusedWindowTest/ActualFocusedWindowBlockingTest.java
+++ b/jdk/test/java/awt/Focus/ActualFocusedWindowTest/ActualFocusedWindowBlockingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug       6314575
   @summary   Tests that previosly focused owned window doesn't steal focus when an owner's component requests focus.
   @author    Anton.Tarasov: area=awt.focus

--- a/jdk/test/java/awt/Focus/AppletInitialFocusTest/AppletInitialFocusTest.html
+++ b/jdk/test/java/awt/Focus/AppletInitialFocusTest/AppletInitialFocusTest.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--
   @test
+  @key headful
   @bug 4041703 4096228 4025223 4260929
   @summary Ensures that appletviewer sets a reasonable default focus for an Applet on start
   @author  das area=appletviewer

--- a/jdk/test/java/awt/Focus/AppletInitialFocusTest/AppletInitialFocusTest1.html
+++ b/jdk/test/java/awt/Focus/AppletInitialFocusTest/AppletInitialFocusTest1.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--
   @test
+  @key headful
   @bug 4411534 4517274
   @summary ensures that user's requestFocus() during applet initialization
            is not ignored

--- a/jdk/test/java/awt/Focus/ChildWindowFocusTest/ChildWindowFocusTest.html
+++ b/jdk/test/java/awt/Focus/ChildWindowFocusTest/ChildWindowFocusTest.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2004, 2014, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2004, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--  
   @test
+  @key headful
   @bug        5090325
   @summary    Tests that Window's child can be focused on XAWT.
   @author     anton.tarasov@sun.com: area=awt.focus

--- a/jdk/test/java/awt/Focus/ChoiceFocus/ChoiceFocus.java
+++ b/jdk/test/java/awt/Focus/ChoiceFocus/ChoiceFocus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 4053856
   @summary Choice components don't honour key focus
   @library ../../regtesthelpers

--- a/jdk/test/java/awt/Focus/ClearLwQueueBreakTest/ClearLwQueueBreakTest.java
+++ b/jdk/test/java/awt/Focus/ClearLwQueueBreakTest/ClearLwQueueBreakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug       6496958
   @summary   Tests that breaking the proccess of clearing LW requests doesn't break focus.
   @author    anton.tarasov@...: area=awt-focus

--- a/jdk/test/java/awt/Focus/CloseDialogActivateOwnerTest/CloseDialogActivateOwnerTest.java
+++ b/jdk/test/java/awt/Focus/CloseDialogActivateOwnerTest/CloseDialogActivateOwnerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug       6785058
   @summary   Tests that an owner is activated on closing its owned dialog with the warning icon.
   @author    Anton Tarasov: area=awt.focus

--- a/jdk/test/java/awt/Focus/ConsumeNextKeyTypedOnModalShowTest/ConsumeNextKeyTypedOnModalShowTest.java
+++ b/jdk/test/java/awt/Focus/ConsumeNextKeyTypedOnModalShowTest/ConsumeNextKeyTypedOnModalShowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test      %W% %E%
+  @key headful
   @bug       6637607
   @summary   Showing a modal dlg on TAB KEY_PRESS shouldn't consume inappropriate KEY_TYPED.
   @author    Anton Tarasov: area=awt-focus

--- a/jdk/test/java/awt/Focus/ContainerFocusAutoTransferTest/ContainerFocusAutoTransferTest.java
+++ b/jdk/test/java/awt/Focus/ContainerFocusAutoTransferTest/ContainerFocusAutoTransferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug       6607170
   @summary   Tests for focus-auto-transfer.
   @author    Anton Tarasov: area=awt-focus

--- a/jdk/test/java/awt/Focus/DeiconifiedFrameLoosesFocus/DeiconifiedFrameLoosesFocus.html
+++ b/jdk/test/java/awt/Focus/DeiconifiedFrameLoosesFocus/DeiconifiedFrameLoosesFocus.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2006, 2013, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--
   @test
+  @key headful
   @bug        6480534
   @summary    A Frame changing its state from ICONIFIED to NORMAL should regain focus.
   @author     anton.tarasov@...: area=awt.focus

--- a/jdk/test/java/awt/Focus/DisposedWindow/DisposeDialogNotActivateOwnerTest/DisposeDialogNotActivateOwnerTest.html
+++ b/jdk/test/java/awt/Focus/DisposedWindow/DisposeDialogNotActivateOwnerTest/DisposeDialogNotActivateOwnerTest.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2006, 2014, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--
   @test
+  @key headful
   @bug        6386592
   @summary    Tests that disposing a dialog doesn't activate its invisible owner.
   @author     anton.tarasov@sun.com: area=awt.focus

--- a/jdk/test/java/awt/Focus/FocusOwnerFrameOnClick/FocusOwnerFrameOnClick.java
+++ b/jdk/test/java/awt/Focus/FocusOwnerFrameOnClick/FocusOwnerFrameOnClick.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test      FocusOwnerFrameOnClick.java %W% %E%
+  @key headful
   @bug       6886678
   @summary   Tests that clicking an owner frame switches focus from its owned window.
   @author    Anton Tarasov: area=awt.focus

--- a/jdk/test/java/awt/Focus/FocusSubRequestTest/FocusSubRequestTest.html
+++ b/jdk/test/java/awt/Focus/FocusSubRequestTest/FocusSubRequestTest.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2004, 2014, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2004, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--  
   @test
+  @key headful
   @bug        5082319
   @summary    Tests that focus request for already focused component doesn't block key events.
   @author     anton.tarasov@sun.com

--- a/jdk/test/java/awt/Focus/FocusTraversalPolicy/DefaultFTPTest.java
+++ b/jdk/test/java/awt/Focus/FocusTraversalPolicy/DefaultFTPTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug       6463545
   @summary   Tests java.awt.DefaultFocusTraversalPolicy functionality.
   @author    anton.tarasov area=awt.focus

--- a/jdk/test/java/awt/Focus/FocusTraversalPolicy/InitialFTP.java
+++ b/jdk/test/java/awt/Focus/FocusTraversalPolicy/InitialFTP.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug       7125044
   @summary   Tests defaut focus traversal policy in AWT & Swing toplevel windows.
   @author    anton.tarasov@sun.com: area=awt.focus

--- a/jdk/test/java/awt/Focus/FocusTraversalPolicy/LayoutFTPTest.java
+++ b/jdk/test/java/awt/Focus/FocusTraversalPolicy/LayoutFTPTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug       6463545
   @summary   Tests javax.swing.LayoutFocusTraversalPolicy functionality.
   @author    anton.tarasov, oleg.sukhodolsky: area=awt.focus

--- a/jdk/test/java/awt/Focus/FrameJumpingToMouse/FrameJumpingToMouse.java
+++ b/jdk/test/java/awt/Focus/FrameJumpingToMouse/FrameJumpingToMouse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,14 +22,15 @@
  */
 
 /*
-    @test
-    @bug        4752312
-    @summary    Tests that after moving non-focusable window it ungrabs mouse pointer
-    @author     Denis Mikhalkin: area=awt.focus
-    @library    ../../regtesthelpers
-    @build      Util
-    @run        main FrameJumpingToMouse
-*/
+ * @test
+ * @key headful
+ * @bug        4752312
+ * @summary    Tests that after moving non-focusable window it ungrabs mouse pointer
+ * @author     Denis Mikhalkin: area=awt.focus
+ * @library    ../../regtesthelpers
+ * @build      Util
+ * @run        main FrameJumpingToMouse
+ */
 
 import java.applet.Applet;
 import java.awt.BorderLayout;

--- a/jdk/test/java/awt/Focus/FrameMinimizeTest/FrameMinimizeTest.java
+++ b/jdk/test/java/awt/Focus/FrameMinimizeTest/FrameMinimizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6502358
   @summary focus is not restored after programmatic iconification and restoring
   @author : area=awt.focus

--- a/jdk/test/java/awt/Focus/IconifiedFrameFocusChangeTest/IconifiedFrameFocusChangeTest.java
+++ b/jdk/test/java/awt/Focus/IconifiedFrameFocusChangeTest/IconifiedFrameFocusChangeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug       6522725
   @summary   Tests for proper request-focus-back on FOCUS_LOST.
   @author    Anton Tarasov: area=awt-focus

--- a/jdk/test/java/awt/Focus/InputVerifierTest3/InputVerifierTest3.java
+++ b/jdk/test/java/awt/Focus/InputVerifierTest3/InputVerifierTest3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6432665
   @summary Inputverifier is not executed when focus owner is removed
   @author oleg.sukhodolsky: area=awt.focus

--- a/jdk/test/java/awt/Focus/ModalBlockedStealsFocusTest/ModalBlockedStealsFocusTest.html
+++ b/jdk/test/java/awt/Focus/ModalBlockedStealsFocusTest/ModalBlockedStealsFocusTest.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2006, 2013, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--
   @test
+  @key headful
   @bug        6426132
   @summary    Modal blocked window shouldn't steal focus when shown, or brought to front.
   @author     anton.tarasov@...: area=awt.focus

--- a/jdk/test/java/awt/Focus/ModalDialogInitialFocusTest/ModalDialogInitialFocusTest.html
+++ b/jdk/test/java/awt/Focus/ModalDialogInitialFocusTest/ModalDialogInitialFocusTest.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2006, 2014, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--
   @test
+  @key headful
   @bug        6382750
   @summary
   @author     anton.tarasov@sun.com: area=awt.focus

--- a/jdk/test/java/awt/Focus/ModalExcludedWindowClickTest/ModalExcludedWindowClickTest.html
+++ b/jdk/test/java/awt/Focus/ModalExcludedWindowClickTest/ModalExcludedWindowClickTest.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2005, 2015, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--  
   @test
+  @key headful
   @bug        6271849
   @summary    Tests that component in modal excluded Window which parent is blocked responses to mouse clicks.
   @author     anton.tarasov@sun.com: area=awt.focus

--- a/jdk/test/java/awt/Focus/NoAutotransferToDisabledCompTest/NoAutotransferToDisabledCompTest.java
+++ b/jdk/test/java/awt/Focus/NoAutotransferToDisabledCompTest/NoAutotransferToDisabledCompTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug       4685768
   @summary   Tests that auto-transfering focus doesn't stuck on a disabled component.
   @author    Anton Tarasov: area=awt.focus

--- a/jdk/test/java/awt/Focus/NonFocusableBlockedOwnerTest/NonFocusableBlockedOwnerTest.html
+++ b/jdk/test/java/awt/Focus/NonFocusableBlockedOwnerTest/NonFocusableBlockedOwnerTest.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2005, 2015, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--  
   @test
+  @key headful
   @bug        6272324
   @summary    Modal excluded Window which decorated parent is blocked should be non-focusable.
   @author     anton.tarasov@sun.com: area=awt.focus

--- a/jdk/test/java/awt/Focus/NonFocusableResizableTooSmall/NonFocusableResizableTooSmall.java
+++ b/jdk/test/java/awt/Focus/NonFocusableResizableTooSmall/NonFocusableResizableTooSmall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6581927
   @summary Non-focusable frame should honor the size of the frame buttons/decorations when resizing
   @library ../../regtesthelpers

--- a/jdk/test/java/awt/Focus/NonFocusableWindowTest/NoEventsTest.java
+++ b/jdk/test/java/awt/Focus/NonFocusableWindowTest/NoEventsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 4452384
   @summary Tests that non-focusable windows doesn't generate any focus events when accessed.
   @author Denis.Mikhalkin: area=awt.focus

--- a/jdk/test/java/awt/Focus/NonFocusableWindowTest/NonfocusableOwnerTest.java
+++ b/jdk/test/java/awt/Focus/NonFocusableWindowTest/NonfocusableOwnerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug       6182359
   @summary   Tests that Window having non-focusable owner can't be a focus owner.
   @author    Anton.Tarasov: area=awt.focus

--- a/jdk/test/java/awt/Focus/OwnedWindowFocusIMECrashTest/OwnedWindowFocusIMECrashTest.java
+++ b/jdk/test/java/awt/Focus/OwnedWindowFocusIMECrashTest/OwnedWindowFocusIMECrashTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug       6542975
   @summary   Tests that switching focus from an owned window doesn't crash.
   @author    anton.tarasov@sun.com: area=awt-focus

--- a/jdk/test/java/awt/Focus/RequestFocusAndHideTest/RequestFocusAndHideTest.java
+++ b/jdk/test/java/awt/Focus/RequestFocusAndHideTest/RequestFocusAndHideTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug       6562853 6562853 6562853
   @summary   Tests that focus can not be set to removed component.
   @author    Oleg Sukhodolsky: area=awt.focus

--- a/jdk/test/java/awt/Focus/RequestFocusToDisabledCompTest/RequestFocusToDisabledCompTest.java
+++ b/jdk/test/java/awt/Focus/RequestFocusToDisabledCompTest/RequestFocusToDisabledCompTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug       4685768
   @summary   Tests that it's possible to manually request focus on a disabled component.
   @author    Anton Tarasov: area=awt.focus

--- a/jdk/test/java/awt/Focus/RequestOnCompWithNullParent/RequestOnCompWithNullParent1.java
+++ b/jdk/test/java/awt/Focus/RequestOnCompWithNullParent/RequestOnCompWithNullParent1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6418028
   @summary java/awt/Focus/RequestOnCompWithNullParent/RequestOnCompWithNullParent_Barrier.java fails
   @author oleg.sukhodolsky: area=awt.focus

--- a/jdk/test/java/awt/Focus/ResetMostRecentFocusOwnerTest/ResetMostRecentFocusOwnerTest.java
+++ b/jdk/test/java/awt/Focus/ResetMostRecentFocusOwnerTest/ResetMostRecentFocusOwnerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug      8013773
   @summary  Tests that disabled component is not retained as most recent focus owner.
   @author   Anton.Tarasov: area=awt.focus

--- a/jdk/test/java/awt/Focus/RestoreFocusOnDisabledComponentTest/RestoreFocusOnDisabledComponentTest.java
+++ b/jdk/test/java/awt/Focus/RestoreFocusOnDisabledComponentTest/RestoreFocusOnDisabledComponentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test      %W% %E%
+  @key headful
   @bug       6598089
   @summary   Tests restoring focus on a single disabled coponent
   @author    Anton Tarasov: area=awt-focus

--- a/jdk/test/java/awt/Focus/ShowFrameCheckForegroundTest/ShowFrameCheckForegroundTest.java
+++ b/jdk/test/java/awt/Focus/ShowFrameCheckForegroundTest/ShowFrameCheckForegroundTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug       6492970
   @summary   Tests that showing a toplvel in a not foreground Java process activates it.
   @library   ../../regtesthelpers

--- a/jdk/test/java/awt/Focus/ToFrontFocusTest/ToFrontFocus.html
+++ b/jdk/test/java/awt/Focus/ToFrontFocusTest/ToFrontFocus.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2002, 2013, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2002, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--  
   @test
+  @key headful
   @bug 4092033 4529626
   @summary Tests that toFront makes window focused unless it is non-focusable
   @author  area=awt.focus

--- a/jdk/test/java/awt/Focus/WindowInitialFocusTest/WindowInitialFocusTest.html
+++ b/jdk/test/java/awt/Focus/WindowInitialFocusTest/WindowInitialFocusTest.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2006, 2013, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--
   @test
+  @key headful
   @bug        6426132
   @summary    A Window should be focused upon start (XAWT bug).
   @author     anton.tarasov@...: area=awt.focus

--- a/jdk/test/java/awt/Focus/WindowIsFocusableAccessByThreadsTest/WindowIsFocusableAccessByThreadsTest.java
+++ b/jdk/test/java/awt/Focus/WindowIsFocusableAccessByThreadsTest/WindowIsFocusableAccessByThreadsTest.java
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug      8047288
   @summary  Tests method isFocusable of Window component. It should be accessed only from EDT
   @author   artem.malinko@oracle.com

--- a/jdk/test/java/awt/Focus/WindowUpdateFocusabilityTest/WindowUpdateFocusabilityTest.html
+++ b/jdk/test/java/awt/Focus/WindowUpdateFocusabilityTest/WindowUpdateFocusabilityTest.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2005, 2015, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--
   @test
+  @key headful
   @bug        6253913
   @summary    Tests that a Window shown before its owner is focusable.
   @author     anton.tarasov@sun.com: area=awt-focus

--- a/jdk/test/java/awt/Focus/WrongKeyTypedConsumedTest/WrongKeyTypedConsumedTest.java
+++ b/jdk/test/java/awt/Focus/WrongKeyTypedConsumedTest/WrongKeyTypedConsumedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug      4782886
   @summary  FocusManager consumes wrong KEY_TYPED events
   @author   Oleg.Sukhodolsky: area=awt.focus

--- a/jdk/test/java/awt/FontClass/CreateFont/bigfont.html
+++ b/jdk/test/java/awt/FontClass/CreateFont/bigfont.html
@@ -1,6 +1,6 @@
 <!--
 
- Copyright (c) 2008, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  questions.
 
   @test
+  @key headful
   @bug 6522586
   @run applet bigfont.html
   @summary Enforce limits on font creation

--- a/jdk/test/java/awt/Frame/7024749/bug7024749.java
+++ b/jdk/test/java/awt/Frame/7024749/bug7024749.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 7024749 8019990
  * @summary JDK7 b131---a crash in: Java_sun_awt_windows_ThemeReader_isGetThemeTransitionDurationDefined+0x75
  * @library ../../regtesthelpers

--- a/jdk/test/java/awt/Frame/DisposeStressTest/DisposeStressTest.html
+++ b/jdk/test/java/awt/Frame/DisposeStressTest/DisposeStressTest.html
@@ -1,6 +1,7 @@
 <html>
 <!--  
   @test
+  @key headful
   @bug 4051487 4145670
   @summary Tests that disposing of an empty Frame or a Frame with a MenuBar
            while it is being created does not crash the VM.

--- a/jdk/test/java/awt/Frame/DynamicLayout/DynamicLayout.java
+++ b/jdk/test/java/awt/Frame/DynamicLayout/DynamicLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6500477
   @summary Tests whether DynamicLayout is really off
   @author anthony.petrov@...: area=awt.toplevel

--- a/jdk/test/java/awt/Frame/FrameLocation/FrameLocation.java
+++ b/jdk/test/java/awt/Frame/FrameLocation/FrameLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6895647
   @summary X11 Frame locations should be what we set them to
   @author anthony.petrov@oracle.com: area=awt.toplevel

--- a/jdk/test/java/awt/Frame/FrameResize/ShowChildWhileResizingTest.java
+++ b/jdk/test/java/awt/Frame/FrameResize/ShowChildWhileResizingTest.java
@@ -1,3 +1,4 @@
+
 /*
  * Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -21,11 +22,13 @@
  * questions.
  */
 
-/* @test
-   @bug 8079595
-   @summary Resizing dialog which is JWindow parent makes JVM crash
-   @author Semyon Sadetsky
-  */
+/*
+ * @test
+ * @key headful
+ * @bug 8079595
+ * @summary Resizing dialog which is JWindow parent makes JVM crash
+ * @author Semyon Sadetsky
+ */
 
 import javax.swing.*;
 import java.awt.*;

--- a/jdk/test/java/awt/Frame/FrameSetSizeStressTest/FrameSetSizeStressTest.java
+++ b/jdk/test/java/awt/Frame/FrameSetSizeStressTest/FrameSetSizeStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ import java.awt.Frame;
 
 /*
   @test
+  @key headful
   @bug 7177173
   @summary setBounds can cause StackOverflow in case of the considerable loading
   @author Sergey Bylokhov

--- a/jdk/test/java/awt/Frame/FrameSize/TestFrameSize.java
+++ b/jdk/test/java/awt/Frame/FrameSize/TestFrameSize.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2009 Red Hat, Inc.  All Rights Reserved.
- * Copyright (c) 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 
 /*
   @test
+  @key headful
   @bug 6721088
   @summary X11 Window sizes should be what we set them to
   @author Omair Majid <omajid@redhat.com>: area=awt.toplevel

--- a/jdk/test/java/awt/Frame/HideMaximized/HideMaximized.java
+++ b/jdk/test/java/awt/Frame/HideMaximized/HideMaximized.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 7177173
   @summary The maximized state shouldn't be reset upon hiding a frame
   @author anthony.petrov@oracle.com: area=awt.toplevel

--- a/jdk/test/java/awt/Frame/HugeFrame/HugeFrame.java
+++ b/jdk/test/java/awt/Frame/HugeFrame/HugeFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 7160609
   @summary A window with huge dimensions shouldn't crash JVM
   @author anthony.petrov@oracle.com: area=awt.toplevel

--- a/jdk/test/java/awt/Frame/InvisibleOwner/InvisibleOwner.java
+++ b/jdk/test/java/awt/Frame/InvisibleOwner/InvisibleOwner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 7154177
   @summary An invisible owner frame should never become visible
   @author anthony.petrov@oracle.com: area=awt.toplevel

--- a/jdk/test/java/awt/Frame/LayoutOnMaximizeTest/LayoutOnMaximizeTest.java
+++ b/jdk/test/java/awt/Frame/LayoutOnMaximizeTest/LayoutOnMaximizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6355340
   @summary Test correctness of laying out the contents of a frame on maximize
   @author anthony.petrov@...: area=awt.toplevel

--- a/jdk/test/java/awt/Frame/MaximizedNormalBoundsUndecoratedTest/MaximizedNormalBoundsUndecoratedTest.java
+++ b/jdk/test/java/awt/Frame/MaximizedNormalBoundsUndecoratedTest/MaximizedNormalBoundsUndecoratedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ import java.awt.Toolkit;
 import java.awt.Dimension;
 /*
  * @test
+ * @key headful
  * @bug 8066436
  * @summary Set the size of frame. Set extendedState Frame.MAXIMIZED_BOTH and Frame.NORMAL
  *          sequentially for undecorated Frame and .

--- a/jdk/test/java/awt/Frame/MaximizedToIconified/MaximizedToIconified.java
+++ b/jdk/test/java/awt/Frame/MaximizedToIconified/MaximizedToIconified.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 4977491
   @summary State changes should always be reported as events
   @author anthony.petrov@...: area=awt.toplevel

--- a/jdk/test/java/awt/Frame/MaximizedToMaximized/MaximizedToMaximized.java
+++ b/jdk/test/java/awt/Frame/MaximizedToMaximized/MaximizedToMaximized.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import java.awt.Robot;
 
 /**
  * @test
+ * @key headful
  * @bug 8007219
  * @author Alexander Scherbatiy
  * @summary Frame size reverts meaning of maximized attribute

--- a/jdk/test/java/awt/Frame/MaximizedUndecorated/MaximizedUndecorated.java
+++ b/jdk/test/java/awt/Frame/MaximizedUndecorated/MaximizedUndecorated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import java.awt.Rectangle;
 import java.lang.reflect.InvocationTargetException;
 /*
  * @test
+ * @key headful
  * @bug 8022302
  * @summary Set extendedState Frame.MAXIMIZED_BOTH for undecorated Frame and JFrame.
  *          Check if resulted size is equal to GraphicsEnvironment.getMaximumWindowBounds().

--- a/jdk/test/java/awt/Frame/MiscUndecorated/UndecoratedInitiallyIconified.java
+++ b/jdk/test/java/awt/Frame/MiscUndecorated/UndecoratedInitiallyIconified.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ import java.awt.EventQueue;
 import java.awt.FlowLayout;
 /*
  * @test
+ * @key headful
  * @bug 4464710 7102299
  * @summary Recurring bug is, an undecorated JFrame cannot be set iconified
  *          before setVisible(true)

--- a/jdk/test/java/awt/Frame/NonEDT_GUI_DeadlockTest/NonEDT_GUI_Deadlock.html
+++ b/jdk/test/java/awt/Frame/NonEDT_GUI_DeadlockTest/NonEDT_GUI_Deadlock.html
@@ -1,6 +1,6 @@
 <html>
 <!--
- Copyright (c) 2003, 2015, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 
 <!--  
   @test
+  @key headful
   @bug 4828019
   @summary Frame/Window deadlock
   @author yan@sparc.spb.su: area=

--- a/jdk/test/java/awt/Frame/ResizeAfterSetFont/ResizeAfterSetFont.java
+++ b/jdk/test/java/awt/Frame/ResizeAfterSetFont/ResizeAfterSetFont.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@
 
 /*
  @test
+ @key headful
  @bug 7170655
  @summary Frame size does not change after changing font
  @author Jonathan Lu

--- a/jdk/test/java/awt/Frame/ShownOffScreenOnWin98/ShownOffScreenOnWin98Test.java
+++ b/jdk/test/java/awt/Frame/ShownOffScreenOnWin98/ShownOffScreenOnWin98Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6477497
   @summary Windows drawn off-screen on Win98 if locationByPlatform is true
   @author anthony.petrov@...: area=awt.toplevel

--- a/jdk/test/java/awt/Frame/SlideNotResizableTest/SlideNotResizableTest.java
+++ b/jdk/test/java/awt/Frame/SlideNotResizableTest/SlideNotResizableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ import java.awt.event.InputEvent;
 
 /**
  * @test
+ * @key headful
  * @bug 8032595
  * @summary setResizable(false) makes a frame slide down
  * @author Petr Pchelko

--- a/jdk/test/java/awt/Frame/UnfocusableMaximizedFrameResizablity/UnfocusableMaximizedFrameResizablity.java
+++ b/jdk/test/java/awt/Frame/UnfocusableMaximizedFrameResizablity/UnfocusableMaximizedFrameResizablity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 4980161
   @summary Setting focusable window state to false makes the maximized frame resizable
   @author anthony.petrov@...: area=awt.toplevel

--- a/jdk/test/java/awt/FullScreen/8013581/bug8013581.java
+++ b/jdk/test/java/awt/FullScreen/8013581/bug8013581.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8013581
  * @summary [macosx] Key Bindings break with awt GraphicsEnvironment setFullScreenWindow
  * @author leonid.romanov@oracle.com

--- a/jdk/test/java/awt/FullScreen/AltTabCrashTest/AltTabCrashTest.java
+++ b/jdk/test/java/awt/FullScreen/AltTabCrashTest/AltTabCrashTest.java
@@ -23,6 +23,7 @@
 
 /*
  @test
+ @key headful
  @bug 6275887 6429971 6459792
  @summary Test that we don't crash when alt+tabbing in and out of
          fullscreen app

--- a/jdk/test/java/awt/FullScreen/BufferStrategyExceptionTest/BufferStrategyExceptionTest.java
+++ b/jdk/test/java/awt/FullScreen/BufferStrategyExceptionTest/BufferStrategyExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key headful
  * @bug 6366813 6459844
  * @summary Tests that no exception is thrown if a frame is resized just
  * before we create a bufferStrategy

--- a/jdk/test/java/awt/FullScreen/DisplayChangeVITest/DisplayChangeVITest.java
+++ b/jdk/test/java/awt/FullScreen/DisplayChangeVITest/DisplayChangeVITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key headful
  * @bug 6366359
  * @summary Test that we don't crash when changing from 8 to 16/32 bit modes
  * @author Dmitri.Trembovetski@Sun.COM area=FullScreen

--- a/jdk/test/java/awt/FullScreen/FullScreenInsets/FullScreenInsets.java
+++ b/jdk/test/java/awt/FullScreen/FullScreenInsets/FullScreenInsets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import java.awt.image.BufferedImage;
 
 /**
  * @test
+ * @key headful
  * @bug 8003173 7019055
  * @summary Full-screen windows should have the proper insets.
  * @author Sergey Bylokhov

--- a/jdk/test/java/awt/FullScreen/MultimonFullscreenTest/MultimonDeadlockTest.java
+++ b/jdk/test/java/awt/FullScreen/MultimonFullscreenTest/MultimonDeadlockTest.java
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 8129116
   @summary Deadlock with multimonitor fullscreen windows.
   @run main/timeout=20 MultimonDeadlockTest

--- a/jdk/test/java/awt/FullScreen/NoResizeEventOnDMChangeTest/NoResizeEventOnDMChangeTest.java
+++ b/jdk/test/java/awt/FullScreen/NoResizeEventOnDMChangeTest/NoResizeEventOnDMChangeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  */
 /*
  * @test
+ * @key headful
  * @bug 6646411
  * @summary Tests that full screen window and its children receive resize
             event when display mode changes

--- a/jdk/test/java/awt/FullScreen/NonExistentDisplayModeTest/NonExistentDisplayModeTest.java
+++ b/jdk/test/java/awt/FullScreen/NonExistentDisplayModeTest/NonExistentDisplayModeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import static java.awt.DisplayMode.REFRESH_RATE_UNKNOWN;
 
 /**
  * @test
+ * @key headful
  * @bug 6430607
  * @summary Test that we throw an exception for incorrect display modes
  * @author Dmitri.Trembovetski@Sun.COM area=FullScreen

--- a/jdk/test/java/awt/FullScreen/SetFSWindow/FSFrame.java
+++ b/jdk/test/java/awt/FullScreen/SetFSWindow/FSFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6240507 6662642
  * @summary verify that isFullScreenSupported and getFullScreenWindow work
  * correctly with and without a SecurityManager. Note that the test may fail

--- a/jdk/test/java/awt/GradientPaint/GradientTransformTest.java
+++ b/jdk/test/java/awt/GradientPaint/GradientTransformTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ import java.awt.image.*;
 
 /**
  * @test
+ * @key headful
  * @bug 8023483
  * @summary tests if the transform-parameter is applied correctly when creating
  *          a gradient.

--- a/jdk/test/java/awt/GradientPaint/LinearColorSpaceGradientTest.java
+++ b/jdk/test/java/awt/GradientPaint/LinearColorSpaceGradientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ import java.awt.image.*;
 
 /**
  * @test
+ * @key headful
  * @bug 8023483
  * @summary tests wether the colorspace-parameter is applied correctly when
  *          creating a gradient.

--- a/jdk/test/java/awt/Graphics/LineClipTest.java
+++ b/jdk/test/java/awt/Graphics/LineClipTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key headful
  * @bug   4780022 4862193 7179526
  * @summary  Tests that clipped lines are drawn over the same pixels
  * as unclipped lines (within the clip bounds)

--- a/jdk/test/java/awt/Graphics2D/DrawString/DrawStrSuper.java
+++ b/jdk/test/java/awt/Graphics2D/DrawString/DrawStrSuper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key headful
  * @bug 6684056
  * @summary Super-scripted text needs to be positioned the same with
  *          drawString and TextLayout.

--- a/jdk/test/java/awt/Graphics2D/DrawString/LCDTextSrcEa.java
+++ b/jdk/test/java/awt/Graphics2D/DrawString/LCDTextSrcEa.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key headful
  * @bug 6996867
  * @summary Render as LCD Text in SrcEa composite mode.
  */

--- a/jdk/test/java/awt/Graphics2D/DrawString/ScaledLCDTextMetrics.java
+++ b/jdk/test/java/awt/Graphics2D/DrawString/ScaledLCDTextMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key headful
  * @bug 6685312
  * @summary Check advance of LCD text on a scaled graphics.
  */

--- a/jdk/test/java/awt/Graphics2D/DrawString/TextRenderingTest.java
+++ b/jdk/test/java/awt/Graphics2D/DrawString/TextRenderingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@ import java.awt.image.VolatileImage;
 
 /*
  * @test
+ * @key headful
  * @bug 7189452 8024767
  * @summary Check if source offset for text rendering is handled correctly
  *          (shouldn't see the text on a similarly colored background).

--- a/jdk/test/java/awt/Graphics2D/DrawString/XRenderElt254TextTest.java
+++ b/jdk/test/java/awt/Graphics2D/DrawString/XRenderElt254TextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import javax.swing.*;
 
 /**
  * @test
+ * @key headful
  * @bug 8028722
  * @summary tests wether drawString with 254 characters causes the xrender
  *          pipeline to hang.

--- a/jdk/test/java/awt/Graphics2D/FillTexturePaint/FillTexturePaint.java
+++ b/jdk/test/java/awt/Graphics2D/FillTexturePaint/FillTexturePaint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,7 @@ import java.awt.image.VolatileImage;
 
 /**
  * @test
+ * @key headful
  * @bug 8000629
  * @summary TexturePaint areas shouldn't separates.
  * @author Sergey Bylokhov

--- a/jdk/test/java/awt/Graphics2D/FlipDrawImage/FlipDrawImage.java
+++ b/jdk/test/java/awt/Graphics2D/FlipDrawImage/FlipDrawImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import java.awt.image.VolatileImage;
 
 /**
  * @test
+ * @key headful
  * @bug 8000629
  * @author Sergey Bylokhov
  */

--- a/jdk/test/java/awt/Graphics2D/TransformSetGet/TransformSetGet.java
+++ b/jdk/test/java/awt/Graphics2D/TransformSetGet/TransformSetGet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import sun.java2d.SunGraphics2D;
 
 /**
  * @test
+ * @key headful
  * @bug 8000629
  * @summary Set/get transform should work on constrained graphics.
  * @author Sergey Bylokhov

--- a/jdk/test/java/awt/GraphicsConfiguration/NormalizingTransformTest/NormalizingTransformTest.java
+++ b/jdk/test/java/awt/GraphicsConfiguration/NormalizingTransformTest/NormalizingTransformTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key headful
  * @bug 6373505
  * @summary Tests that the result of Toolkit.getScreenResolution() is
  * consistent with GraphicsConfiguration.getNormalizingTransform().

--- a/jdk/test/java/awt/GraphicsDevice/CheckDisplayModes.java
+++ b/jdk/test/java/awt/GraphicsDevice/CheckDisplayModes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8007146 8213119
  * @summary [macosx] Setting a display mode crashes JDK under VNC
  * @author Alexander Scherbatiy

--- a/jdk/test/java/awt/GraphicsDevice/CloneConfigsTest.java
+++ b/jdk/test/java/awt/GraphicsDevice/CloneConfigsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug     6822057 7124400
  *
  * @summary Test verifies that list of supported graphics configurations

--- a/jdk/test/java/awt/GraphicsDevice/IncorrectDisplayModeExitFullscreen.java
+++ b/jdk/test/java/awt/GraphicsDevice/IncorrectDisplayModeExitFullscreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import java.awt.GraphicsEnvironment;
 
 /**
  * @test
+ * @key headful
  * @bug 8019587
  * @author Sergey Bylokhov
  * @library ../../../lib/testlibrary/

--- a/jdk/test/java/awt/GraphicsEnvironment/LoadLock/GE_init3.java
+++ b/jdk/test/java/awt/GraphicsEnvironment/LoadLock/GE_init3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 7002839
  * @summary Static init deadlock Win32GraphicsEnvironment and WToolkit
  * @run main GE_init3

--- a/jdk/test/java/awt/GridBagLayout/GridBagLayoutIpadXYTest/GridBagLayoutIpadXYTest.html
+++ b/jdk/test/java/awt/GridBagLayout/GridBagLayoutIpadXYTest/GridBagLayoutIpadXYTest.html
@@ -1,7 +1,7 @@
 <html>
 <!--  
 
- Copyright (c) 2009, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
  questions.
 
   @test
+  @key headful
   @bug 5004032
   @summary GridBagConstraints.ipad(x|y) defined in a new way
   @author dav@sparc.spb.su area= 

--- a/jdk/test/java/awt/GridLayout/LayoutExtraGaps/LayoutExtraGaps.java
+++ b/jdk/test/java/awt/GridLayout/LayoutExtraGaps/LayoutExtraGaps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
    @test
+  @key headful
    @bug 4370316
    @summary GridLayout does not centre its component properly
     (summary was GridLayout does not fill its Container)

--- a/jdk/test/java/awt/Insets/CombinedTestApp1.java
+++ b/jdk/test/java/awt/Insets/CombinedTestApp1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 4068386
   @summary Insets are incorrect for Frame w/MenuBar
   @library ../regtesthelpers

--- a/jdk/test/java/awt/KeyboardFocusmanager/ConsumeNextMnemonicKeyTypedTest/ConsumeForModalDialogTest/ConsumeForModalDialogTest.html
+++ b/jdk/test/java/awt/KeyboardFocusmanager/ConsumeNextMnemonicKeyTypedTest/ConsumeForModalDialogTest/ConsumeForModalDialogTest.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2006, 2014, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--
   @test
+  @key headful
   @bug        6391688
   @summary    Tests that next mnemonic KeyTyped is consumed for a modal dialog.
   @author     anton.tarasov@sun.com: area=awt.focus

--- a/jdk/test/java/awt/KeyboardFocusmanager/ConsumeNextMnemonicKeyTypedTest/ConsumeNextMnemonicKeyTypedTest.html
+++ b/jdk/test/java/awt/KeyboardFocusmanager/ConsumeNextMnemonicKeyTypedTest/ConsumeNextMnemonicKeyTypedTest.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2006, 2014, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--
   @test
+  @key headful
   @bug        6346690
   @summary    Tests that key_typed is consumed after mnemonic key_pressed is handled for a menu item.
   @author     anton.tarasov@sun.com: area=awt-focus

--- a/jdk/test/java/awt/KeyboardFocusmanager/DefaultPolicyChange/DefaultPolicyChange_AWT.java
+++ b/jdk/test/java/awt/KeyboardFocusmanager/DefaultPolicyChange/DefaultPolicyChange_AWT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6741526
   @summary KeyboardFocusManager.setDefaultFocusTraversalPolicy(FocusTraversalPolicy) affects created components
   @library ../../regtesthelpers

--- a/jdk/test/java/awt/KeyboardFocusmanager/TypeAhead/ButtonActionKeyTest/ButtonActionKeyTest.html
+++ b/jdk/test/java/awt/KeyboardFocusmanager/TypeAhead/ButtonActionKeyTest/ButtonActionKeyTest.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2006, 2013, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--
   @test
+  @key headful
   @bug        6396785
   @summary    Action key pressed on a button should be swallowed.
   @author     anton.tarasov@...: area=awt.focus

--- a/jdk/test/java/awt/KeyboardFocusmanager/TypeAhead/EnqueueWithDialogButtonTest/EnqueueWithDialogButtonTest.java
+++ b/jdk/test/java/awt/KeyboardFocusmanager/TypeAhead/EnqueueWithDialogButtonTest/EnqueueWithDialogButtonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,12 +22,13 @@
  */
 
 /*
-@test
-@bug 4799136
-@summary Tests that type-ahead for dialog works and doesn't block program
-@author Dmitry.Cherepanov@SUN.COM area=awt.focus
-@run main EnqueueWithDialogButtonTest
-*/
+ * @test
+ * @key headful
+ * @bug 4799136
+ * @summary Tests that type-ahead for dialog works and doesn't block program
+ * @author Dmitry.Cherepanov@SUN.COM area=awt.focus
+ * @run main EnqueueWithDialogButtonTest
+ */
 
 import java.awt.*;
 import java.lang.reflect.InvocationTargetException;

--- a/jdk/test/java/awt/KeyboardFocusmanager/TypeAhead/EnqueueWithDialogTest/EnqueueWithDialogTest.java
+++ b/jdk/test/java/awt/KeyboardFocusmanager/TypeAhead/EnqueueWithDialogTest/EnqueueWithDialogTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,12 +22,13 @@
  */
 
 /*
-@test
-@bug 4799136
-@summary Tests that type-ahead for dialog works and doesn't block program
-@author Dmitry.Cherepanov@SUN.COM area=awt.focus
-@run main EnqueueWithDialogTest
-*/
+ * @test
+ * @key headful
+ * @bug 4799136
+ * @summary Tests that type-ahead for dialog works and doesn't block program
+ * @author Dmitry.Cherepanov@SUN.COM area=awt.focus
+ * @run main EnqueueWithDialogTest
+ */
 
 import java.awt.*;
 import java.lang.reflect.InvocationTargetException;

--- a/jdk/test/java/awt/KeyboardFocusmanager/TypeAhead/FreezeTest/FreezeTest.java
+++ b/jdk/test/java/awt/KeyboardFocusmanager/TypeAhead/FreezeTest/FreezeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,12 +21,13 @@
  * questions.
  */
 /*
-@test
-@bug 4799136
-@summary Tests that type-ahead for dialog works and doesn't block program
-@author Dmitry.Cherepanov@SUN.COM area=awt.focus
-@run main FreezeTest
-*/
+ * @test
+ * @key headful
+ * @bug 4799136
+ * @summary Tests that type-ahead for dialog works and doesn't block program
+ * @author Dmitry.Cherepanov@SUN.COM area=awt.focus
+ * @run main FreezeTest
+ */
 
 import java.awt.*;
 import java.lang.reflect.InvocationTargetException;

--- a/jdk/test/java/awt/KeyboardFocusmanager/TypeAhead/MenuItemActivatedTest/MenuItemActivatedTest.html
+++ b/jdk/test/java/awt/KeyboardFocusmanager/TypeAhead/MenuItemActivatedTest/MenuItemActivatedTest.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2006, 2013, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--
   @test
+  @key headful
   @bug        6396785
   @summary    MenuItem activated with space should swallow this space.
   @author     anton.tarasov@...: area=awt.focus

--- a/jdk/test/java/awt/KeyboardFocusmanager/TypeAhead/SubMenuShowTest/SubMenuShowTest.html
+++ b/jdk/test/java/awt/KeyboardFocusmanager/TypeAhead/SubMenuShowTest/SubMenuShowTest.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2006, 2013, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--
   @test
+  @key headful
   @bug        6380743
   @summary    Submenu should be shown by mnemonic key press.
   @author     anton.tarasov@...: area=awt.focus

--- a/jdk/test/java/awt/KeyboardFocusmanager/TypeAhead/TestDialogTypeAhead.html
+++ b/jdk/test/java/awt/KeyboardFocusmanager/TypeAhead/TestDialogTypeAhead.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--  
   @test
+  @key headful
   @bug 4799136
   @summary Tests that type-ahead for dialog works and doesn't block program
   @author  area=awt.focus

--- a/jdk/test/java/awt/List/ActionAfterRemove/ActionAfterRemove.java
+++ b/jdk/test/java/awt/List/ActionAfterRemove/ActionAfterRemove.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6426186
   @summary XToolkit: List throws ArrayIndexOutOfBoundsException on double clicking when the List is empty
   @author Dmitry Cherepanov area=awt-list

--- a/jdk/test/java/awt/List/FirstItemRemoveTest/FirstItemRemoveTest.html
+++ b/jdk/test/java/awt/List/FirstItemRemoveTest/FirstItemRemoveTest.html
@@ -1,6 +1,6 @@
 <html>
 <!--
-  Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+  Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  
   This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
  -->
 <!--  
   @test
+  @key headful
   @bug 6299858
   @summary PIT. Focused border not shown on List if selected item is removed, XToolkit
   @author Dmitry.Cherepanov@SUN.COM area=awt.list

--- a/jdk/test/java/awt/List/FocusEmptyListTest/FocusEmptyListTest.html
+++ b/jdk/test/java/awt/List/FocusEmptyListTest/FocusEmptyListTest.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2007, 2015, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  
  This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 <html>
 <!--  
   @test
+  @key headful
   @bug 6387275
   @summary List: the focus is at the top of the first item, XAWT
   @author Dmitry.Cherepanov@SUN.COM area=awt.list

--- a/jdk/test/java/awt/List/KeyEventsTest/KeyEventsTest.html
+++ b/jdk/test/java/awt/List/KeyEventsTest/KeyEventsTest.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2005, 2014, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--  
   @test
+  @key headful
   @bug 6190768 6190778
   @summary Tests that triggering events on AWT list by pressing CTRL + HOME, CTRL + END, PG-UP, PG-DOWN similar Motif behavior
   @author Dmitry.Cherepanov@SUN.COM area=awt.list

--- a/jdk/test/java/awt/List/ListGarbageCollectionTest/AwtListGarbageCollectionTest.java
+++ b/jdk/test/java/awt/List/ListGarbageCollectionTest/AwtListGarbageCollectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key headful
  * @bug 8040076
  * @summary AwtList not garbage collected
  * @run main/othervm -Xmx100m AwtListGarbageCollectionTest

--- a/jdk/test/java/awt/List/ListPeer/R2303044ListSelection.java
+++ b/jdk/test/java/awt/List/ListPeer/R2303044ListSelection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ import java.awt.Robot;
 
 /**
  * @test
+ * @key headful
  * @summary rdar://problem/2303044 List selection not set when peer is created
  * @summary com.apple.junit.java.awt.List;
  * @run main R2303044ListSelection

--- a/jdk/test/java/awt/List/ScrollOutside/ScrollOut.java
+++ b/jdk/test/java/awt/List/ScrollOutside/ScrollOut.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 7036733
   @summary Regression : NullPointerException when scrolling horizontally on AWT List
   @author Andrei Dmitriev area=awt-list

--- a/jdk/test/java/awt/List/SingleModeDeselect/SingleModeDeselect.java
+++ b/jdk/test/java/awt/List/SingleModeDeselect/SingleModeDeselect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6248040
   @summary List.deselect() de-selects the currently selected item regardless of the index, win32
   @author Dmitry Cherepanov area=awt.list

--- a/jdk/test/java/awt/Menu/NullMenuLabelTest/NullMenuLabelTest.java
+++ b/jdk/test/java/awt/Menu/NullMenuLabelTest/NullMenuLabelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,12 +21,14 @@
  * questions.
  */
 
-/*      @test 1.5 98/07/23
-        @bug 4064202 4253466
-        @summary Test for Win32 NPE when MenuItem with null label added.
-        @author fred.ecks
-        @run main/othervm NullMenuLabelTest
-*/
+/*
+ * @test 1.5 98/07/23
+ * @key headful
+ * @bug 4064202 4253466
+ * @summary Test for Win32 NPE when MenuItem with null label added.
+ * @author fred.ecks
+ * @run main/othervm NullMenuLabelTest
+ */
 
 import java.awt.*;
 

--- a/jdk/test/java/awt/Menu/OpensWithNoGrab/OpensWithNoGrab.java
+++ b/jdk/test/java/awt/Menu/OpensWithNoGrab/OpensWithNoGrab.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6354721
   @summary REG: Menu does not disappear when clicked, keeping Choice's drop-down open, XToolkit
   @author andrei.dmitriev: area=awt.menu

--- a/jdk/test/java/awt/MenuBar/DeadlockTest1/DeadlockTest1.java
+++ b/jdk/test/java/awt/MenuBar/DeadlockTest1/DeadlockTest1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6990904
   @summary on oel5.5, Frame doesn't show if the Frame has only a MenuBar as its component.
   @author Andrei Dmitriev: area=awt-menubar

--- a/jdk/test/java/awt/MenuBar/RemoveHelpMenu/RemoveHelpMenu.java
+++ b/jdk/test/java/awt/MenuBar/RemoveHelpMenu/RemoveHelpMenu.java
@@ -27,6 +27,7 @@ import java.awt.MenuBar;
 
 /**
  * @test
+ * @key headful
  * @bug 6475361
  * @author Sergey Bylokhov
  */

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/HierarchyBoundsListenerMixingTest.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/HierarchyBoundsListenerMixingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,11 +33,12 @@ import java.io.*;
  * <p>See <a href="https://bugs.openjdk.java.net/browse/JDK-6768230">CR6768230</a> for details.
  */
 /*
-@test
-@bug 6768230
-@summary Mixing test for HierarchyBoundsListener ancestors
-@build FrameBorderCounter
-@run main HierarchyBoundsListenerMixingTest
+ * @test
+ * @key headful
+ * @bug 6768230
+ * @summary Mixing test for HierarchyBoundsListener ancestors
+ * @build FrameBorderCounter
+ * @run main HierarchyBoundsListenerMixingTest
  */
 public class HierarchyBoundsListenerMixingTest {
 

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/JButtonInGlassPaneOverlapping.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/JButtonInGlassPaneOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,12 +29,13 @@ import javax.swing.*;
  * <p>See base class for details.
  */
 /*
-@test
-@summary Simple Overlapping test for javax.swing.JButton
-@author sergey.grinev@oracle.com: area=awt.mixing
-@library ../../regtesthelpers
-@build Util
-@run main JButtonInGlassPaneOverlapping
+ * @test
+ * @key headful
+ * @summary Simple Overlapping test for javax.swing.JButton
+ * @author sergey.grinev@oracle.com: area=awt.mixing
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main JButtonInGlassPaneOverlapping
  */
 public class JButtonInGlassPaneOverlapping extends GlassPaneOverlappingTestBase {
 

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/JButtonOverlapping.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/JButtonOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,12 +29,12 @@ import javax.swing.*;
  * <p>See base class for details.
  */
 /*
-@test
-@summary Simple Overlapping test for javax.swing.JButton
-@author sergey.grinev@oracle.com: area=awt.mixing
-@library ../../regtesthelpers
-@build Util
-@run main JButtonOverlapping
+ * @test
+ * @key headful
+ * @summary Simple Overlapping test for javax.swing.JButton
+ * @author sergey.grinev@oracle.com: area=awt.mixing
+ * @build Util
+ * @run main JButtonOverlapping
  */
 public class JButtonOverlapping extends SimpleOverlappingTestBase {
 

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/JColorChooserOverlapping.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/JColorChooserOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,12 +28,13 @@ import javax.swing.*;
  * <p>See base class for details.
  */
 /*
-@test
-@summary Simple Overlapping test for javax.swing.JColorChooser
-@author sergey.grinev@oracle.com: area=awt.mixing
-@library ../../regtesthelpers
-@build Util
-@run main JColorChooserOverlapping
+ * @test
+ * @key headful
+ * @summary Simple Overlapping test for javax.swing.JColorChooser
+ * @author sergey.grinev@oracle.com: area=awt.mixing
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main JColorChooserOverlapping
  */
 public class JColorChooserOverlapping extends SimpleOverlappingTestBase {
 

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/JComboBoxOverlapping.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/JComboBoxOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,12 +39,13 @@ import test.java.awt.regtesthelpers.Util;
  * <p>See base class for details.
  */
 /*
-@test
-@summary Overlapping test for javax.swing.JScrollPane
-@author sergey.grinev@oracle.com: area=awt.mixing
-@library ../../regtesthelpers
-@build Util
-@run main JComboBoxOverlapping
+ * @test
+ * @key headful
+ * @summary Overlapping test for javax.swing.JScrollPane
+ * @author sergey.grinev@oracle.com: area=awt.mixing
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main JComboBoxOverlapping
  */
 public class JComboBoxOverlapping extends OverlappingTestBase {
 

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/JEditorPaneInGlassPaneOverlapping.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/JEditorPaneInGlassPaneOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,12 +30,13 @@ import javax.swing.*;
  * <p>See base class for details.
  */
 /*
-@test
-@summary Simple Overlapping test for javax.swing.JLabel
-@author sergey.grinev@oracle.com: area=awt.mixing
-@library ../../regtesthelpers
-@build Util
-@run main JEditorPaneInGlassPaneOverlapping
+ * @test
+ * @key headful
+ * @summary Simple Overlapping test for javax.swing.JLabel
+ * @author sergey.grinev@oracle.com: area=awt.mixing
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main JEditorPaneInGlassPaneOverlapping
  */
 public class JEditorPaneInGlassPaneOverlapping extends GlassPaneOverlappingTestBase {
 

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/JEditorPaneOverlapping.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/JEditorPaneOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,12 +28,13 @@ import javax.swing.*;
  * <p>See base class for details.
  */
 /*
-@test
-@summary Simple Overlapping test for javax.swing.JLabel
-@author sergey.grinev@oracle.com: area=awt.mixing
-@library ../../regtesthelpers
-@build Util
-@run main JEditorPaneOverlapping
+ * @test
+ * @key headful
+ * @summary Simple Overlapping test for javax.swing.JLabel
+ * @author sergey.grinev@oracle.com: area=awt.mixing
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main JEditorPaneOverlapping
  */
 public class JEditorPaneOverlapping extends SimpleOverlappingTestBase {
 

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/JGlassPaneInternalFrameOverlapping.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/JGlassPaneInternalFrameOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,13 +40,14 @@ import test.java.awt.regtesthelpers.Util;
  * <p>See base class for details.
  */
 /*
-@test
-@bug 6637655 6985776
-@summary Overlapping test for javax.swing.JScrollPane
-@author sergey.grinev@oracle.com: area=awt.mixing
-@library ../../regtesthelpers
-@build Util
-@run main JGlassPaneInternalFrameOverlapping
+ * @test
+ * @key headful
+ * @bug 6637655 6985776
+ * @summary Overlapping test for javax.swing.JScrollPane
+ * @author sergey.grinev@oracle.com: area=awt.mixing
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main JGlassPaneInternalFrameOverlapping
  */
 public class JGlassPaneInternalFrameOverlapping extends OverlappingTestBase {
 

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/JGlassPaneMoveOverlapping.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/JGlassPaneMoveOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,13 +41,14 @@ import test.java.awt.regtesthelpers.Util;
  * <p>See base class for details.
  */
 /*
-@test
-@bug 6637655 6981919
-@summary Overlapping test for javax.swing.JScrollPane
-@author sergey.grinev@oracle.com: area=awt.mixing
-@library ../../regtesthelpers
-@build Util
-@run main JGlassPaneMoveOverlapping
+ * @test
+ * @key headful
+ * @bug 6637655 6981919
+ * @summary Overlapping test for javax.swing.JScrollPane
+ * @author sergey.grinev@oracle.com: area=awt.mixing
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main JGlassPaneMoveOverlapping
  */
 public class JGlassPaneMoveOverlapping extends OverlappingTestBase {
 

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/JInternalFrameMoveOverlapping.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/JInternalFrameMoveOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,13 +37,14 @@ import test.java.awt.regtesthelpers.Util;
  * <p>See <a href="http://monaco.sfbay.sun.com/detail.jsf?cr=6985399">CR6768230</a> for details and base class for test info.
  */
 /*
-@test
-@bug 6985399
-@summary Overlapping test for javax.swing.JScrollPane
-@author sergey.grinev@oracle.com: area=awt.mixing
-@library ../../regtesthelpers
-@build Util
-@run main JInternalFrameMoveOverlapping
+ * @test
+ * @key headful
+ * @bug 6985399
+ * @summary Overlapping test for javax.swing.JScrollPane
+ * @author sergey.grinev@oracle.com: area=awt.mixing
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main JInternalFrameMoveOverlapping
  */
 public class JInternalFrameMoveOverlapping extends OverlappingTestBase {
 

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/JInternalFrameOverlapping.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/JInternalFrameOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,12 +37,13 @@ import test.java.awt.regtesthelpers.Util;
  * <p>See base class for test info.
  */
 /*
-@test
-@summary Overlapping test for javax.swing.JScrollPane
-@author sergey.grinev@oracle.com: area=awt.mixing
-@library ../../regtesthelpers
-@build Util
-@run main JInternalFrameOverlapping
+ * @test
+ * @key headful
+ * @summary Overlapping test for javax.swing.JScrollPane
+ * @author sergey.grinev@oracle.com: area=awt.mixing
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main JInternalFrameOverlapping
  */
 public class JInternalFrameOverlapping extends OverlappingTestBase {
 

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/JLabelInGlassPaneOverlapping.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/JLabelInGlassPaneOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,12 +30,13 @@ import javax.swing.*;
  * <p>See base class for details.
  */
 /*
-@test
-@summary Simple Overlapping test for javax.swing.JLabel
-@author sergey.grinev@oracle.com: area=awt.mixing
-@library ../../regtesthelpers
-@build Util
-@run main JLabelInGlassPaneOverlapping
+ * @test
+ * @key headful
+ * @summary Simple Overlapping test for javax.swing.JLabel
+ * @author sergey.grinev@oracle.com: area=awt.mixing
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main JLabelInGlassPaneOverlapping
  */
 public class JLabelInGlassPaneOverlapping extends GlassPaneOverlappingTestBase {
 

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/JLabelOverlapping.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/JLabelOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,12 +29,13 @@ import javax.swing.*;
  * <p>See base class for details.
  */
 /*
-@test
-@summary Simple Overlapping test for javax.swing.JLabel
-@author sergey.grinev@oracle.com: area=awt.mixing
-@library ../../regtesthelpers
-@build Util
-@run main JLabelOverlapping
+ * @test
+ * @key headful
+ * @summary Simple Overlapping test for javax.swing.JLabel
+ * @author sergey.grinev@oracle.com: area=awt.mixing
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main JLabelOverlapping
  */
 public class JLabelOverlapping extends SimpleOverlappingTestBase {
 

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/JListInGlassPaneOverlapping.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/JListInGlassPaneOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,12 +29,13 @@ import javax.swing.*;
  * <p>See base class for details.
  */
 /*
-@test
-@summary Simple Overlapping test for javax.swing.JList
-@author sergey.grinev@oracle.com: area=awt.mixing
-@library ../../regtesthelpers
-@build Util
-@run main JListInGlassPaneOverlapping
+ * @test
+ * @key headful
+ * @summary Simple Overlapping test for javax.swing.JList
+ * @author sergey.grinev@oracle.com: area=awt.mixing
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main JListInGlassPaneOverlapping
  */
 public class JListInGlassPaneOverlapping extends GlassPaneOverlappingTestBase {
 

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/JListOverlapping.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/JListOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,12 +28,13 @@ import javax.swing.*;
  * <p>See base class for details.
  */
 /*
-@test
-@summary Simple Overlapping test for javax.swing.JList
-@author sergey.grinev@oracle.com: area=awt.mixing
-@library ../../regtesthelpers
-@build Util
-@run main JListOverlapping
+ * @test
+ * @key headful
+ * @summary Simple Overlapping test for javax.swing.JList
+ * @author sergey.grinev@oracle.com: area=awt.mixing
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main JListOverlapping
  */
 public class JListOverlapping extends SimpleOverlappingTestBase {
 

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/JMenuBarOverlapping.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/JMenuBarOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,12 +44,13 @@ import test.java.awt.regtesthelpers.Util;
  * <p>See base class for test info.
  */
 /*
-@test
-@summary Overlapping test for javax.swing.JScrollPane
-@author sergey.grinev@oracle.com: area=awt.mixing
-@library ../../regtesthelpers
-@build Util
-@run main JMenuBarOverlapping
+ * @test
+ * @key headful
+ * @summary Overlapping test for javax.swing.JScrollPane
+ * @author sergey.grinev@oracle.com: area=awt.mixing
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main JMenuBarOverlapping
  */
 public class JMenuBarOverlapping extends OverlappingTestBase {
 

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/JPanelInGlassPaneOverlapping.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/JPanelInGlassPaneOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,12 +30,13 @@ import javax.swing.*;
  * <p>See base class for details.
  */
 /*
-@test
-@summary Simple Overlapping test for javax.swing.JPanel
-@author sergey.grinev@oracle.com: area=awt.mixing
-@library ../../regtesthelpers
-@build Util
-@run main JPanelInGlassPaneOverlapping
+ * @test
+ * @key headful
+ * @summary Simple Overlapping test for javax.swing.JPanel
+ * @author sergey.grinev@oracle.com: area=awt.mixing
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main JPanelInGlassPaneOverlapping
  */
 public class JPanelInGlassPaneOverlapping extends GlassPaneOverlappingTestBase {
 

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/JPanelOverlapping.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/JPanelOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,12 +29,13 @@ import javax.swing.*;
  * <p>See base class for details.
  */
 /*
-@test
-@summary Simple Overlapping test for javax.swing.JPanel
-@author sergey.grinev@oracle.com: area=awt.mixing
-@library ../../regtesthelpers
-@build Util
-@run main JPanelOverlapping
+ * @test
+ * @key headful
+ * @summary Simple Overlapping test for javax.swing.JPanel
+ * @author sergey.grinev@oracle.com: area=awt.mixing
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main JPanelOverlapping
  */
 public class JPanelOverlapping extends SimpleOverlappingTestBase {
 

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/JPopupMenuOverlapping.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/JPopupMenuOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,12 +41,13 @@ import test.java.awt.regtesthelpers.Util;
  * <p>See base class for test info.
  */
 /*
-@test
-@summary Overlapping test for javax.swing.JScrollPane
-@author sergey.grinev@oracle.com: area=awt.mixing
-@library ../../regtesthelpers
-@build Util
-@run main JPopupMenuOverlapping
+ * @test
+ * @key headful
+ * @summary Overlapping test for javax.swing.JScrollPane
+ * @author sergey.grinev@oracle.com: area=awt.mixing
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main JPopupMenuOverlapping
  */
 public class JPopupMenuOverlapping extends OverlappingTestBase {
 

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/JProgressBarInGlassPaneOverlapping.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/JProgressBarInGlassPaneOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,12 +30,13 @@ import javax.swing.*;
  * <p>See base class for details.
  */
 /*
-@test
-@summary Simple Overlapping test for javax.swing.JProgressBar
-@author sergey.grinev@oracle.com: area=awt.mixing
-@library ../../regtesthelpers
-@build Util
-@run main JProgressBarInGlassPaneOverlapping
+ * @test
+ * @key headful
+ * @summary Simple Overlapping test for javax.swing.JProgressBar
+ * @author sergey.grinev@oracle.com: area=awt.mixing
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main JProgressBarInGlassPaneOverlapping
  */
 public class JProgressBarInGlassPaneOverlapping extends GlassPaneOverlappingTestBase {
 

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/JProgressBarOverlapping.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/JProgressBarOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,12 +29,13 @@ import javax.swing.*;
  * <p>See base class for details.
  */
 /*
-@test
-@summary Simple Overlapping test for javax.swing.JProgressBar
-@author sergey.grinev@oracle.com: area=awt.mixing
-@library ../../regtesthelpers
-@build Util
-@run main JProgressBarOverlapping
+ * @test
+ * @key headful
+ * @summary Simple Overlapping test for javax.swing.JProgressBar
+ * @author sergey.grinev@oracle.com: area=awt.mixing
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main JProgressBarOverlapping
  */
 public class JProgressBarOverlapping extends SimpleOverlappingTestBase {
 

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/JScrollBarInGlassPaneOverlapping.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/JScrollBarInGlassPaneOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,12 +33,13 @@ import javax.swing.*;
  * <p>See base class for details.
  */
 /*
-@test
-@summary Simple Overlapping test for javax.swing.JScrollBar
-@author sergey.grinev@oracle.com: area=awt.mixing
-@library ../../regtesthelpers
-@build Util
-@run main JScrollBarInGlassPaneOverlapping
+ * @test
+ * @key headful
+ * @summary Simple Overlapping test for javax.swing.JScrollBar
+ * @author sergey.grinev@oracle.com: area=awt.mixing
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main JScrollBarInGlassPaneOverlapping
  */
 public class JScrollBarInGlassPaneOverlapping extends GlassPaneOverlappingTestBase {
 

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/JScrollBarOverlapping.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/JScrollBarOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,12 +32,13 @@ import javax.swing.*;
  * <p>See base class for details.
  */
 /*
-@test
-@summary Simple Overlapping test for javax.swing.JScrollBar
-@author sergey.grinev@oracle.com: area=awt.mixing
-@library ../../regtesthelpers
-@build Util
-@run main JScrollBarOverlapping
+ * @test
+ * @key headful
+ * @summary Simple Overlapping test for javax.swing.JScrollBar
+ * @author sergey.grinev@oracle.com: area=awt.mixing
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main JScrollBarOverlapping
  */
 public class JScrollBarOverlapping extends SimpleOverlappingTestBase {
 

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/JScrollPaneOverlapping.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/JScrollPaneOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,12 +39,13 @@ import test.java.awt.regtesthelpers.Util;
  * <p>See base class for test info.
  */
 /*
-@test
-@summary Overlapping test for javax.swing.JScrollPane
-@author sergey.grinev@oracle.com: area=awt.mixing
-@library ../../regtesthelpers
-@build Util
-@run main JScrollPaneOverlapping
+ * @test
+ * @key headful
+ * @summary Overlapping test for javax.swing.JScrollPane
+ * @author sergey.grinev@oracle.com: area=awt.mixing
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main JScrollPaneOverlapping
  */
 public class JScrollPaneOverlapping extends OverlappingTestBase {
 

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/JSliderInGlassPaneOverlapping.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/JSliderInGlassPaneOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,12 +30,13 @@ import javax.swing.*;
  * <p>See base class for details.
  */
 /*
-@test
-@summary Simple Overlapping test for javax.swing.JSlider
-@author sergey.grinev@oracle.com: area=awt.mixing
-@library ../../regtesthelpers
-@build Util
-@run main JSliderInGlassPaneOverlapping
+ * @test
+ * @key headful
+ * @summary Simple Overlapping test for javax.swing.JSlider
+ * @author sergey.grinev@oracle.com: area=awt.mixing
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main JSliderInGlassPaneOverlapping
  */
 public class JSliderInGlassPaneOverlapping extends GlassPaneOverlappingTestBase {
 

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/JSliderOverlapping.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/JSliderOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,12 +29,13 @@ import javax.swing.*;
  * <p>See base class for details.
  */
 /*
-@test
-@summary Simple Overlapping test for javax.swing.JSlider
-@author sergey.grinev@oracle.com: area=awt.mixing
-@library ../../regtesthelpers
-@build Util
-@run main JSliderOverlapping
+ * @test
+ * @key headful
+ * @summary Simple Overlapping test for javax.swing.JSlider
+ * @author sergey.grinev@oracle.com: area=awt.mixing
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main JSliderOverlapping
  */
 public class JSliderOverlapping extends SimpleOverlappingTestBase {
 

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/JSpinnerInGlassPaneOverlapping.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/JSpinnerInGlassPaneOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,12 +32,13 @@ import javax.swing.event.ChangeListener;
  * <p>See base class for details.
  */
 /*
-@test
-@summary Simple Overlapping test for javax.swing.JSpinner
-@author sergey.grinev@oracle.com: area=awt.mixing
-@library ../../regtesthelpers
-@build Util
-@run main JSpinnerInGlassPaneOverlapping
+ * @test
+ * @key headful
+ * @summary Simple Overlapping test for javax.swing.JSpinner
+ * @author sergey.grinev@oracle.com: area=awt.mixing
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main JSpinnerInGlassPaneOverlapping
  */
 public class JSpinnerInGlassPaneOverlapping extends GlassPaneOverlappingTestBase {
 

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/JSpinnerOverlapping.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/JSpinnerOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,12 +31,13 @@ import javax.swing.event.ChangeListener;
  * <p>See base class for details.
  */
 /*
-@test
-@summary Simple Overlapping test for javax.swing.JSpinner
-@author sergey.grinev@oracle.com: area=awt.mixing
-@library ../../regtesthelpers
-@build Util
-@run main JSpinnerOverlapping
+ * @test
+ * @key headful
+ * @summary Simple Overlapping test for javax.swing.JSpinner
+ * @author sergey.grinev@oracle.com: area=awt.mixing
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main JSpinnerOverlapping
  */
 public class JSpinnerOverlapping extends SimpleOverlappingTestBase {
 

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/JSplitPaneOverlapping.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/JSplitPaneOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,13 +45,14 @@ import test.java.awt.regtesthelpers.Util;
  * <p>See base class for test info.
  */
 /*
-@test
-@bug 6986109
-@summary Overlapping test for javax.swing.JSplitPane
-@author sergey.grinev@oracle.com: area=awt.mixing
-@library ../../regtesthelpers
-@build Util
-@run main JSplitPaneOverlapping
+ * @test
+ * @key headful
+ * @bug 6986109
+ * @summary Overlapping test for javax.swing.JSplitPane
+ * @author sergey.grinev@oracle.com: area=awt.mixing
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main JSplitPaneOverlapping
  */
 public class JSplitPaneOverlapping extends OverlappingTestBase {
 

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/JTableInGlassPaneOverlapping.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/JTableInGlassPaneOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,12 +32,13 @@ import javax.swing.event.TableModelListener;
  * <p>See base class for details.
  */
 /*
-@test
-@summary Simple Overlapping test for JTable
-@author sergey.grinev@oracle.com: area=awt.mixing
-@library ../../regtesthelpers
-@build Util
-@run main JTableInGlassPaneOverlapping
+ * @test
+ * @key headful
+ * @summary Simple Overlapping test for JTable
+ * @author sergey.grinev@oracle.com: area=awt.mixing
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main JTableInGlassPaneOverlapping
  */
 public class JTableInGlassPaneOverlapping extends GlassPaneOverlappingTestBase {
 

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/JTableOverlapping.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/JTableOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,13 +28,15 @@ import javax.swing.*;
  * <p>See base class for details.
  */
 /*
-@test
-@summary Simple Overlapping test for JTable
-@author sergey.grinev@oracle.com: area=awt.mixing
-@library ../../regtesthelpers
-@build Util
-@run main JTableOverlapping
+ * @test
+ * @key headful
+ * @summary Simple Overlapping test for JTable
+ * @author sergey.grinev@oracle.com: area=awt.mixing
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main JTableOverlapping
  */
+
 public class JTableOverlapping extends SimpleOverlappingTestBase {
 
     @Override

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/JTextAreaInGlassPaneOverlapping.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/JTextAreaInGlassPaneOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,13 +30,15 @@ import javax.swing.*;
  * <p>See base class for details.
  */
 /*
-@test
-@summary Simple Overlapping test for javax.swing.JLabel
-@author sergey.grinev@oracle.com: area=awt.mixing
-@library ../../regtesthelpers
-@build Util
-@run main JTextAreaInGlassPaneOverlapping
+ * @test
+ * @key headful
+ * @summary Simple Overlapping test for javax.swing.JLabel
+ * @author sergey.grinev@oracle.com: area=awt.mixing
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main JTextAreaInGlassPaneOverlapping
  */
+
 public class JTextAreaInGlassPaneOverlapping extends GlassPaneOverlappingTestBase {
 
     @Override

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/JTextAreaOverlapping.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/JTextAreaOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,13 +29,15 @@ import javax.swing.*;
  * <p>See base class for details.
  */
 /*
-@test
-@summary Simple Overlapping test for javax.swing.JLabel
-@author sergey.grinev@oracle.com: area=awt.mixing
-@library ../../regtesthelpers
-@build Util
-@run main JTextAreaOverlapping
+ * @test
+ * @key headful
+ * @summary Simple Overlapping test for javax.swing.JLabel
+ * @author sergey.grinev@oracle.com: area=awt.mixing
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main JTextAreaOverlapping
  */
+
 public class JTextAreaOverlapping extends SimpleOverlappingTestBase {
 
     @Override

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/JTextFieldInGlassPaneOverlapping.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/JTextFieldInGlassPaneOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,13 +30,15 @@ import javax.swing.*;
  * <p>See base class for details.
  */
 /*
-@test
-@summary Simple Overlapping test for javax.swing.JLabel
-@author sergey.grinev@oracle.com: area=awt.mixing
-@library ../../regtesthelpers
-@build Util
-@run main JTextFieldInGlassPaneOverlapping
+ * @test
+ * @key headful
+ * @summary Simple Overlapping test for javax.swing.JLabel
+ * @author sergey.grinev@oracle.com: area=awt.mixing
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main JTextFieldInGlassPaneOverlapping
  */
+
 public class JTextFieldInGlassPaneOverlapping extends GlassPaneOverlappingTestBase {
 
     @Override

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/JTextFieldOverlapping.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/JTextFieldOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,13 +29,15 @@ import javax.swing.*;
  * <p>See base class for details.
  */
 /*
-@test
-@summary Simple Overlapping test for javax.swing.JLabel
-@author sergey.grinev@oracle.com: area=awt.mixing
-@library ../../regtesthelpers
-@build Util
-@run main JTextFieldOverlapping
+ * @test
+ * @key headful
+ * @summary Simple Overlapping test for javax.swing.JLabel
+ * @author sergey.grinev@oracle.com: area=awt.mixing
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main JTextFieldOverlapping
  */
+
 public class JTextFieldOverlapping extends SimpleOverlappingTestBase {
 
     @Override

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/JToggleButtonInGlassPaneOverlapping.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/JToggleButtonInGlassPaneOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,13 +29,15 @@ import javax.swing.*;
  * <p>See base class for details.
  */
 /*
-@test
-@summary Simple Overlapping test for javax.swing.JToggleButton
-@author sergey.grinev@oracle.com: area=awt.mixing
-@library ../../regtesthelpers
-@build Util
-@run main JToggleButtonInGlassPaneOverlapping
+ * @test
+ * @key headful
+ * @summary Simple Overlapping test for javax.swing.JToggleButton
+ * @author sergey.grinev@oracle.com: area=awt.mixing
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main JToggleButtonInGlassPaneOverlapping
  */
+
 public class JToggleButtonInGlassPaneOverlapping extends GlassPaneOverlappingTestBase {
 
     @Override

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/JToggleButtonOverlapping.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/JToggleButtonOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,13 +28,15 @@ import javax.swing.*;
  * <p>See base class for details.
  */
 /*
-@test
-@summary Simple Overlapping test for javax.swing.JToggleButton
-@author sergey.grinev@oracle.com: area=awt.mixing
-@library ../../regtesthelpers
-@build Util
-@run main JToggleButtonOverlapping
+ * @test
+ * @key headful
+ * @summary Simple Overlapping test for javax.swing.JToggleButton
+ * @author sergey.grinev@oracle.com: area=awt.mixing
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main JToggleButtonOverlapping
  */
+
 public class JToggleButtonOverlapping extends SimpleOverlappingTestBase {
 
     @Override

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/MixingFrameResizing.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/MixingFrameResizing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,14 +37,16 @@ import test.java.awt.regtesthelpers.Util;
  * <p>See base class for test info.
  */
 /*
-@test
-@bug 6777370
-@summary Issues when resizing the JFrame with HW components
-@author sergey.grinev@oracle.com: area=awt.mixing
-@library ../../regtesthelpers
-@build Util
-@run main MixingFrameResizing
+ * @test
+ * @key headful
+ * @bug 6777370
+ * @summary Issues when resizing the JFrame with HW components
+ * @author sergey.grinev@oracle.com: area=awt.mixing
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main MixingFrameResizing
  */
+
 public class MixingFrameResizing extends OverlappingTestBase {
 
     {testEmbeddedFrame = true;}

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/MixingPanelsResizing.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/MixingPanelsResizing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,14 +33,15 @@ import test.java.awt.regtesthelpers.Util;
  * <p>See <a href="https://bugs.openjdk.java.net/browse/JDK-6786219">JDK-6786219</a> for details
  */
 /*
-@test
-@bug 6786219
-@summary Issues when resizing the frame after mixing of heavy weight & light weight components
-@author sergey.grinev@oracle.com: area=awt.mixing
-@library ../../regtesthelpers
-@build Util
-@build FrameBorderCounter
-@run main MixingPanelsResizing
+ * @test
+ * @key headful
+ * @bug 6786219
+ * @summary Issues when resizing the frame after mixing of heavy weight & light weight components
+ * @author sergey.grinev@oracle.com: area=awt.mixing
+ * @library ../../regtesthelpers
+ * @build Util
+ * @build FrameBorderCounter
+ * @run main MixingPanelsResizing
  */
 public class MixingPanelsResizing {
 

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/OpaqueOverlapping.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/OpaqueOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,13 +42,15 @@ import test.java.awt.regtesthelpers.Util;
  * <p>See base class for test info.
  */
 /*
-@test
-@bug 6776743
-@summary Opaque overlapping test for each AWT component
-@library ../../regtesthelpers
-@build Util
-@run main OpaqueOverlapping
+ * @test
+ * @key headful
+ * @bug 6776743
+ * @summary Opaque overlapping test for each AWT component
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main OpaqueOverlapping
  */
+
 public class OpaqueOverlapping extends OverlappingTestBase {
 
     {

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/OpaqueOverlappingChoice.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/OpaqueOverlappingChoice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,13 +28,15 @@
  * This test case was separated from {@link OpaqueOverlapping} due to CR 6994264 (Choice autohides dropdown on Solaris 10)
  */
 /*
-@test
-@bug 6994264
-@summary Opaque overlapping test for Choice AWT component
-@library ../../regtesthelpers
-@build Util
-@run main OpaqueOverlappingChoice
+ * @test
+ * @key headful
+ * @bug 6994264
+ * @summary Opaque overlapping test for Choice AWT component
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main OpaqueOverlappingChoice
  */
+
 public class OpaqueOverlappingChoice extends OpaqueOverlapping  {
     {
         onlyClassName = "Choice";

--- a/jdk/test/java/awt/Mixing/AWT_Mixing/ViewportOverlapping.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/ViewportOverlapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,14 +46,16 @@ import test.java.awt.regtesthelpers.Util;
  * <p>See base class for test info.
  */
 /*
-@test
-@bug 6778882
-@summary Viewport overlapping test for each AWT component
-@author sergey.grinev@oracle.com: area=awt.mixing
-@library ../../regtesthelpers
-@build Util
-@run main ViewportOverlapping
+ * @test
+ * @key headful
+ * @bug 6778882
+ * @summary Viewport overlapping test for each AWT component
+ * @author sergey.grinev@oracle.com: area=awt.mixing
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main ViewportOverlapping
  */
+
 public class ViewportOverlapping extends OverlappingTestBase {
 
     private volatile int frameClicked;

--- a/jdk/test/java/awt/Mixing/HWDisappear.java
+++ b/jdk/test/java/awt/Mixing/HWDisappear.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test %W% %E%
+  @key headful
   @bug 6769511
   @summary AWT components are invisible for a while after frame is moved & menu items are visible
   @author anthony.petrov@...: area=awt.mixing

--- a/jdk/test/java/awt/Mixing/JButtonInGlassPane.java
+++ b/jdk/test/java/awt/Mixing/JButtonInGlassPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test %W% %E%
+  @key headful
   @bug 6779670
   @summary Tests if a LW components in the glass pane affects HW in the content pane
   @author anthony.petrov@...: area=awt.mixing

--- a/jdk/test/java/awt/Mixing/LWComboBox.java
+++ b/jdk/test/java/awt/Mixing/LWComboBox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test %W% %E%
+  @key headful
   @bug 6637655
   @summary Tests whether a LW combobox correctly overlaps a HW button
   @author anthony.petrov@...: area=awt.mixing

--- a/jdk/test/java/awt/Mixing/LWPopupMenu.java
+++ b/jdk/test/java/awt/Mixing/LWPopupMenu.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 4811096
   @summary Tests whether a LW menu correctly overlaps a HW button
   @author anthony.petrov@...: area=awt.mixing

--- a/jdk/test/java/awt/Mixing/MixingInHwPanel.java
+++ b/jdk/test/java/awt/Mixing/MixingInHwPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6829858
   @summary Mixing should work inside heavyweight containers
   @author anthony.petrov@sun.com: area=awt.mixing

--- a/jdk/test/java/awt/Mixing/MixingOnDialog.java
+++ b/jdk/test/java/awt/Mixing/MixingOnDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 4811096
   @summary Tests whether mixing works on Dialogs
   @author anthony.petrov@...: area=awt.mixing

--- a/jdk/test/java/awt/Mixing/MixingOnShrinkingHWButton.java
+++ b/jdk/test/java/awt/Mixing/MixingOnShrinkingHWButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test %W% %E%
+  @key headful
   @bug 6777320
   @summary PIT : Canvas is not fully painted on the internal frame & internal frame goes behind the canvas
   @author dmitry.cherepanov@...: area=awt.mixing

--- a/jdk/test/java/awt/Mixing/NonOpaqueInternalFrame.java
+++ b/jdk/test/java/awt/Mixing/NonOpaqueInternalFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test %W% %E%
+  @key headful
   @bug 6768332
   @summary Tests whether internal frames are always considered opaque
   @author anthony.petrov@...: area=awt.mixing

--- a/jdk/test/java/awt/Mixing/OpaqueTest.java
+++ b/jdk/test/java/awt/Mixing/OpaqueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 4811096
   @summary Tests whether opaque and non-opaque components mix correctly
   @author anthony.petrov@...: area=awt.mixing

--- a/jdk/test/java/awt/Mixing/OverlappingButtons.java
+++ b/jdk/test/java/awt/Mixing/OverlappingButtons.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 4811096
   @summary Tests whether overlapping buttons mix correctly
   @author anthony.petrov@...: area=awt.mixing

--- a/jdk/test/java/awt/Mixing/ValidBounds.java
+++ b/jdk/test/java/awt/Mixing/ValidBounds.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6637796
   @summary Shape should be correctly updated on invalid components
   @author anthony.petrov@...: area=awt.mixing

--- a/jdk/test/java/awt/Mixing/Validating.java
+++ b/jdk/test/java/awt/Mixing/Validating.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6682046
   @summary Mixing code does not always recalculate shapes correctly when resizing components
   @author anthony.petrov@...: area=awt.mixing

--- a/jdk/test/java/awt/Mixing/setComponentZOrder.java
+++ b/jdk/test/java/awt/Mixing/setComponentZOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6589530
   @summary Mixing code should correctly handle insertion of components with setComponentZOrder.
   @author antohny.petrov@...: area=awt.mixing

--- a/jdk/test/java/awt/Modal/LWModalTest/LWModalTest.java
+++ b/jdk/test/java/awt/Modal/LWModalTest/LWModalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6178755
   @summary The test checks that Container's method startLWModal
 and stopLWModal work correctly. The test scenario is very close

--- a/jdk/test/java/awt/Modal/ModalDialogOrderingTest/ModalDialogOrderingTest.java
+++ b/jdk/test/java/awt/Modal/ModalDialogOrderingTest/ModalDialogOrderingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import java.awt.event.InputEvent;
 
 /**
  * @test
+ * @key headful
  * @bug 8008728
  * @summary [macosx] Swing. JDialog. Modal dialog goes to background
  * @author Alexandr Scherbatiy

--- a/jdk/test/java/awt/Modal/ModalitySettingsTest/ModalitySettingsTest.java
+++ b/jdk/test/java/awt/Modal/ModalitySettingsTest/ModalitySettingsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ import static jdk.testlibrary.Asserts.*;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367
  * @summary Check modality settings for Window and Dialog.
  *

--- a/jdk/test/java/awt/Modal/NpeOnClose/NpeOnCloseTest.java
+++ b/jdk/test/java/awt/Modal/NpeOnClose/NpeOnCloseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6547881
   @summary NPE when closing modal dialog
   @author Oleg Sukhodolsky: area=awt.modal

--- a/jdk/test/java/awt/Modal/SupportedTest/SupportedTest.java
+++ b/jdk/test/java/awt/Modal/SupportedTest/SupportedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6520635
   @summary Test that modality and modal exclusion types are handled
 correctly according Toolkit.isModalityTypeSupported() and

--- a/jdk/test/java/awt/Mouse/ExtraMouseClick/ExtraMouseClick.html
+++ b/jdk/test/java/awt/Mouse/ExtraMouseClick/ExtraMouseClick.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--  
   @test
+  @key headful
   @bug 5039416 6404008
   @summary REGRESSION: Extra mouse click dispatched after press-drag- release sequence.
   @library ../../regtesthelpers

--- a/jdk/test/java/awt/Mouse/MaximizedFrameTest/MaximizedFrameTest.java
+++ b/jdk/test/java/awt/Mouse/MaximizedFrameTest/MaximizedFrameTest.java
@@ -23,6 +23,7 @@
 
 /*
  @test
+ @key headful
  @bug 6176814 8132766
  @summary Metalworks frame maximizes after the move
  @run main MaximizedFrameTest

--- a/jdk/test/java/awt/Mouse/MouseModifiersUnitTest/ExtraButtonDrag.java
+++ b/jdk/test/java/awt/Mouse/MouseModifiersUnitTest/ExtraButtonDrag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test %I% %E%
+  @key headful
   @bug 6315717
   @summary verifies that drag events are coming for every button if the property is set to true
   @author Andrei Dmitriev : area=awt.mouse

--- a/jdk/test/java/awt/Mouse/MouseModifiersUnitTest/MouseModifiersUnitTest_Extra.java
+++ b/jdk/test/java/awt/Mouse/MouseModifiersUnitTest/MouseModifiersUnitTest_Extra.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test %I% %E%
+  @key headful
   @bug 6315717
   @summary verifies that modifiers are correct for extra buttons
   @author Andrei Dmitriev : area=awt.mouse

--- a/jdk/test/java/awt/Mouse/MouseModifiersUnitTest/MouseModifiersUnitTest_Standard.java
+++ b/jdk/test/java/awt/Mouse/MouseModifiersUnitTest/MouseModifiersUnitTest_Standard.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test %I% %E%
+  @key headful
   @bug 6315717
   @summary verifies that modifiers are correct for standard (1, 2, 3, wheel) mouse buttons
   @author Andrei Dmitriev : area=awt.mouse

--- a/jdk/test/java/awt/Mouse/TitleBarDoubleClick/TitleBarDoubleClick.html
+++ b/jdk/test/java/awt/Mouse/TitleBarDoubleClick/TitleBarDoubleClick.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2002, 2013, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2002, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--  
   @test
+  @key headful
   @bug 4664415
   @summary Test that double clicking the titlebar does not send RELEASE/CLICKED
   @library    ../../regtesthelpers

--- a/jdk/test/java/awt/MouseInfo/GetPointerInfoTest.java
+++ b/jdk/test/java/awt/MouseInfo/GetPointerInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @summary unit test for getPointerInfo() from MouseInfo class
   @author dav@sparc.spb.su: area=
   @bug 4009555

--- a/jdk/test/java/awt/MouseInfo/MultiscreenPointerInfo.java
+++ b/jdk/test/java/awt/MouseInfo/MultiscreenPointerInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @summary unit test for getPointerInfo() from MouseInfo class
   @author prs@sparc.spb.su: area=
   @bug 4009555

--- a/jdk/test/java/awt/Multiscreen/MouseEventTest/MouseEventTest.java
+++ b/jdk/test/java/awt/Multiscreen/MouseEventTest/MouseEventTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 8017472
   @summary MouseEvent has wrong coordinates when using multiple monitors
   @run main MouseEventTest

--- a/jdk/test/java/awt/Multiscreen/MultiScreenInsetsTest/MultiScreenInsetsTest.java
+++ b/jdk/test/java/awt/Multiscreen/MultiScreenInsetsTest/MultiScreenInsetsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 8020443
   @summary Frame is not created on the specified GraphicsDevice with two
 monitors

--- a/jdk/test/java/awt/Multiscreen/MultiScreenLocationTest/MultiScreenLocationTest.java
+++ b/jdk/test/java/awt/Multiscreen/MultiScreenLocationTest/MultiScreenLocationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 8013116
   @summary Robot moves mouse to point which differs from set in mouseMove on
  Unity shell

--- a/jdk/test/java/awt/Multiscreen/UpdateGCTest/UpdateGCTest.java
+++ b/jdk/test/java/awt/Multiscreen/UpdateGCTest/UpdateGCTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 4452373 6567564
   @summary Tests that all the child and toplevel components have
 their GraphicsConfiguration updated when the window moves from

--- a/jdk/test/java/awt/Multiscreen/WPanelPeerPerf/WPanelPeerPerf.java
+++ b/jdk/test/java/awt/Multiscreen/WPanelPeerPerf/WPanelPeerPerf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  @test
+ @key headful
  @bug 5085626
  @summary Exponential performance regression in AWT components (multiple mon)
  @run main WPanelPeerPerf

--- a/jdk/test/java/awt/Multiscreen/WindowGCChangeTest/WindowGCChangeTest.html
+++ b/jdk/test/java/awt/Multiscreen/WindowGCChangeTest/WindowGCChangeTest.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--  
   @test
+  @key headful
   @bug 4868278
   @summary Tests that GraphicsConfig for invisible (peerless) windows is
 updated after showing the window

--- a/jdk/test/java/awt/Paint/ButtonRepaint.java
+++ b/jdk/test/java/awt/Paint/ButtonRepaint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ import java.awt.peer.ButtonPeer;
 
 /**
  * @test
+ * @key headful
  * @bug 7090424
  * @author Sergey Bylokhov
  */

--- a/jdk/test/java/awt/Paint/CheckboxRepaint.java
+++ b/jdk/test/java/awt/Paint/CheckboxRepaint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ import java.awt.peer.CheckboxPeer;
 
 /**
  * @test
+ * @key headful
  * @bug 7090424
  * @author Sergey Bylokhov
  */

--- a/jdk/test/java/awt/Paint/ComponentIsNotDrawnAfterRemoveAddTest/ComponentIsNotDrawnAfterRemoveAddTest.java
+++ b/jdk/test/java/awt/Paint/ComponentIsNotDrawnAfterRemoveAddTest/ComponentIsNotDrawnAfterRemoveAddTest.java
@@ -1,5 +1,6 @@
+
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,10 +22,12 @@
  * questions.
  */
 
-/* @test
-   @bug 8139581
-   @summary AWT components are not drawn after removal and addition to a container
-   @author Anton Litvinov
+/*
+ * @test
+ * @key headful
+ * @bug 8139581
+ * @summary AWT components are not drawn after removal and addition to a container
+ * @author Anton Litvinov
  */
 
 import java.awt.Button;

--- a/jdk/test/java/awt/Paint/LabelRepaint.java
+++ b/jdk/test/java/awt/Paint/LabelRepaint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import java.awt.peer.LabelPeer;
 
 /**
  * @test
+ * @key headful
  * @bug 7090424
  * @author Sergey Bylokhov
  */

--- a/jdk/test/java/awt/Paint/ListRepaint.java
+++ b/jdk/test/java/awt/Paint/ListRepaint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import java.awt.peer.ListPeer;
 
 /**
  * @test
+ * @key headful
  * @bug 7090424
  * @author Sergey Bylokhov
  */

--- a/jdk/test/java/awt/PrintJob/MultipleEnd/MultipleEnd.java
+++ b/jdk/test/java/awt/PrintJob/MultipleEnd/MultipleEnd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key headful
  * @bug 4112758
  * @summary Checks that a second invocation of PrintJob.end() does not cause
  * an exception or segmentation violation.

--- a/jdk/test/java/awt/PrintJob/PrintArcTest/PrintArcTest.java
+++ b/jdk/test/java/awt/PrintJob/PrintArcTest/PrintArcTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,11 +22,12 @@
  */
 
 /*
-   @test
-   @bug 4105609
-   @summary Test printing of drawArc preceded by drawString
-   @author robi.khan
-*/
+ * @test
+ * @key headful
+ * @bug 4105609
+ * @summary Test printing of drawArc preceded by drawString
+ * @author robi.khan
+ */
 
 import java.awt.*;
 import java.awt.event.*;

--- a/jdk/test/java/awt/PrintJob/QuoteAndBackslashTest/QuoteAndBackslashTest.java
+++ b/jdk/test/java/awt/PrintJob/QuoteAndBackslashTest/QuoteAndBackslashTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key headful
  * @bug 4040668
  * @summary Checks that banner titles which contain double quotation marks
  * or backslashes still print correctly.

--- a/jdk/test/java/awt/PrintJob/RoundedRectTest/RoundedRectTest.java
+++ b/jdk/test/java/awt/PrintJob/RoundedRectTest/RoundedRectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key headful
  * @bug 4061440
  * @summary Checks that rounded rectangles print correctly.
  * @author dpm

--- a/jdk/test/java/awt/PrintJob/Security/SecurityDialogTest.java
+++ b/jdk/test/java/awt/PrintJob/Security/SecurityDialogTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key headful
  * @bug 6195901 6195923 6195928 6195933 6491273 6888734
  * @summary No SecurityException should be thrown when printing to a file
             using the given policy.

--- a/jdk/test/java/awt/Robot/CtorTest/CtorTest.java
+++ b/jdk/test/java/awt/Robot/CtorTest/CtorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6855323
   @summary  Robot(GraphicsDevice) constructor initializes LEGAL_BUTTON_MASK variable improperly
   @author Dmitry Cherepanov area=awt.robot

--- a/jdk/test/java/awt/Robot/RobotExtraButton/RobotExtraButton.java
+++ b/jdk/test/java/awt/Robot/RobotExtraButton/RobotExtraButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test %I% %E%
+  @key headful
   @bug 6315717
   @summary verifies that robot could accept extra buttons
   @author Andrei Dmitriev : area=awt.mouse

--- a/jdk/test/java/awt/Robot/RobotWheelTest/RobotWheelTest.java
+++ b/jdk/test/java/awt/Robot/RobotWheelTest/RobotWheelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 /*
  * @test 1.2 98/08/05
+ * @key headful
  * @bug 4373478 8079255
  * @summary Test mouse wheel functionality of Robot
  * @author bchristi: area=Robot

--- a/jdk/test/java/awt/ScrollPane/ScrollPanePreferredSize/ScrollPanePreferredSize.java
+++ b/jdk/test/java/awt/ScrollPane/ScrollPanePreferredSize/ScrollPanePreferredSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ import java.awt.Toolkit;
 
 /**
  * @test
+ * @key headful
  * @bug 7124213
  * @author Sergey Bylokhov
  * @library ../../../../lib/testlibrary/

--- a/jdk/test/java/awt/ScrollPane/bug8077409Test.java
+++ b/jdk/test/java/awt/ScrollPane/bug8077409Test.java
@@ -21,12 +21,14 @@
  * questions.
  */
 
-/* @test
-   @bug 8077409
-   @summary Drawing deviates when validate() is invoked on java.awt.ScrollPane
-   @author mikhail.cherkasov@oracle.com
-   @run main bug8077409Test
-*/
+/*
+ * @test
+ * @key headful
+ * @bug 8077409
+ * @summary Drawing deviates when validate() is invoked on java.awt.ScrollPane
+ * @author mikhail.cherkasov@oracle.com
+ * @run main bug8077409Test
+ */
 
 
 import java.awt.*;

--- a/jdk/test/java/awt/SplashScreen/MultiResolutionSplash/MultiResolutionSplashTest.java
+++ b/jdk/test/java/awt/SplashScreen/MultiResolutionSplash/MultiResolutionSplashTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,6 +40,7 @@ import sun.java2d.SunGraphics2D;
 
 /**
  * @test
+ * @key headful
  * @bug 8043869 8075244 8078082
  * @author Alexander Scherbatiy
  * @summary [macosx] java -splash does not honor 2x hi dpi notation for retina

--- a/jdk/test/java/awt/TextArea/Mixing/TextAreaMixing.java
+++ b/jdk/test/java/awt/TextArea/Mixing/TextAreaMixing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,9 @@
  * questions.
  */
 
-/* @test
+/*
+ * @test
+ * @key headful
  * @bug 8013189
  * @run main TextAreaMixing
  * @summary TextArea should support HW/LW mixing

--- a/jdk/test/java/awt/TextArea/ScrollbarIntersectionTest/ScrollbarIntersectionTest.java
+++ b/jdk/test/java/awt/TextArea/ScrollbarIntersectionTest/ScrollbarIntersectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6429174
   @summary Tests that mouse click at the are of intersection of two
    scrollbars for text area doesn't trigger any scrolling

--- a/jdk/test/java/awt/TextArea/TextAreaTwicePack/TextAreaTwicePack.java
+++ b/jdk/test/java/awt/TextArea/TextAreaTwicePack/TextAreaTwicePack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import java.awt.Robot;
 
 /**
  * @test
+ * @key headful
  * @bug 7160627
  * @summary We shouldn't get different frame size when we call Frame.pack()
  * twice.

--- a/jdk/test/java/awt/TextArea/UsingWithMouse/SelectionAutoscrollTest.java
+++ b/jdk/test/java/awt/TextArea/UsingWithMouse/SelectionAutoscrollTest.java
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6497109 6734341
   @summary TextArea must have selection expanding, and also be autoscrolled, if mouse is dragged from inside.
   @library ../../regtesthelpers

--- a/jdk/test/java/awt/TextField/SelectionInvisibleTest/SelectionInvisibleTest.java
+++ b/jdk/test/java/awt/TextField/SelectionInvisibleTest/SelectionInvisibleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import java.awt.event.InputEvent;
 
 /**
  * @test
+ * @key headful
  * @bug 8036110
  * @author Alexander Scherbatiy
  * @summary In TextField can only select text visible or to the left

--- a/jdk/test/java/awt/Toolkit/DynamicLayout/bug7172833.java
+++ b/jdk/test/java/awt/Toolkit/DynamicLayout/bug7172833.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,6 +40,7 @@ import java.util.Properties;
 
 /**
  * @test
+ * @key headful
  * @bug 7172833
  * @summary java.awt.Toolkit methods is/setDynamicLayout() should be consistent.
  * @author Sergey Bylokhov

--- a/jdk/test/java/awt/Toolkit/RealSync/RealSyncOnEDT.java
+++ b/jdk/test/java/awt/Toolkit/RealSync/RealSyncOnEDT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6541903
   @summary Tests if the realSync() throws the IllegalThreadException while invoked on the EDT
   @author anthony.petrov: area=awt.toolkit

--- a/jdk/test/java/awt/Toolkit/ScreenInsetsTest/ScreenInsetsTest.java
+++ b/jdk/test/java/awt/Toolkit/ScreenInsetsTest/ScreenInsetsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 4737732
   @summary Tests that Toolkit.getScreenInsets() returns correct insets
   @author artem.ananiev: area=awt.toplevel

--- a/jdk/test/java/awt/Toolkit/ToolkitPropertyTest/SystemPropTest_1.java
+++ b/jdk/test/java/awt/Toolkit/ToolkitPropertyTest/SystemPropTest_1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test %I% %E%
+  @key headful
   @bug 6315717
   @summary verifies that system property sun.awt.enableExtraMouseButtons is true by default
   @author Andrei Dmitriev : area=awt.mouse

--- a/jdk/test/java/awt/Toolkit/ToolkitPropertyTest/SystemPropTest_2.java
+++ b/jdk/test/java/awt/Toolkit/ToolkitPropertyTest/SystemPropTest_2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test %I% %E%
+  @key headful
   @bug 6315717
   @summary verifies that system property sun.awt.enableExtraMouseButtons might be set to true by the command line
   @author Andrei Dmitriev : area=awt.mouse

--- a/jdk/test/java/awt/Toolkit/ToolkitPropertyTest/SystemPropTest_3.java
+++ b/jdk/test/java/awt/Toolkit/ToolkitPropertyTest/SystemPropTest_3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test %I% %E%
+  @key headful
   @bug 6315717
   @summary verifies that system property sun.awt.enableExtraMouseButtons might be set to false by the command line
   @author Andrei Dmitriev : area=awt.mouse

--- a/jdk/test/java/awt/Toolkit/ToolkitPropertyTest/SystemPropTest_4.java
+++ b/jdk/test/java/awt/Toolkit/ToolkitPropertyTest/SystemPropTest_4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test %I% %E%
+  @key headful
   @bug 6315717
   @summary verifies that system property sun.awt.enableExtraMouseButtons might be set to true by the System class API.
   @author Andrei Dmitriev : area=awt.mouse

--- a/jdk/test/java/awt/Toolkit/ToolkitPropertyTest/SystemPropTest_5.java
+++ b/jdk/test/java/awt/Toolkit/ToolkitPropertyTest/SystemPropTest_5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test %I% %E%
+  @key headful
   @bug 6315717
   @summary verifies that system property sun.awt.enableExtraMouseButtons might be set to false by the System class API.
   @author Andrei Dmitriev : area=awt.mouse

--- a/jdk/test/java/awt/Toolkit/ToolkitPropertyTest/ToolkitPropertyTest_Disable.java
+++ b/jdk/test/java/awt/Toolkit/ToolkitPropertyTest/ToolkitPropertyTest_Disable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test %I% %E%
+  @key headful
   @bug 6315717
   @summary verifies that sun.awt.enableExtraMouseButtons = false consumes extra events
   @author Andrei Dmitriev : area=awt.mouse

--- a/jdk/test/java/awt/Toolkit/ToolkitPropertyTest/ToolkitPropertyTest_Enable.java
+++ b/jdk/test/java/awt/Toolkit/ToolkitPropertyTest/ToolkitPropertyTest_Enable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test %I% %E%
+  @key headful
   @bug 6315717
   @summary verifies that sun.awt.enableExtraMouseButtons is working
   @author Andrei Dmitriev : area=awt.mouse

--- a/jdk/test/java/awt/Window/AlwaysOnTop/AlwaysOnTopEvenOfWindow.java
+++ b/jdk/test/java/awt/Window/AlwaysOnTop/AlwaysOnTopEvenOfWindow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 5028924
   @summary Always-on-top frame should be on top of Window.
   @author Yuri.Nesterenko: area=awt.toplevel

--- a/jdk/test/java/awt/Window/AlwaysOnTop/SyncAlwaysOnTopFieldTest.java
+++ b/jdk/test/java/awt/Window/AlwaysOnTop/SyncAlwaysOnTopFieldTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ import java.awt.Window;
 
 /**
  * @test
+ * @key headful
  * @bug 8064468
  * @author Alexander Scherbatiy
  * @summary ownedWindowList access requires synchronization in

--- a/jdk/test/java/awt/Window/AlwaysOnTop/TestAlwaysOnTopBeforeShow.java
+++ b/jdk/test/java/awt/Window/AlwaysOnTop/TestAlwaysOnTopBeforeShow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,12 +21,13 @@
  * questions.
  */
 /*
-@test
-@bug 6236247
-@summary Test that setting of always-on-top flags before showing window works
-@author dom@sparc.spb.su: area=awt.toplevel
-@run main TestAlwaysOnTopBeforeShow
-*/
+ * @test
+ * @key headful
+ * @bug 6236247
+ * @summary Test that setting of always-on-top flags before showing window works
+ * @author dom@sparc.spb.su: area=awt.toplevel
+ * @run main TestAlwaysOnTopBeforeShow
+ */
 
 /**
  * TestAlwaysOnTopBeforeShow.java

--- a/jdk/test/java/awt/Window/BackgroundIsNotUpdated/BackgroundIsNotUpdated.java
+++ b/jdk/test/java/awt/Window/BackgroundIsNotUpdated/BackgroundIsNotUpdated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import java.awt.Window;
 
 /**
  * @test
+ * @key headful
  * @bug 8001472
  * @summary Background of the window should not depend from the paint()/update()
  * @author Sergey Bylokhov

--- a/jdk/test/java/awt/Window/GetWindowsTest/GetWindowsTest.java
+++ b/jdk/test/java/awt/Window/GetWindowsTest/GetWindowsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 /*
   @test
+  @key headful
   @bug 6322270
   @summary Test for new API introduced in the fix for 6322270: Window.getWindows(),
 Window.getOwnerlessWindows() and Frame.getFrames()

--- a/jdk/test/java/awt/Window/Grab/GrabTest.java
+++ b/jdk/test/java/awt/Window/Grab/GrabTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 7124430
   @summary Tests that SunToolkit.grab API works
   @author anton.tarasov@oracle.com: area=awt.toolkit

--- a/jdk/test/java/awt/Window/GrabSequence/GrabSequence.java
+++ b/jdk/test/java/awt/Window/GrabSequence/GrabSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
  /*
   @test
+  @key headful
   @bug 6273031
   @summary  PIT. Choice drop down does not close once it is right clicked to show a popup menu
   @author andrei.dmitriev: area=awt.window

--- a/jdk/test/java/awt/Window/HandleWindowDestroyTest/HandleWindowDestroyTest.html
+++ b/jdk/test/java/awt/Window/HandleWindowDestroyTest/HandleWindowDestroyTest.html
@@ -1,6 +1,7 @@
 <html>
 <!--  
   @test
+  @key headful
   @bug 6260648
   @summary Tests that WINDOW_DESTROY event can be handled by overriding handleEvent(). Also,
 tests that handleEvent() is not called by AWT if any listener is added to the component

--- a/jdk/test/java/awt/Window/LocationByPlatform/LocationByPlatformTest.java
+++ b/jdk/test/java/awt/Window/LocationByPlatform/LocationByPlatformTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key headful
  * @bug 7092283
  * @author Alexander Scherbatiy
  * @summary Property Window.locationByPlatform is not cleared by calling

--- a/jdk/test/java/awt/Window/OwnedWindowsLeak/OwnedWindowsLeak.java
+++ b/jdk/test/java/awt/Window/OwnedWindowsLeak/OwnedWindowsLeak.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6758673
   @summary Tests that windows are removed from owner's child windows list
   @author art: area=awt.toplevel

--- a/jdk/test/java/awt/Window/PropertyChangeListenerLockSerialization/PropertyChangeListenerLockSerialization.java
+++ b/jdk/test/java/awt/Window/PropertyChangeListenerLockSerialization/PropertyChangeListenerLockSerialization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6681889
   @summary Showing a deserialized frame should not throw NPE
   @author anthony.petrov@...: area=awt.toplevel

--- a/jdk/test/java/awt/Window/SetBackgroundNPE/SetBackgroundNPE.java
+++ b/jdk/test/java/awt/Window/SetBackgroundNPE/SetBackgroundNPE.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6853916
   @summary Window.setBackground() should not throw NPE
   @author anthony.petrov@sun.com: area=awt.toplevel

--- a/jdk/test/java/awt/Window/ShapedAndTranslucentWindows/FocusAWTTest.java
+++ b/jdk/test/java/awt/Window/ShapedAndTranslucentWindows/FocusAWTTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import java.util.HashMap;
 
 /*
  * @test
+ * @key headful
  * @bug 8013450
  * @summary Check if the window events (Focus and Activation) are triggered correctly
  *          when clicked on visible and clipped areas.

--- a/jdk/test/java/awt/Window/ShapedAndTranslucentWindows/SetShape.java
+++ b/jdk/test/java/awt/Window/ShapedAndTranslucentWindows/SetShape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ import java.awt.geom.*;
 
 /*
  * @test
+ * @key headful
  * @summary Check if a window set with shape appears in the expected shape
  *
  * Test Description: Check if PERPIXEL_TRANSPARENT Translucency type is supported

--- a/jdk/test/java/awt/Window/ShapedAndTranslucentWindows/SetShapeAndClick.java
+++ b/jdk/test/java/awt/Window/ShapedAndTranslucentWindows/SetShapeAndClick.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import java.awt.geom.Rectangle2D;
 
 /*
  * @test
+ * @key headful
  * @summary Check if a window set with shape clips the contents
  *
  * Test Description: Check if PERPIXEL_TRANSPARENT Translucency type is supported

--- a/jdk/test/java/awt/Window/ShapedAndTranslucentWindows/SetShapeDynamicallyAndClick.java
+++ b/jdk/test/java/awt/Window/ShapedAndTranslucentWindows/SetShapeDynamicallyAndClick.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import java.awt.geom.Rectangle2D;
 
 /*
  * @test
+ * @key headful
  * @summary Check if dynamically setting a shape works
  *
  * Test Description: Check if PERPIXEL_TRANSPARENT Translucency type is supported

--- a/jdk/test/java/awt/Window/ShapedAndTranslucentWindows/Shaped.java
+++ b/jdk/test/java/awt/Window/ShapedAndTranslucentWindows/Shaped.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ import java.awt.*;
 
 /*
  * @test
+ * @key headful
  * @summary Check if dynamically shaped window is dragged and resized
  *          by mouse correctly
  *

--- a/jdk/test/java/awt/Window/ShapedAndTranslucentWindows/ShapedByAPI.java
+++ b/jdk/test/java/awt/Window/ShapedAndTranslucentWindows/ShapedByAPI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ import java.awt.*;
 
 /*
  * @test
+ * @key headful
  * @summary Check if dynamically shaped window is moved and resized by
  *          API correctly.
  *

--- a/jdk/test/java/awt/Window/ShapedAndTranslucentWindows/ShapedTranslucent.java
+++ b/jdk/test/java/awt/Window/ShapedAndTranslucentWindows/ShapedTranslucent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ import java.awt.*;
 
 /*
  * @test
+ * @key headful
  * @summary Check if a translucent shaped window is dragged and
  *          resized correctly.
  *

--- a/jdk/test/java/awt/Window/ShapedAndTranslucentWindows/ShapedTranslucentWindowClick.java
+++ b/jdk/test/java/awt/Window/ShapedAndTranslucentWindows/ShapedTranslucentWindowClick.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import java.util.BitSet;
 
 /*
  * @test
+ * @key headful
  * @summary Check if a translucent shaped window trigger events correctly.
  *
  * Test Description: Check if TRANSLUCENT and PERPIXEL_TRANSPARENT traslucency

--- a/jdk/test/java/awt/Window/ShapedAndTranslucentWindows/StaticallyShaped.java
+++ b/jdk/test/java/awt/Window/ShapedAndTranslucentWindows/StaticallyShaped.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ import java.awt.*;
 
 /*
  * @test
+ * @key headful
  * @summary Check if statically shaped window is dragged and resized correctly.
  *
  * Test Description: Check if PERPIXEL_TRANSPARENT translucency type is supported

--- a/jdk/test/java/awt/Window/ShapedAndTranslucentWindows/Translucent.java
+++ b/jdk/test/java/awt/Window/ShapedAndTranslucentWindows/Translucent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ import java.awt.*;
 
 /*
  * @test
+ * @key headful
  * @summary Check if translucent window is dragged and resized
  *          correctly.
  *

--- a/jdk/test/java/awt/Window/ShapedAndTranslucentWindows/TranslucentChoice.java
+++ b/jdk/test/java/awt/Window/ShapedAndTranslucentWindows/TranslucentChoice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ import java.awt.event.MouseEvent;
 
 /*
  * @test
+ * @key headful
  * @summary Check if a Choice present in a window set with opacity less than 1.0
  *          shows a translucent drop down
  *

--- a/jdk/test/java/awt/Window/ShapedAndTranslucentWindows/TranslucentWindowClick.java
+++ b/jdk/test/java/awt/Window/ShapedAndTranslucentWindows/TranslucentWindowClick.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ import java.awt.event.MouseEvent;
 
 /*
  * @test
+ * @key headful
  * @summary Check if components present in a window set with opacity less than 1.0
  *          triggers events correctly
  *

--- a/jdk/test/java/awt/Window/WindowClosedEvents/WindowClosedEventOnDispose.java
+++ b/jdk/test/java/awt/Window/WindowClosedEvents/WindowClosedEventOnDispose.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 8015500
   @summary DisposeAction multiplies the WINDOW_CLOSED event.
   @author jlm@joseluismartin.info

--- a/jdk/test/java/awt/Window/WindowType/WindowType.java
+++ b/jdk/test/java/awt/Window/WindowType/WindowType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6402325
   @summary Test showing windows of different types
   @author anthony.petrov@sun.com: area=awt.toplevel

--- a/jdk/test/java/awt/Window/setLocRelativeTo/SetLocationRelativeToTest.java
+++ b/jdk/test/java/awt/Window/setLocRelativeTo/SetLocationRelativeToTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,15 +26,16 @@ import java.util.ArrayList;
 import javax.swing.*;
 
 /*
-@test
-@summary Toplevel should be correctly positioned as relative to a component:
-       so that their centers coincide
-       or, if the component is hidden, centered on the screen.
-@bug 8036915
-@library ../../../../lib/testlibrary
-@build ExtendedRobot
-@run main/timeout=1200 SetLocationRelativeToTest
-*/
+ * @test
+ * @key headful
+ * @summary Toplevel should be correctly positioned as relative to a component:
+ *          so that their centers coincide
+ *          or, if the component is hidden, centered on the screen.
+ * @bug 8036915
+ * @library ../../../../lib/testlibrary
+ * @build ExtendedRobot
+ * @run main/timeout=1200 SetLocationRelativeToTest
+ */
 
 public class SetLocationRelativeToTest {
     private static int delay = 500;

--- a/jdk/test/java/awt/datatransfer/Clipboard/GetContentsInterruptedTest.java
+++ b/jdk/test/java/awt/datatransfer/Clipboard/GetContentsInterruptedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@ import java.io.InputStream;
 
 /*
  * @test
+ * @key headful
  * @bug 4532299 4648733
  * @summary Tests that getting clipboard contents on the interrupted thread will
  *          not cause deadlock.Also check that lostOwnership event occurs while

--- a/jdk/test/java/awt/datatransfer/ClipboardInterVMTest/ClipboardInterVMTest.java
+++ b/jdk/test/java/awt/datatransfer/ClipboardInterVMTest/ClipboardInterVMTest.java
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 8071668
   @summary Check whether clipboard see changes from external process after taking ownership
   @author Anton Nashatyrev: area=datatransfer

--- a/jdk/test/java/awt/datatransfer/CustomClassLoaderTransferTest/CustomClassLoaderTransferTest.java
+++ b/jdk/test/java/awt/datatransfer/CustomClassLoaderTransferTest/CustomClassLoaderTransferTest.java
@@ -1,5 +1,6 @@
 /*
   @test
+  @key headful
   @bug 4932376
   @summary verifies that data transfer within one JVM works correctly if
            the transfer data was created with a custom class loader.

--- a/jdk/test/java/awt/datatransfer/DragUnicodeBetweenJVMTest/DragUnicodeBetweenJVMTest.html
+++ b/jdk/test/java/awt/datatransfer/DragUnicodeBetweenJVMTest/DragUnicodeBetweenJVMTest.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--  
   @test
+  @key headful
   @bug 5098433
   @summary REG: DnD of File-List between JVM is broken for non ASCII file names - Win32
   @author Denis Fokin: area=dnd

--- a/jdk/test/java/awt/datatransfer/ImageTransfer/ImageTransferTest.java
+++ b/jdk/test/java/awt/datatransfer/ImageTransfer/ImageTransferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import java.util.Vector;
 
 /*
  * @test
+ * @key headful
  * @summary To check Whether java.awt.Image can be transferred through the
  *          system clipboard
  * @author Jitender(jitender.singh@eng.sun.com) area=AWT

--- a/jdk/test/java/awt/datatransfer/Independence/IndependenceAWTTest.java
+++ b/jdk/test/java/awt/datatransfer/Independence/IndependenceAWTTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import java.util.Properties;
 
 /*
  * @test
+ * @key headful
  * @summary To make sure that System & Primary clipboards should behave independently
  * @author Jitender(jitender.singh@eng.sun.com) area=AWT
  * @author dmitriy.ermashov@oracle.com

--- a/jdk/test/java/awt/datatransfer/Independence/IndependenceSwingTest.java
+++ b/jdk/test/java/awt/datatransfer/Independence/IndependenceSwingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@ import java.util.Properties;
 
 /*
  * @test
+ * @key headful
  * @summary To make sure that System & Primary clipboards should behave independently
  * @author Jitender(jitender.singh@eng.sun.com) area=AWT
  * @author dmitriy.ermashov@oracle.com

--- a/jdk/test/java/awt/datatransfer/MissedHtmlAndRtfBug/MissedHtmlAndRtfBug.html
+++ b/jdk/test/java/awt/datatransfer/MissedHtmlAndRtfBug/MissedHtmlAndRtfBug.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2013, 2014, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--  
   @test
+  @key headful
   @bug 8005932 8017456
   @summary Java 7 on mac os x only provides text clipboard formats
   @author mikhail.cherkasov@oracle.com

--- a/jdk/test/java/awt/datatransfer/SystemSelection/SystemSelectionAWTTest.java
+++ b/jdk/test/java/awt/datatransfer/SystemSelection/SystemSelectionAWTTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@ import java.util.Properties;
 
 /*
  * @test
+ * @key headful
  * @summary To check the functionality of newly added API getSystemSelection & make sure
  *          that it's mapped to primary clipboard
  * @author Jitender(jitender.singh@eng.sun.com) area=AWT

--- a/jdk/test/java/awt/datatransfer/SystemSelection/SystemSelectionSwingTest.java
+++ b/jdk/test/java/awt/datatransfer/SystemSelection/SystemSelectionSwingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import java.util.Properties;
 
 /*
  * @test
+ * @key headful
  * @summary To check the functionality of newly added API getSystemSelection & make sure
  *          that it's mapped to primary clipboard
  * @author Jitender(jitender.singh@eng.sun.com) area=AWT

--- a/jdk/test/java/awt/dnd/Button2DragTest/Button2DragTest.java
+++ b/jdk/test/java/awt/dnd/Button2DragTest/Button2DragTest.java
@@ -41,6 +41,7 @@ import test.java.awt.regtesthelpers.Util;
 
 /**
  * @test
+ * @key headful
  * @bug 4955110
  * @summary tests that DragSourceDragEvent.getDropAction() accords to its new
  *          spec (does not depend on the user drop action)

--- a/jdk/test/java/awt/dnd/DragInterceptorAppletTest/DragInterceptorAppletTest.html
+++ b/jdk/test/java/awt/dnd/DragInterceptorAppletTest/DragInterceptorAppletTest.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--  
   @test
+  @key headful
   @bug 6887703
   @summary Unsigned applet can retrieve the dragged information before drop action occurs
   @author : area=dnd

--- a/jdk/test/java/awt/dnd/DragSourceListenerSerializationTest/DragSourceListenerSerializationTest.java
+++ b/jdk/test/java/awt/dnd/DragSourceListenerSerializationTest/DragSourceListenerSerializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 4422345 8039083
   @summary tests serialization of DragSourceListeners
   @author das@sparc.spb.su area=dnd

--- a/jdk/test/java/awt/dnd/FileListBetweenJVMsTest/FileListBetweenJVMsTest.html
+++ b/jdk/test/java/awt/dnd/FileListBetweenJVMsTest/FileListBetweenJVMsTest.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2007, 2013, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--  
   @test
+  @key headful
   @bug 5079469
   @summary DnD of File-List across JVM adds two empty items to the list
   @author : area=dnd

--- a/jdk/test/java/awt/dnd/ImageDecoratedDnDInOut/ImageDecoratedDnDInOut.html
+++ b/jdk/test/java/awt/dnd/ImageDecoratedDnDInOut/ImageDecoratedDnDInOut.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--
   @test %W% %E%
+  @key headful
   @bug 4874070
   @summary Tests basic DnD functionality
   @author Your Name: Alexey Utkin area=dnd

--- a/jdk/test/java/awt/dnd/ImageDecoratedDnDNegative/ImageDecoratedDnDNegative.html
+++ b/jdk/test/java/awt/dnd/ImageDecoratedDnDNegative/ImageDecoratedDnDNegative.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--
   @test %W% %E%
+  @key headful
   @bug 4874070
   @summary Tests basic DnD functionality
   @author Your Name: Alexey Utkin area=dnd

--- a/jdk/test/java/awt/dnd/ImageTransferTest/ImageTransferTest.java
+++ b/jdk/test/java/awt/dnd/ImageTransferTest/ImageTransferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 4397404 4720930
   @summary tests that images of all supported native image formats are transfered properly
   @library ../../../../lib/testlibrary

--- a/jdk/test/java/awt/dnd/InterJVMGetDropSuccessTest/InterJVMGetDropSuccessTest.html
+++ b/jdk/test/java/awt/dnd/InterJVMGetDropSuccessTest/InterJVMGetDropSuccessTest.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--  
   @test
+  @key headful
   @bug 4658741
   @summary verifies that getDropSuccess() returns correct value for inter-JVM DnD
   @author das@sparc.spb.su area=dnd

--- a/jdk/test/java/awt/dnd/MissingEventsOnModalDialog/MissingEventsOnModalDialogTest.java
+++ b/jdk/test/java/awt/dnd/MissingEventsOnModalDialog/MissingEventsOnModalDialogTest.java
@@ -43,6 +43,7 @@ import java.awt.event.MouseEvent;
 
 /*
  * @test
+ * @key headful
  * @bug 8134917
  * @summary [macosx] JOptionPane doesn't receive mouse events when opened from a drop event
  * @author Alexandr Scherbatiy

--- a/jdk/test/java/awt/dnd/NoFormatsCrashTest/NoFormatsCrashTest.html
+++ b/jdk/test/java/awt/dnd/NoFormatsCrashTest/NoFormatsCrashTest.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--  
   @test
+  @key headful
   @bug 4870762
   @summary tests that a drop target JVM doesn't crash if the source doesn't export 
            data in native formats.

--- a/jdk/test/java/awt/dnd/URIListBetweenJVMsTest/URIListBetweenJVMsTest.html
+++ b/jdk/test/java/awt/dnd/URIListBetweenJVMsTest/URIListBetweenJVMsTest.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--  
   @test
+  @key headful
   @bug 4899516
   @summary Transferable has no DataFlavors when dragging from Gnome window to Swing
   @author : area=dnd

--- a/jdk/test/java/awt/dnd/URIListToFileListBetweenJVMsTest/URIListToFileListBetweenJVMsTest.html
+++ b/jdk/test/java/awt/dnd/URIListToFileListBetweenJVMsTest/URIListToFileListBetweenJVMsTest.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--  
   @test
+  @key headful
   @bug 8029565
   @summary Conversion of a URI list to File list fails
   @author Petr Pchelko <petr.pchelko@oracle.com>

--- a/jdk/test/java/awt/event/ComponentEvent/MovedResizedTardyEventTest/MovedResizedTardyEventTest.html
+++ b/jdk/test/java/awt/event/ComponentEvent/MovedResizedTardyEventTest/MovedResizedTardyEventTest.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2004, 2015, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2004, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--  
   @test
+  @key headful
   @bug          4985250
   @summary      COMPONENT_MOVED/RESIZED tardy events shouldn't be generated.
   @author       tav@sparc.spb.su

--- a/jdk/test/java/awt/event/HierarchyEvent/AncestorResized/AncestorResized.java
+++ b/jdk/test/java/awt/event/HierarchyEvent/AncestorResized/AncestorResized.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6533330
   @summary ANCESTOR_RESIZED is not sent while resizing a frame. Regression caused by 6500477.
   @author anthony.petrov: area=awt.toplevel

--- a/jdk/test/java/awt/event/InputEvent/ButtonArraysEquality/ButtonArraysEquality.java
+++ b/jdk/test/java/awt/event/InputEvent/ButtonArraysEquality/ButtonArraysEquality.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test %I% %E%
+  @key headful
   @bug 6315717
   @summary verifies that InputEvents button masks arrays are the same
   @author Andrei Dmitriev : area=awt.event

--- a/jdk/test/java/awt/event/InputEvent/EventWhenTest/EventWhenTest.java
+++ b/jdk/test/java/awt/event/InputEvent/EventWhenTest/EventWhenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import java.awt.event.MouseEvent;
 
 /*
  * @test
+ * @key headful
  * @bug 8046495
  * @summary Verifies that mouse/key events has always increasing 'when' timestamps
  * @author Anton Nashatyrev

--- a/jdk/test/java/awt/event/KeyEvent/DeadKey/DeadKeySystemAssertionDialog.java
+++ b/jdk/test/java/awt/event/KeyEvent/DeadKey/DeadKeySystemAssertionDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ import java.awt.TextField;
 import java.awt.event.KeyEvent;
 /*
  * @test
+ * @key headful
  * @bug 8013849
  * @summary Awt assert on Hashtable.cpp:124
  * @author alexandr.scherbatiy area=awt.event

--- a/jdk/test/java/awt/event/KeyEvent/KeyChar/KeyCharTest.java
+++ b/jdk/test/java/awt/event/KeyEvent/KeyChar/KeyCharTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import java.util.Locale;
 
 /*
  * @test
+ * @key headful
  * @bug 8022401 8160623
  * @summary Wrong key char
  * @author Alexandr Scherbatiy

--- a/jdk/test/java/awt/event/KeyEvent/KeyTyped/CtrlASCII.html
+++ b/jdk/test/java/awt/event/KeyEvent/KeyTyped/CtrlASCII.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2007, 2013, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--  
   @test
+  @key headful
   @bug  6497426
   @summary ests that pressing of Ctrl+ascii mostly fires KEY_TYPED with a Unicode control symbols
   @author yuri.nesterenko@... area=awt.keyboard

--- a/jdk/test/java/awt/event/MouseEvent/AcceptExtraButton/AcceptExtraButton.java
+++ b/jdk/test/java/awt/event/MouseEvent/AcceptExtraButton/AcceptExtraButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test %I% %E%
+  @key headful
   @bug 6315717
   @summary verifies that MouseEvent CTOR accepts extra mouse button numbers
   @author Andrei Dmitriev : area=awt.event

--- a/jdk/test/java/awt/event/MouseEvent/CheckGetMaskForButton/CheckGetMaskForButton.java
+++ b/jdk/test/java/awt/event/MouseEvent/CheckGetMaskForButton/CheckGetMaskForButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test %I% %E%
+  @key headful
   @bug 6315717
   @summary verifies that InputEvent.getMaskForButton() returns the same values as in InputEvent.BUTTON_DOWN_MASK
   @author Andrei Dmitriev : area=awt.event

--- a/jdk/test/java/awt/event/MouseEvent/ClickDuringKeypress/ClickDuringKeypress.java
+++ b/jdk/test/java/awt/event/MouseEvent/ClickDuringKeypress/ClickDuringKeypress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test 1.2 98/08/05
+  @key headful
   @bug 4515763
   @summary Tests that clicking mouse and pressing keys generates correct amount of click-counts
   @author andrei.dmitriev: area=awt.mouse

--- a/jdk/test/java/awt/event/MouseEvent/EventTimeInFuture/EventTimeInFuture.java
+++ b/jdk/test/java/awt/event/MouseEvent/EventTimeInFuture/EventTimeInFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6451578
   @library ../../../regtesthelpers
   @build Sysout AbstractTest Util

--- a/jdk/test/java/awt/event/MouseEvent/FrameMouseEventAbsoluteCoordsTest/FrameMouseEventAbsoluteCoordsTest.html
+++ b/jdk/test/java/awt/event/MouseEvent/FrameMouseEventAbsoluteCoordsTest/FrameMouseEventAbsoluteCoordsTest.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2004, 2013, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2004, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--  
   @test
+  @key headful
   @bug 4992908
   @summary Need way to get location of MouseEvent in screen  coordinates (Unit-test)
   @author Andrei.Dmitriev area=event

--- a/jdk/test/java/awt/event/MouseEvent/MenuDragMouseEventAbsoluteCoordsTest/MenuDragMouseEventAbsoluteCoordsTest.html
+++ b/jdk/test/java/awt/event/MouseEvent/MenuDragMouseEventAbsoluteCoordsTest/MenuDragMouseEventAbsoluteCoordsTest.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2004, 2013, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2004, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--  
   @test
+  @key headful
   @bug 4992908
   @summary Need way to get location of MouseEvent in screen coordinates
   @author Andrei.Dmitriev area=event

--- a/jdk/test/java/awt/event/MouseEvent/MouseClickTest/MouseClickTest.html
+++ b/jdk/test/java/awt/event/MouseEvent/MouseClickTest/MouseClickTest.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2007, 2013, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--  
   @test
+  @key headful
   @bug 6267983
   @summary PIT: MouseClicked is triggered when the mouse is released outside the tray icon, Win32
   @author dmitry.cherepanov@... area=awt.event

--- a/jdk/test/java/awt/event/MouseEvent/MouseWheelEventAbsoluteCoordsTest/MouseWheelEventAbsoluteCoordsTest.html
+++ b/jdk/test/java/awt/event/MouseEvent/MouseWheelEventAbsoluteCoordsTest/MouseWheelEventAbsoluteCoordsTest.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2004, 2013, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2004, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--  
   @test
+  @key headful
   @bug 4992908
   @summary Need way to get location of MouseEvent in screen coordinates
   @author Andrei.Dmitriev area=event 

--- a/jdk/test/java/awt/event/MouseEvent/RobotLWTest/RobotLWTest.html
+++ b/jdk/test/java/awt/event/MouseEvent/RobotLWTest/RobotLWTest.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2000, 2013, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2000, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--
   @test
+  @key headful
   @bug 4350402
   @summary Tests that mouse behavior on LW component
   @compile ../../../regtesthelpers/Util.java

--- a/jdk/test/java/awt/event/MouseWheelEvent/DisabledComponent/DisabledComponent.java
+++ b/jdk/test/java/awt/event/MouseWheelEvent/DisabledComponent/DisabledComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6847958
   @summary MouseWheel event is getting triggered for the disabled Textarea in jdk7 b60 pit build.
   @author Dmitry Cherepanov: area=awt.event

--- a/jdk/test/java/awt/event/MouseWheelEvent/InfiniteRecursion/InfiniteRecursion_2.html
+++ b/jdk/test/java/awt/event/MouseWheelEvent/InfiniteRecursion/InfiniteRecursion_2.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2007, 2013, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--  
   @test
+  @key headful
   @bug 6480024
   @library ../../../regtesthelpers
   @build Util Sysout AbstractTest

--- a/jdk/test/java/awt/event/MouseWheelEvent/InfiniteRecursion/InfiniteRecursion_3.html
+++ b/jdk/test/java/awt/event/MouseWheelEvent/InfiniteRecursion/InfiniteRecursion_3.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2007, 2013, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--  
   @test
+  @key headful
   @bug 6480024
   @library ../../../regtesthelpers
   @build Util Sysout AbstractTest

--- a/jdk/test/java/awt/event/OtherEvents/UngrabID/UngrabID.java
+++ b/jdk/test/java/awt/event/OtherEvents/UngrabID/UngrabID.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6960516
   @summary check if the ungrab event has the ID < AWTEvent.RESERVED_ID_MAX
   @author Andrei Dmitriev : area=awt.event

--- a/jdk/test/java/awt/font/Rotate/Shear.java
+++ b/jdk/test/java/awt/font/Rotate/Shear.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6692979
  * @summary Verify no crashes with extreme shears.
  */

--- a/jdk/test/java/awt/font/Underline/UnderlineTest.java
+++ b/jdk/test/java/awt/font/Underline/UnderlineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 
 /**
  * @test
+ * @key headful
  * @bug 6216010
  * @summary check to see that underline thickness scales.
  * @run main UnderlineTest

--- a/jdk/test/java/awt/grab/EmbeddedFrameTest1/EmbeddedFrameTest1.java
+++ b/jdk/test/java/awt/grab/EmbeddedFrameTest1/EmbeddedFrameTest1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6359129
   @summary REGRESSION: Popup menus dont respond to selections when extend outside Applet
   @author oleg.sukhodolsky area=awt.grab

--- a/jdk/test/java/awt/grab/MenuDragEvents/MenuDragEvents.html
+++ b/jdk/test/java/awt/grab/MenuDragEvents/MenuDragEvents.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2006, 2014, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--
   @test
+  @key headful
   @bug 6390326
   @summary REGRESSION: Broken mouse behaviour of menus partially outside the main window.
   @author oleg.sukhodolsky: area=awt-drab

--- a/jdk/test/java/awt/im/InputContext/InputContextTest.java
+++ b/jdk/test/java/awt/im/InputContext/InputContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,9 @@
  * questions.
  */
 
-/* @test
+/*
+ * @test
+ * @key headful
  * @bug 4151222
  * @bug 4150206
  * @bug 4243948

--- a/jdk/test/java/awt/im/InputContext/bug4625203.java
+++ b/jdk/test/java/awt/im/InputContext/bug4625203.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 4625203
  * @summary 1. install two input locales on Windows
  *          2. run this application

--- a/jdk/test/java/awt/image/DrawImage/EABlitTest.java
+++ b/jdk/test/java/awt/image/DrawImage/EABlitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ import javax.swing.*;
 
 /**
  * @test
+ * @key headful
  * @bug 8024895
  * @summary tests if changing extra alpha values are honored for transformed blits
  * @author ceisserer

--- a/jdk/test/java/awt/image/DrawImage/IncorrectAlphaConversionBicubic.java
+++ b/jdk/test/java/awt/image/DrawImage/IncorrectAlphaConversionBicubic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,7 @@ import static java.awt.Transparency.TRANSLUCENT;
 
 /**
  * @test
+ * @key headful
  * @bug 8062164
  * @summary We should get correct alpha, when we draw to/from VolatileImage and
  *          bicubic interpolation is enabled

--- a/jdk/test/java/awt/image/DrawImage/IncorrectAlphaSurface2SW.java
+++ b/jdk/test/java/awt/image/DrawImage/IncorrectAlphaSurface2SW.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,7 @@ import static java.awt.image.BufferedImage.TYPE_INT_ARGB_PRE;
 
 /**
  * @test
+ * @key headful
  * @bug 8017626
  * @summary Tests drawing transparent volatile image to transparent BI.
  *          Results of the blit compatibleImage to transparent BI used for

--- a/jdk/test/java/awt/image/DrawImage/IncorrectBounds.java
+++ b/jdk/test/java/awt/image/DrawImage/IncorrectBounds.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import java.awt.image.VolatileImage;
 
 /**
  * @test
+ * @key headful
  * @bug 8000629
  * @summary Temporary backbuffer in the DrawImage should not fill background
  * outside of source image bounds.

--- a/jdk/test/java/awt/image/DrawImage/IncorrectClipSurface2SW.java
+++ b/jdk/test/java/awt/image/DrawImage/IncorrectClipSurface2SW.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,7 @@ import static java.awt.geom.Rectangle2D.Double;
 
 /**
  * @test
+ * @key headful
  * @bug 8041644
  * @summary Tests drawing volatile image to BI using different clip.
  *          Results of the blit compatibleImage to BI used for comparison.

--- a/jdk/test/java/awt/image/DrawImage/IncorrectClipXorModeSW2Surface.java
+++ b/jdk/test/java/awt/image/DrawImage/IncorrectClipXorModeSW2Surface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,6 +44,7 @@ import static java.awt.geom.Rectangle2D.Double;
 
 /**
  * @test
+ * @key headful
  * @bug 8061456
  * @summary Tests drawing BI to volatile image using different clips + xor mode.
  *          Results of the blit BI to compatibleImage is used for comparison.

--- a/jdk/test/java/awt/image/DrawImage/IncorrectClipXorModeSurface2Surface.java
+++ b/jdk/test/java/awt/image/DrawImage/IncorrectClipXorModeSurface2Surface.java
@@ -40,6 +40,7 @@ import static java.awt.geom.Rectangle2D.Double;
 
 /**
  * @test
+ * @key headful
  * @bug 8061831 8130400
  * @summary Tests drawing volatile image to volatile image using different
  *          clips + xor mode. Results of the blit compatibleImage to

--- a/jdk/test/java/awt/image/DrawImage/IncorrectDestinationOffset.java
+++ b/jdk/test/java/awt/image/DrawImage/IncorrectDestinationOffset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import javax.imageio.ImageIO;
 
 /**
  * @test
+ * @key headful
  * @bug 8041129
  * @summary Destination offset should be correct in case of Surface->SW blit.
  *          Destination outside of the drawing area should be untouched.

--- a/jdk/test/java/awt/image/DrawImage/IncorrectOffset.java
+++ b/jdk/test/java/awt/image/DrawImage/IncorrectOffset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import java.awt.image.VolatileImage;
 
 /**
  * @test
+ * @key headful
  * @bug 8000629
  * @summary Temporary backbuffer in the DrawImage should have correct offset.
  * @author Sergey Bylokhov

--- a/jdk/test/java/awt/image/DrawImage/IncorrectSourceOffset.java
+++ b/jdk/test/java/awt/image/DrawImage/IncorrectSourceOffset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@ import javax.imageio.ImageIO;
 
 /**
  * @test
+ * @key headful
  * @bug 8041129
  * @summary Tests asymmetric source offsets.
  * @author Sergey Bylokhov

--- a/jdk/test/java/awt/image/DrawImage/IncorrectUnmanagedImageRotatedClip.java
+++ b/jdk/test/java/awt/image/DrawImage/IncorrectUnmanagedImageRotatedClip.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,6 +44,7 @@ import static java.awt.image.BufferedImage.TYPE_INT_ARGB;
 
 /**
  * @test
+ * @key headful
  * @bug 8059942
  * @summary Tests rotated clip when unmanaged image is drawn to VI.
  *          Results of the blit to compatibleImage are used for comparison.

--- a/jdk/test/java/awt/image/DrawImage/UnmanagedDrawImagePerformance.java
+++ b/jdk/test/java/awt/image/DrawImage/UnmanagedDrawImagePerformance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,6 +41,7 @@ import static java.awt.image.BufferedImage.*;
 
 /*
  * @test
+ * @key headful
  * @bug 8029253 8059941
  * @summary Unmanaged images should be drawn fast.
  * @author Sergey Bylokhov

--- a/jdk/test/java/awt/image/VolatileImage/BitmaskVolatileImage.java
+++ b/jdk/test/java/awt/image/VolatileImage/BitmaskVolatileImage.java
@@ -34,6 +34,7 @@ import static java.awt.Transparency.BITMASK;
 
 /**
  * @test
+ * @key headful
  * @bug 7188942
  * @summary We should get correct volatile image, when we use BITMASK
  *          transparency

--- a/jdk/test/java/awt/image/VolatileImage/VolatileImageBug.java
+++ b/jdk/test/java/awt/image/VolatileImage/VolatileImageBug.java
@@ -26,6 +26,7 @@ import java.awt.image.VolatileImage;
 
 /**
  * @test
+ * @key headful
  * @bug 8140530
  * @run main VolatileImageBug
  * @summary Creating volatileimage(0,0) should throw IAE

--- a/jdk/test/java/awt/print/PageFormat/NullPaper.java
+++ b/jdk/test/java/awt/print/PageFormat/NullPaper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 4199506
   @summary  java.awt.print.PageFormat.setpaper(Paper paper)
                  assertion test fails by not throwing

--- a/jdk/test/java/awt/print/PageFormat/ReverseLandscapeTest.java
+++ b/jdk/test/java/awt/print/PageFormat/ReverseLandscapeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 4254954
  * @summary PageFormat would fail on solaris when setting orientation
  */

--- a/jdk/test/java/awt/print/PaintSetEnabledDeadlock/PaintSetEnabledDeadlock.java
+++ b/jdk/test/java/awt/print/PaintSetEnabledDeadlock/PaintSetEnabledDeadlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 7108598
  * @summary Container.paint/KeyboardFocusManager.clearMostRecentFocusOwner methods deadlock
  * @library ../../regtesthelpers

--- a/jdk/test/java/awt/print/PrinterJob/PrintToDir.java
+++ b/jdk/test/java/awt/print/PrinterJob/PrintToDir.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,11 +21,14 @@
  * questions.
  */
 
-/* @test
-   @bug 4973278 8015586
-   @run main PrintToDir
-   @summary Must throw exception when printing to an invalid filename - a dir.
-*/
+/*
+ * @test
+ * @key headful
+ * @bug 4973278 8015586
+ * @run main PrintToDir
+ * @summary Must throw exception when printing to an invalid filename - a dir.
+ */
+
 import java.io.*;
 import java.net.*;
 import java.awt.*;

--- a/jdk/test/java/awt/security/Permissions.java
+++ b/jdk/test/java/awt/security/Permissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,9 @@
  * questions.
  */
 
-/* @test
+/*
+ * @test
+ * @key headful
  * @bug 8008981
  * @summary Test that selected Toolkit and Window methods/constructors do
  *   the appropriate permission check

--- a/jdk/test/java/awt/xembed/server/RunTestXEmbed.java
+++ b/jdk/test/java/awt/xembed/server/RunTestXEmbed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key headful
  * @bug 4931668
  * @summary Tests XEmbed server/client functionality
  * @author Denis Mikhalkin: area=awt.xembed

--- a/jdk/test/javax/swing/JColorChooser/Test4165217.java
+++ b/jdk/test/javax/swing/JColorChooser/Test4165217.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 4165217
  * @summary Tests JColorChooser serialization
  * @author Ilya Boyandin

--- a/jdk/test/javax/swing/JColorChooser/Test4177735.java
+++ b/jdk/test/javax/swing/JColorChooser/Test4177735.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 4177735
  * @summary Tests that JColorChooser leaves no threads when disposed
  * @author Shannon Hickey

--- a/jdk/test/javax/swing/JColorChooser/Test4193384.java
+++ b/jdk/test/javax/swing/JColorChooser/Test4193384.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 4193384 4200976
  * @summary Tests the color conversions and the preview panel foreground color
  * @author Mark Davidson

--- a/jdk/test/javax/swing/JColorChooser/Test4234761.java
+++ b/jdk/test/javax/swing/JColorChooser/Test4234761.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 4234761
  * @summary RGB values sholdn't be changed in transition to HSB tab
  * @author Oleg Mokhovikov

--- a/jdk/test/javax/swing/JColorChooser/Test4461329.java
+++ b/jdk/test/javax/swing/JColorChooser/Test4461329.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 4461329
  * @summary Tests getPreviewPanel() and setPreviewPanel() methods
  * @author Leif Samuelsson

--- a/jdk/test/javax/swing/JColorChooser/Test4711996.java
+++ b/jdk/test/javax/swing/JColorChooser/Test4711996.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 4711996
  * @summary Checks if IllegalArgumentException is thrown when updating JColorChooserUI
  * @author Konstantin Eremin

--- a/jdk/test/javax/swing/JColorChooser/Test6524757.java
+++ b/jdk/test/javax/swing/JColorChooser/Test6524757.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6524757
  * @summary Tests different locales
  * @author Sergey Malenkov

--- a/jdk/test/javax/swing/JColorChooser/Test6707406.java
+++ b/jdk/test/javax/swing/JColorChooser/Test6707406.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6707406
  * @summary Tests color chooser with invalid UI
  * @author Sergey Malenkov

--- a/jdk/test/javax/swing/JComponent/6683775/bug6683775.java
+++ b/jdk/test/javax/swing/JComponent/6683775/bug6683775.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,12 +21,14 @@
  * questions.
  */
 
-/* @test
-   @bug 6683775 6794764
-   @summary Painting artifacts is seen when panel is made setOpaque(false) for a translucent window
-   @author Alexander Potochkin
-   @run main bug6683775
-*/
+/*
+ * @test
+ * @key headful
+ * @bug 6683775 6794764
+ * @summary Painting artifacts is seen when panel is made setOpaque(false) for a translucent window
+ * @author Alexander Potochkin
+ * @run main bug6683775
+ */
 
 import com.sun.awt.AWTUtilities;
 import sun.awt.SunToolkit;

--- a/jdk/test/javax/swing/JFileChooser/6520101/bug6520101.java
+++ b/jdk/test/javax/swing/JFileChooser/6520101/bug6520101.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test @(#)bug6520101
+ * @key headful
  * @bug 6520101
  * @summary JFileChooser throws OOM in 1.4.2, 5.0u4 and 1.6.0
  * @author Praveen Gupta

--- a/jdk/test/javax/swing/JFrame/4962534/bug4962534.html
+++ b/jdk/test/javax/swing/JFrame/4962534/bug4962534.html
@@ -1,6 +1,6 @@
 <html>
 <!--
-  Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+  Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
   This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 
 <!--
   @test
+  @key headful
   @bug 4962534
   @summary JFrame dances very badly
   @author dav@sparc.spb.su area=

--- a/jdk/test/javax/swing/JMenu/8071705/bug8071705.java
+++ b/jdk/test/javax/swing/JMenu/8071705/bug8071705.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8071705
  * @summary  Java application menu misbehaves when running multiple screen stacked vertically
  * @build bug8071705

--- a/jdk/test/javax/swing/JMenuItem/7036148/bug7036148.java
+++ b/jdk/test/javax/swing/JMenuItem/7036148/bug7036148.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
  /*
  * @test
+ * @key headful
  * @bug 7036148
  * @summary NullPointerException with null JMenu name
  * @author Alexander Potochkin

--- a/jdk/test/javax/swing/JPopupMenu/4634626/bug4634626.java
+++ b/jdk/test/javax/swing/JPopupMenu/4634626/bug4634626.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,14 +20,18 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-/* @test
-   @bug 4634626
-   @summary Implement context popup menus for components
-   @author Alexander Zuev
-   @library ../../../../lib/testlibrary
-   @build ExtendedRobot
-   @run applet bug4634626.html
-*/
+
+/*
+ * @test
+ * @key headful
+ * @bug 4634626
+ * @summary Implement context popup menus for components
+ * @author Alexander Zuev
+ * @library ../../../../lib/testlibrary
+ * @build ExtendedRobot
+ * @run applet bug4634626.html
+ */
+
 import javax.swing.*;
 import java.awt.event.*;
 import java.awt.*;

--- a/jdk/test/javax/swing/JSlider/6794836/bug6794836.java
+++ b/jdk/test/javax/swing/JSlider/6794836/bug6794836.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,9 @@
  * questions.
  */
 
-/* @test
+/*
+ * @test
+ * @key headful
  * @bug 6794836
  * @summary BasicSliderUI throws NullPointerExc when JSlider maximum is Integer.MAX_VALUE
  * @author Pavel Porvatov

--- a/jdk/test/javax/swing/JSpinner/5012888/bug5012888.java
+++ b/jdk/test/javax/swing/JSpinner/5012888/bug5012888.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,12 +21,15 @@
  * questions.
  */
 
-/* @test 1.0 04/04/23
-   @bug 5012888
-   @summary REGRESSION: Click & hold on arrow of JSpinner only transfers focus
-   @author Konstantin Eremin
-   @run main bug5012888
-*/
+/*
+ * @test 1.0 04/04/23
+ * @key headful
+ * @bug 5012888
+ * @summary REGRESSION: Click & hold on arrow of JSpinner only transfers focus
+ * @author Konstantin Eremin
+ * @run main bug5012888
+ */
+
 import javax.swing.*;
 import javax.swing.event.*;
 import java.awt.*;

--- a/jdk/test/javax/swing/JWindow/ShapedAndTranslucentWindows/PerPixelTranslucent.java
+++ b/jdk/test/javax/swing/JWindow/ShapedAndTranslucentWindows/PerPixelTranslucent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ import java.awt.*;
 
 /*
  * @test
+ * @key headful
  * @summary Check if a per-pixel translucent window is dragged and resized
  *          by mouse correctly.
  * Test Description: Check if PERPIXEL_TRANSLUCENT translucency type is supported

--- a/jdk/test/javax/swing/JWindow/ShapedAndTranslucentWindows/PerPixelTranslucentGradient.java
+++ b/jdk/test/javax/swing/JWindow/ShapedAndTranslucentWindows/PerPixelTranslucentGradient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ import java.awt.*;
 
 /*
  * @test
+ * @key headful
  * @bug 8032644
  * @summary Check if a per-pixel translucent window is dragged and resized by
  *          mouse correctly

--- a/jdk/test/javax/swing/JWindow/ShapedAndTranslucentWindows/PerPixelTranslucentSwing.java
+++ b/jdk/test/javax/swing/JWindow/ShapedAndTranslucentWindows/PerPixelTranslucentSwing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ import java.awt.*;
 
 /*
  * @test
+ * @key headful
  * @summary Check if a per-pixel translucent window shows only the area having
  *          opaque pixels
  * Test Description: Check if PERPIXEL_TRANSLUCENT Translucency type is supported

--- a/jdk/test/javax/swing/JWindow/ShapedAndTranslucentWindows/SetShapeAndClickSwing.java
+++ b/jdk/test/javax/swing/JWindow/ShapedAndTranslucentWindows/SetShapeAndClickSwing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,7 @@ import java.awt.geom.Rectangle2D;
 
 /*
  * @test
+ * @key headful
  * @summary Check if a window set with shape clips the contents
  * Test Description: Check if PERPIXEL_TRANSPARENT translucency type is supported
  *      by the current platform. Proceed if it is supported. Apply different types

--- a/jdk/test/javax/swing/JWindow/ShapedAndTranslucentWindows/ShapedPerPixelTranslucentGradient.java
+++ b/jdk/test/javax/swing/JWindow/ShapedAndTranslucentWindows/ShapedPerPixelTranslucentGradient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ import java.awt.*;
 
 /*
  * @test
+ * @key headful
  * @bug 7043845
  * @summary Check if shaped and per-pixel translucent window is dragged and
  *          resized by mouse correctly.

--- a/jdk/test/javax/swing/JWindow/ShapedAndTranslucentWindows/ShapedTranslucentPerPixelTranslucentGradient.java
+++ b/jdk/test/javax/swing/JWindow/ShapedAndTranslucentWindows/ShapedTranslucentPerPixelTranslucentGradient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ import java.awt.*;
 
 /*
  * @test
+ * @key headful
  * @summary Check if shaped, translucent and per-pixel translucent window is
  *          dragged and resized by mouse correctly.
  * Test Description: Check if PERPIXEL_TRANSLUCENT, TRANSLUCENT and

--- a/jdk/test/javax/swing/JWindow/ShapedAndTranslucentWindows/TranslucentJComboBox.java
+++ b/jdk/test/javax/swing/JWindow/ShapedAndTranslucentWindows/TranslucentJComboBox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ import java.awt.event.MouseEvent;
 
 /*
  * @test
+ * @key headful
  * @bug 8024627
  * @summary Check if a JComboBox present in a window set with opacity less than
  *          1.0 shows a translucent drop down

--- a/jdk/test/javax/swing/JWindow/ShapedAndTranslucentWindows/TranslucentPerPixelTranslucentGradient.java
+++ b/jdk/test/javax/swing/JWindow/ShapedAndTranslucentWindows/TranslucentPerPixelTranslucentGradient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ import java.awt.*;
 
 /*
  * @test
+ * @key headful
  * @summary Check if a per-pixel translucent and translucent window is dragged
  *          and resized by mouse correctly
  * Test Description: Check if PERPIXEL_TRANSLUCENT and TRANSLUCENT translucency

--- a/jdk/test/javax/swing/JWindow/ShapedAndTranslucentWindows/TranslucentWindowClickSwing.java
+++ b/jdk/test/javax/swing/JWindow/ShapedAndTranslucentWindows/TranslucentWindowClickSwing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ import java.awt.event.MouseEvent;
 
 /*
  * @test
+ * @key headful
  * @summary Check if swing components present in a window set with opacity less
  *          than 1.0 appears translucent
  * Test Description: Check if TRANSLUCENT Translucency type is supported for the

--- a/jdk/test/javax/swing/LookAndFeel/8145547/DemandGTK.java
+++ b/jdk/test/javax/swing/LookAndFeel/8145547/DemandGTK.java
@@ -26,6 +26,7 @@
   @summary  Tests that GTK LaF is supported on solaris
             regardless of jdk.gtk.version flag values.
   @bug 8156121
+  @key headful
   @requires (os.name == "linux" | os.name == "solaris")
   @run main/othervm -Djdk.gtk.version=2 DemandGTK
   @run main/othervm -Djdk.gtk.version=3 DemandGTK

--- a/jdk/test/javax/swing/LookAndFeel/8145547/DemandGTK2.sh
+++ b/jdk/test/javax/swing/LookAndFeel/8145547/DemandGTK2.sh
@@ -26,6 +26,7 @@
 #   @test
 #   @summary  Try to force GTK2. We must bail out to GTK3 (if any) if no 2 available.
 #
+#   @key headful
 #   @compile ProvokeGTK.java
 #   @requires os.family == "linux"
 #   @run shell/timeout=400 DemandGTK2.sh

--- a/jdk/test/javax/swing/LookAndFeel/8145547/DemandGTK3.sh
+++ b/jdk/test/javax/swing/LookAndFeel/8145547/DemandGTK3.sh
@@ -27,6 +27,7 @@
 #   @test
 #   @summary  Try to force GTK3. We must bail out to GTK2 if no 3 available.
 #
+#   @key headful
 #   @compile ProvokeGTK.java
 #   @requires os.family == "linux"
 #   @run shell/timeout=400 DemandGTK3.sh

--- a/jdk/test/javax/swing/MultiUIDefaults/4300666/bug4300666.java
+++ b/jdk/test/javax/swing/MultiUIDefaults/4300666/bug4300666.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,12 +21,14 @@
  * questions.
  */
 
-/* @test
-   @bug 4300666
-   @summary Printing UIDefaults throws NoSuchElementExcept
-   @author Andrey Pikalev
-   @run applet bug4300666.html
-*/
+/*
+ * @test
+ * @key headful
+ * @bug 4300666
+ * @summary Printing UIDefaults throws NoSuchElementExcept
+ * @author Andrey Pikalev
+ * @run applet bug4300666.html
+ */
 
 import javax.swing.*;
 

--- a/jdk/test/javax/swing/RepaintManager/6608456/bug6608456.java
+++ b/jdk/test/javax/swing/RepaintManager/6608456/bug6608456.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,9 @@
  * questions.
  */
 
-/* @test
+/*
+ * @test
+ * @key headful
  *
  * @bug 6608456
  * @author Igor Kushnirskiy

--- a/jdk/test/javax/swing/SwingUtilities/7170657/bug7170657.java
+++ b/jdk/test/javax/swing/SwingUtilities/7170657/bug7170657.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import javax.swing.event.MenuDragMouseEvent;
 
 /**
  * @test
+ * @key headful
  * @bug 7170657
  * @author Sergey Bylokhov
  */

--- a/jdk/test/javax/swing/plaf/synth/Test6660049.java
+++ b/jdk/test/javax/swing/plaf/synth/Test6660049.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6660049 6849518
  * @summary Tests the Region initialization
  * @author Sergey Malenkov

--- a/jdk/test/javax/swing/text/StyledEditorKit/4506788/bug4506788.java
+++ b/jdk/test/javax/swing/text/StyledEditorKit/4506788/bug4506788.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,12 +21,15 @@
  * questions.
  */
 
-/* @test
- @bug 4506788 7147408
- @summary  Tests if cursor gets stuck after insertion a character
- @author Denis Sharypov
- @run applet bug4506788.html
+/*
+ * @test
+ * @key headful
+ * @bug 4506788 7147408
+ * @summary  Tests if cursor gets stuck after insertion a character
+ * @author Denis Sharypov
+ * @run applet bug4506788.html
  */
+
 import java.awt.*;
 import java.awt.event.*;
 import java.lang.reflect.InvocationTargetException;

--- a/jdk/test/javax/swing/text/html/parser/Parser/7165725/bug7165725.java
+++ b/jdk/test/javax/swing/text/html/parser/Parser/7165725/bug7165725.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,12 +21,14 @@
  * questions.
  */
 
-/* @test
-   @bug 7165725
-   @summary  Tests if HTML parser can handle successive script tags in a line
-             and it does not call false text callback after script tags.
-   @run main bug7165725
-*/
+/*
+ * @test
+ * @key headful
+ * @bug 7165725
+ * @summary  Tests if HTML parser can handle successive script tags in a line
+ *           and it does not call false text callback after script tags.
+ * @run main bug7165725
+ */
 
 import java.awt.BorderLayout;
 import java.awt.Robot;

--- a/jdk/test/sun/java2d/AcceleratedXORModeTest.java
+++ b/jdk/test/sun/java2d/AcceleratedXORModeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,12 +22,13 @@
  */
 
 /*
-* @test
-* @bug     8024343 8042098
-* @summary Test verifies that accelerated pipelines
-*          correctly draws primitives in XOR mode.
-* @run main/othervm -Dsun.java2d.xrender=True AcceleratedXORModeTest
-*/
+ * @test
+ * @key headful
+ * @bug     8024343 8042098
+ * @summary Test verifies that accelerated pipelines
+ *          correctly draws primitives in XOR mode.
+ * @run main/othervm -Dsun.java2d.xrender=True AcceleratedXORModeTest
+ */
 
 import java.awt.Color;
 import java.awt.Graphics2D;

--- a/jdk/test/sun/java2d/DirectX/AccelPaintsTest/AccelPaintsTest.java
+++ b/jdk/test/sun/java2d/DirectX/AccelPaintsTest/AccelPaintsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6659345
  * @summary Tests that various paints work correctly when preceeded by a
  * textured operaiton.

--- a/jdk/test/sun/java2d/DirectX/AcceleratedScaleTest/AcceleratedScaleTest.java
+++ b/jdk/test/sun/java2d/DirectX/AcceleratedScaleTest/AcceleratedScaleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@ import javax.imageio.ImageIO;
 
 /**
  * @test
+ * @key headful
  * @bug 6429665
  * @bug 6588884
  * @summary Tests that the transform is correctly handled

--- a/jdk/test/sun/java2d/DirectX/DrawBitmaskToSurfaceTest.java
+++ b/jdk/test/sun/java2d/DirectX/DrawBitmaskToSurfaceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug     6997116
  * @summary Test verifies that rendering of images with bitmap transparency
  *          to a D3D surface does not cause an ClassCastException.

--- a/jdk/test/sun/java2d/DirectX/InfiniteValidationLoopTest/InfiniteValidationLoopTest.java
+++ b/jdk/test/sun/java2d/DirectX/InfiniteValidationLoopTest/InfiniteValidationLoopTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6648018
  * @summary Tests that we don't run into infinite validation loop when copying
             a VolatileImage to the screen

--- a/jdk/test/sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java
+++ b/jdk/test/sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  */
 /*
  * @test
+ * @key headful
  * @bug 6664068 6666931
  * @summary Tests that resizing a window to which a tight loop is rendering
  * doesn't produce artifacts or crashes

--- a/jdk/test/sun/java2d/DirectX/OpaqueImageToSurfaceBlitTest/OpaqueImageToSurfaceBlitTest.java
+++ b/jdk/test/sun/java2d/DirectX/OpaqueImageToSurfaceBlitTest/OpaqueImageToSurfaceBlitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6764257
  * @summary Tests that the alpha in opaque images doesn't affect result of alpha
  * compositing

--- a/jdk/test/sun/java2d/DirectX/OverriddenInsetsTest/OverriddenInsetsTest.java
+++ b/jdk/test/sun/java2d/DirectX/OverriddenInsetsTest/OverriddenInsetsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6694230
  * @summary Tests that components overriding getInsets paint correctly
  * @author Dmitri.Trembovetski@sun.com: area=Graphics

--- a/jdk/test/sun/java2d/DirectX/RenderingToCachedGraphicsTest/RenderingToCachedGraphicsTest.java
+++ b/jdk/test/sun/java2d/DirectX/RenderingToCachedGraphicsTest/RenderingToCachedGraphicsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6648018 6652662
  * @summary Verifies that rendering to a cached onscreen Graphics works
  * @author Dmitri.Trembovetski@sun.com: area=Graphics

--- a/jdk/test/sun/java2d/DirectX/StrikeDisposalCrashTest/StrikeDisposalCrashTest.java
+++ b/jdk/test/sun/java2d/DirectX/StrikeDisposalCrashTest/StrikeDisposalCrashTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key headful
  * @bug 6705443
  * @summary tests that we don't crash during exit if font strikes were disposed
  * during the lifetime of the application

--- a/jdk/test/sun/java2d/DirectX/SwingOnScreenScrollingTest/SwingOnScreenScrollingTest.java
+++ b/jdk/test/sun/java2d/DirectX/SwingOnScreenScrollingTest/SwingOnScreenScrollingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  */
 /*
  * @test
+ * @key headful
  * @bug 6630702
  * @summary Tests that scrolling after paint() is performed correctly.
  *          This is really only applicable to Vista

--- a/jdk/test/sun/java2d/DirectX/TransformedPaintTest/TransformedPaintTest.java
+++ b/jdk/test/sun/java2d/DirectX/TransformedPaintTest/TransformedPaintTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6689025 8023483
  * @summary Tests that transformed Paints are rendered correctly
  * @author Dmitri.Trembovetski@sun.com: area=Graphics

--- a/jdk/test/sun/java2d/DrawCachedImageAndTransform.java
+++ b/jdk/test/sun/java2d/DrawCachedImageAndTransform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import java.awt.image.VolatileImage;
 
 /**
  * @test
+ * @key headful
  * @bug 8039774
  * @summary Verifies that we get no exception, when we draw with scale
  *          BufferedImage to VolatileImage via intermediate texture.

--- a/jdk/test/sun/java2d/DrawXORModeTest.java
+++ b/jdk/test/sun/java2d/DrawXORModeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug     8036022
  * @summary Test verifies that drawing shapes with XOR composite
  *          does not trigger an InternalError in GDI surface data.

--- a/jdk/test/sun/java2d/GdiRendering/InsetClipping.java
+++ b/jdk/test/sun/java2d/GdiRendering/InsetClipping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key headful
  * @bug 4873505 6588884
  * @author cheth
  * @summary verifies that drawImage behaves the bounds of a complex

--- a/jdk/test/sun/java2d/OpenGL/CopyAreaOOB.java
+++ b/jdk/test/sun/java2d/OpenGL/CopyAreaOOB.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6430601
  * @summary Verifies that copyArea() works properly when the
  * destination parameters are outside the destination bounds.

--- a/jdk/test/sun/java2d/OpenGL/CustomCompositeTest.java
+++ b/jdk/test/sun/java2d/OpenGL/CustomCompositeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug     7124347
  * @summary Verifies that rendering with XOR composite, and arbitraty
  *          custom composite doesn not cause internal errors.

--- a/jdk/test/sun/java2d/OpenGL/DrawBufImgOp.java
+++ b/jdk/test/sun/java2d/OpenGL/DrawBufImgOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  */
 /*
  * @test
+ * @key headful
  * @bug 6514990
  * @summary Verifies that calling
  * Graphics2D.drawImage(BufferedImage, BufferedImageOp, x, y) to an

--- a/jdk/test/sun/java2d/OpenGL/DrawHugeImageTest.java
+++ b/jdk/test/sun/java2d/OpenGL/DrawHugeImageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  */
 /*
  * @test
+ * @key headful
  * @bug     8040617
  * @summary Test verifies that an attempt to get an accelerated copy of
  *          a huge buffered image does not result in an OOME.

--- a/jdk/test/sun/java2d/OpenGL/GradientPaints.java
+++ b/jdk/test/sun/java2d/OpenGL/GradientPaints.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6521533 6525997
  * @summary Verifies that the OGL-accelerated codepaths for GradientPaint,
  * LinearGradientPaint, and RadialGradientPaint produce results that are

--- a/jdk/test/sun/java2d/OpenGL/bug7181438.java
+++ b/jdk/test/sun/java2d/OpenGL/bug7181438.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import java.awt.image.VolatileImage;
 
 /**
  * @test
+ * @key headful
  * @bug 7181438
  * @summary Verifies that we get correct alpha, when we draw opaque
  * BufferedImage to non opaque VolatileImage via intermediate opaque texture.

--- a/jdk/test/sun/java2d/SunGraphics2D/DrawImageBilinear.java
+++ b/jdk/test/sun/java2d/SunGraphics2D/DrawImageBilinear.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  */
 /*
  * @test
+ * @key headful
  * @bug 5009033 6603000 6666362
  * @summary Verifies that images transformed with bilinear filtering do not
  * leave artifacts at the edges.

--- a/jdk/test/sun/java2d/SunGraphics2D/EmptyClipRenderingTest.java
+++ b/jdk/test/sun/java2d/SunGraphics2D/EmptyClipRenderingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,6 +47,7 @@ import sun.awt.ConstrainableGraphics;
 
 /**
  * @test
+ * @key headful
  * @bug 6335200 6419610
  * @summary Tests that we don't render anything if specific empty clip is set
  * @author Dmitri.Trembovetski@Sun.COM: area=Graphics

--- a/jdk/test/sun/java2d/SunGraphics2D/PolyVertTest.java
+++ b/jdk/test/sun/java2d/SunGraphics2D/PolyVertTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 4678208 4771101 6328481 6588884
  * @summary verify the pixelization of degenerate polylines and polygons
  * @run main PolyVertTest

--- a/jdk/test/sun/java2d/SunGraphics2D/SimplePrimQuality.java
+++ b/jdk/test/sun/java2d/SunGraphics2D/SimplePrimQuality.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 4832224 6322584 6328478 6328481 6322580 6588884 6587863
  * @summary Verifies that the pixelization of simple primitives (drawLine,
  * fillRect, drawRect, fill, draw) with the OGL pipeline enabled

--- a/jdk/test/sun/java2d/X11SurfaceData/DrawImageBgTest/DrawImageBgTest.java
+++ b/jdk/test/sun/java2d/X11SurfaceData/DrawImageBgTest/DrawImageBgTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key headful
  * @bug 6603887
  * @summary Verifies that drawImage with bg color works correctly for ICM image
  * @run main/othervm DrawImageBgTest

--- a/jdk/test/sun/java2d/XRenderBlitsTest.java
+++ b/jdk/test/sun/java2d/XRenderBlitsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,12 +22,13 @@
  */
 
 /*
-* @test
-* @bug     6985593
-* @summary Test verifies that rendering standard images to screen does
-*          not caiuse a crash in case of XRender.
-* @run main/othervm -Dsun.java2d.xrender=True XRenderBlitsTest
-*/
+ * @test
+ * @key headful
+ * @bug     6985593
+ * @summary Test verifies that rendering standard images to screen does
+ *          not caiuse a crash in case of XRender.
+ * @run main/othervm -Dsun.java2d.xrender=True XRenderBlitsTest
+ */
 
 import java.awt.Color;
 import java.awt.Component;

--- a/jdk/test/sun/java2d/cmm/ColorConvertOp/ConstructorsNullTest/ConstructorsNullTest.html
+++ b/jdk/test/sun/java2d/cmm/ColorConvertOp/ConstructorsNullTest/ConstructorsNullTest.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2000, 2013, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2000, 2016, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 <html>
 <!--  
   @test
+  @key headful
   @bug 4185854
   @summary Checks that constructors do not accept nulls and throw NPE
   @author tdv@eng.sun.com: area= 

--- a/jdk/test/sun/java2d/pipe/InterpolationQualityTest.java
+++ b/jdk/test/sun/java2d/pipe/InterpolationQualityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 7188093 8000176
  * @summary Tests each of the 3 possible methods for rendering an upscaled
  * image via rendering hints for default, xrender and opengl pipelines.

--- a/jdk/test/sun/java2d/pipe/MutableColorTest/MutableColorTest.java
+++ b/jdk/test/sun/java2d/pipe/MutableColorTest/MutableColorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key headful
  * @bug 6613860 6691934
  * @summary Tests that the pipelines can handle (in somewhat limited
  * manner) mutable Colors

--- a/jdk/test/sun/java2d/pipe/hw/RSLAPITest/RSLAPITest.java
+++ b/jdk/test/sun/java2d/pipe/hw/RSLAPITest/RSLAPITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  */
 /*
  * @test
+ * @key headful
  * @bug 6635805 6653780 6667607
  * @summary Tests that the resource sharing layer API is not broken
  * @author Dmitri.Trembovetski@sun.com: area=Graphics

--- a/jdk/test/sun/java2d/pipe/hw/RSLContextInvalidationTest/RSLContextInvalidationTest.java
+++ b/jdk/test/sun/java2d/pipe/hw/RSLContextInvalidationTest/RSLContextInvalidationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6764257
  * @summary Tests that the color is reset properly after save/restore context
  * @author Dmitri.Trembovetski@sun.com: area=Graphics


### PR DESCRIPTION
The patch is not clean because the 31 tests are omitted, and because of various context differences. The only substantive change is the addition of @headful, which doesn’t affect running any of the tests.

There are 30 tests that were in the original patch that are not present in 8u. And there is 1 test that does not need to handle headful.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8159690](https://bugs.openjdk.org/browse/JDK-8159690) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8159690](https://bugs.openjdk.org/browse/JDK-8159690): [TESTBUG] Mark headful tests with @<!---->key headful. (**Bug** - P4 - Approved)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/306/head:pull/306` \
`$ git checkout pull/306`

Update a local copy of the PR: \
`$ git checkout pull/306` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/306/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 306`

View PR using the GUI difftool: \
`$ git pr show -t 306`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/306.diff">https://git.openjdk.org/jdk8u-dev/pull/306.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/306#issuecomment-1542590143)