### PR TITLE
8268558: [TESTBUG] Case 2 in TestP11KeyFactoryGetRSAKeySpec is skipped

### DIFF
--- a/jdk/test/sun/security/pkcs11/rsa/TestP11KeyFactoryGetRSAKeySpec.java
+++ b/jdk/test/sun/security/pkcs11/rsa/TestP11KeyFactoryGetRSAKeySpec.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, Amazon.com, Inc. or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -21,7 +22,6 @@
  * questions.
  */
 
-import java.math.BigInteger;
 import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
@@ -85,7 +85,7 @@ public class TestP11KeyFactoryGetRSAKeySpec extends PKCS11Test {
 
     private static void testKeySpec(KeyFactory factory, PrivateKey key, Class<? extends KeySpec> specClass) throws Exception {
         try {
-            KeySpec spec = factory.getKeySpec(key, RSAPrivateKeySpec.class);
+            KeySpec spec = factory.getKeySpec(key, specClass);
             if (testingSensitiveKeys) {
                 throw new Exception("Able to retrieve spec from sensitive key");
             }


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [041ae20b](https://github.com/openjdk/jdk/commit/041ae20b10e11381415e8f61fd39e9e19aa8d4f2) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.
The commit being backported was authored by Fernando Guallini on 7 Sep 2021 and was reviewed by Sean Mullan and Rajan Halade.
Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8268558](https://bugs.openjdk.org/browse/JDK-8268558): [TESTBUG] Case 2 in TestP11KeyFactoryGetRSAKeySpec is skipped


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/308/head:pull/308` \
`$ git checkout pull/308`

Update a local copy of the PR: \
`$ git checkout pull/308` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/308/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 308`

View PR using the GUI difftool: \
`$ git pr show -t 308`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/308.diff">https://git.openjdk.org/jdk8u-dev/pull/308.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/308#issuecomment-1520790434)