### PR TITLE
8253269: The CheckCommonColors test should provide more info on failure

### DIFF
--- a/jdk/test/java/awt/Robot/CheckCommonColors/CheckCommonColors.java
+++ b/jdk/test/java/awt/Robot/CheckCommonColors/CheckCommonColors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,10 +22,18 @@
  */
 
 import java.awt.Color;
+import java.awt.Dimension;
 import java.awt.Frame;
 import java.awt.Point;
+import java.awt.Rectangle;
 import java.awt.Robot;
+import java.awt.Toolkit;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
 import java.util.List;
+
+import javax.imageio.ImageIO;
 
 /**
  * @test
@@ -58,6 +66,7 @@ public final class CheckCommonColors {
                                          Color.GREEN, Color.MAGENTA, Color.CYAN,
                                          Color.BLUE}) {
             frame.dispose();
+            robot.waitForIdle();
             frame.setBackground(color);
             frame.setVisible(true);
             checkPixels(color);
@@ -68,14 +77,25 @@ public final class CheckCommonColors {
         int attempt = 0;
         while (true) {
             Point p = frame.getLocationOnScreen();
-            Color pixel = robot.getPixelColor(p.x + frame.getWidth() / 2,
-                                              p.y + frame.getHeight() / 2);
+            p.translate(frame.getWidth() / 2, frame.getHeight() / 2);
+            Color pixel = robot.getPixelColor(p.x, p.y);
             if (color.equals(pixel)) {
                 return;
             }
-            if (attempt > 10) {
+            frame.repaint();
+            if (attempt > 11) {
                 System.err.println("Expected: " + color);
                 System.err.println("Actual: " + pixel);
+                System.err.println("Point: " + p);
+                Dimension screenSize =
+                        Toolkit.getDefaultToolkit().getScreenSize();
+                BufferedImage screen = robot.createScreenCapture(
+                        new Rectangle(screenSize));
+                try {
+                    File output = new File("ScreenCapture.png");
+                    System.err.println("Dump screen to: " + output);
+                    ImageIO.write(screen, "png", output);
+                } catch (IOException ex) {}
                 throw new RuntimeException("Too many attempts: " + attempt);
             }
             // skip Robot.waitForIdle to speedup the common case, but also take


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [1c2754bf](https://github.com/openjdk/jdk/commit/1c2754bfe3294fb3c80defe5479bdd85b0d07e29) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Sergey Bylokhov on 3 Oct 2020 and was reviewed by Phil Race.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8253269](https://bugs.openjdk.org/browse/JDK-8253269): The CheckCommonColors test should provide more info on failure


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/311/head:pull/311` \
`$ git checkout pull/311`

Update a local copy of the PR: \
`$ git checkout pull/311` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/311/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 311`

View PR using the GUI difftool: \
`$ git pr show -t 311`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/311.diff">https://git.openjdk.org/jdk8u-dev/pull/311.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/311#issuecomment-1532243509)