### PR TITLE
8072678: Wrong exception messages in java.awt.color.ICC_ColorSpace

### DIFF
--- a/jdk/src/share/classes/java/awt/color/ICC_ColorSpace.java
+++ b/jdk/src/share/classes/java/awt/color/ICC_ColorSpace.java
@@ -558,7 +558,7 @@ public class ICC_ColorSpace extends ColorSpace {
     public float getMinValue(int component) {
         if ((component < 0) || (component > this.getNumComponents() - 1)) {
             throw new IllegalArgumentException(
-                "Component index out of range: + component");
+                "Component index out of range: " + component);
         }
         return minVal[component];
     }
@@ -583,7 +583,7 @@ public class ICC_ColorSpace extends ColorSpace {
     public float getMaxValue(int component) {
         if ((component < 0) || (component > this.getNumComponents() - 1)) {
             throw new IllegalArgumentException(
-                "Component index out of range: + component");
+                "Component index out of range: " + component);
         }
         return maxVal[component];
     }

--- a/jdk/test/java/awt/Color/GetMinMaxValue_ICC_ColorSpace.java
+++ b/jdk/test/java/awt/Color/GetMinMaxValue_ICC_ColorSpace.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+import java.awt.color.ColorSpace;
+import java.awt.color.ICC_ColorSpace;
+import java.awt.color.ICC_Profile;
+import java.io.IOException;
+
+/**
+  * @test
+  * @bug 8072678
+  * @author Prasanta Sadhukhan
+  */
+
+public class GetMinMaxValue_ICC_ColorSpace {
+
+    public static void main(String[] a) throws Exception {
+        ICC_Profile cmyk_profile = ICC_Profile.getInstance(ColorSpace.CS_sRGB);
+        ICC_ColorSpace colorSpace = new ICC_ColorSpace(cmyk_profile);
+        String minstr = null;
+        String maxstr = null;
+
+        colorSpace.fromRGB(new float[]{4.3f,3.1f,2.2f});
+        try {
+            System.out.println("minvalue " + colorSpace.getMinValue(3));
+        } catch (IllegalArgumentException iae) {
+            minstr = iae.toString();
+        }
+        try {
+            System.out.println("maxvalue " + colorSpace.getMaxValue(3));
+        } catch (IllegalArgumentException iae) {
+            maxstr = iae.toString();
+        }
+
+        if (minstr.endsWith("+ component") || maxstr.endsWith("+ component")) {
+            System.out.println("Test failed");
+            throw new RuntimeException("IllegalArgumentException contains incorrect text message");
+        } else {
+            System.out.println("Test passed");
+        }
+    }
+}


### PR DESCRIPTION
Hi all,

Clean backport for a trivial patch.

This pull request contains a backport of commit [f4fa68a2](https://github.com/openjdk/jdk/commit/f4fa68a2a795ca073409b76332037cc601e66b13) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Prasanta Sadhukhan on 14 Feb 2015 and was reviewed by Phil Race and Sergey Bylokhov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8072678](https://bugs.openjdk.org/browse/JDK-8072678): Wrong exception messages in java.awt.color.ICC_ColorSpace


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/309/head:pull/309` \
`$ git checkout pull/309`

Update a local copy of the PR: \
`$ git checkout pull/309` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/309/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 309`

View PR using the GUI difftool: \
`$ git pr show -t 309`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/309.diff">https://git.openjdk.org/jdk8u-dev/pull/309.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/309#issuecomment-1532212549)