### PR TITLE
8307310: Backport the tests for JDK-8058969 and JDK-8039271 to the OpenJDK8

### DIFF
--- a/jdk/test/java/awt/Color/LoadProfileWithSM.java
+++ b/jdk/test/java/awt/Color/LoadProfileWithSM.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.color.*;
+
+/*
+ * @test
+ * @bug 8058969
+ * @summary test standard profiles loads with SecurityManager installed.
+ * @run main/othervm LoadProfileWithSM
+ */
+
+public class LoadProfileWithSM {
+
+    public static void main(String[] args) {
+        System.setSecurityManager(new SecurityManager());
+        ICC_Profile profile =
+            ((ICC_ColorSpace)(ColorSpace.getInstance(
+                ColorSpace.CS_GRAY))).getProfile();
+        /* request profile data in order to force profile loading */
+        profile.getData();
+   }
+}

--- a/jdk/test/java/awt/Color/LoadStandardProfilesTest.java
+++ b/jdk/test/java/awt/Color/LoadStandardProfilesTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8039271
+ * @summary test all standard profiles load correctly.
+ */
+
+import java.awt.color.ICC_Profile;
+
+public class LoadStandardProfilesTest {
+
+    public static void main(String args[]) {
+        try {
+            ICC_Profile sRGB      = ICC_Profile.getInstance("sRGB.pf");
+            ICC_Profile gray      = ICC_Profile.getInstance("GRAY.pf");
+            ICC_Profile pycc      = ICC_Profile.getInstance("PYCC.pf");
+            ICC_Profile ciexyz    = ICC_Profile.getInstance("CIEXYZ.pf");
+            ICC_Profile linearRGB = ICC_Profile.getInstance("LINEAR_RGB.pf");
+
+            if (sRGB == null ||
+                gray == null ||
+                pycc == null ||
+                ciexyz == null ||
+                linearRGB == null)
+            {
+                throw new RuntimeException("null profile.");
+            }
+        } catch (Exception e) {
+           throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Both tests were created for a bug introduced in the jdk9 and related to the "modules", so the patches are not applicable to the jdk8 but the test code coverage can be improved by the "new" tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307310](https://bugs.openjdk.org/browse/JDK-8307310): Backport the tests for JDK-8058969 and JDK-8039271 to the OpenJDK8


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/310/head:pull/310` \
`$ git checkout pull/310`

Update a local copy of the PR: \
`$ git checkout pull/310` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/310/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 310`

View PR using the GUI difftool: \
`$ git pr show -t 310`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/310.diff">https://git.openjdk.org/jdk8u-dev/pull/310.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/310#issuecomment-1532234955)