### PR TITLE
8139348: Deprecate 3DES and RC4 in Kerberos

### DIFF
--- a/jdk/src/share/classes/sun/security/krb5/internal/crypto/EType.java
+++ b/jdk/src/share/classes/sun/security/krb5/internal/crypto/EType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -221,8 +221,8 @@ public abstract class EType {
             result = BUILTIN_ETYPES;
         }
         if (!allowWeakCrypto) {
-            // The last 2 etypes are now weak ones
-            return Arrays.copyOfRange(result, 0, result.length - 2);
+            // The last 4 etypes are now weak ones
+            return Arrays.copyOfRange(result, 0, result.length - 4);
         }
         return result;
     }

--- a/jdk/test/sun/security/krb5/auto/NewSalt.java
+++ b/jdk/test/sun/security/krb5/auto/NewSalt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ public class NewSalt {
         KDC kdc = new OneKDC(null);
         if (System.getProperty("onlyonepreauth") != null) {
             KDC.saveConfig(OneKDC.KRB5_CONF, kdc,
-                    "default_tgs_enctypes=des3-cbc-sha1");
+                    "default_tgs_enctypes=aes128-cts");
             Config.refresh();
             kdc.setOption(KDC.Option.ONLY_ONE_PREAUTH, true);
         }

--- a/jdk/test/sun/security/krb5/auto/W83.java
+++ b/jdk/test/sun/security/krb5/auto/W83.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,11 +26,11 @@
  * @bug 6932525 6951366 6959292
  * @summary kerberos login failure on win2008 with AD set to win2000 compat mode
  * and cannot login if session key and preauth does not use the same etype
+ * @compile -XDignore.symbol.file W83.java
  * @run main/othervm -Dsun.net.spi.nameservice.provider.1=ns,mock -D6932525 W83
  * @run main/othervm -Dsun.net.spi.nameservice.provider.1=ns,mock -D6959292 W83
  */
 import com.sun.security.auth.module.Krb5LoginModule;
-import java.io.File;
 import sun.security.krb5.Config;
 import sun.security.krb5.EncryptedData;
 import sun.security.krb5.PrincipalName;
@@ -47,7 +47,8 @@ public class W83 {
         KDC kdc = new KDC(OneKDC.REALM, "127.0.0.1", 0, true);
         kdc.addPrincipal(OneKDC.USER, OneKDC.PASS);
         kdc.addPrincipalRandKey("krbtgt/" + OneKDC.REALM);
-        KDC.saveConfig(OneKDC.KRB5_CONF, kdc);
+        KDC.saveConfig(OneKDC.KRB5_CONF, kdc,
+                "allow_weak_crypto = true");
         System.setProperty("java.security.krb5.conf", OneKDC.KRB5_CONF);
         Config.refresh();
 

--- a/jdk/test/sun/security/krb5/etype/WeakCrypto.java
+++ b/jdk/test/sun/security/krb5/etype/WeakCrypto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,41 +22,59 @@
  */
 /*
  * @test
- * @bug 6844909 8012679
+ * @bug 6844909 8012679 8139348
  * @run main/othervm WeakCrypto
  * @run main/othervm WeakCrypto true
  * @run main/othervm WeakCrypto false
  * @summary support allow_weak_crypto in krb5.conf
  */
 
-import java.io.File;
 import java.lang.Exception;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
 
+import sun.security.krb5.EncryptionKey;
 import sun.security.krb5.internal.crypto.EType;
 import sun.security.krb5.EncryptedData;
 
 public class WeakCrypto {
+
+    static List<Integer> weakOnes = Arrays.asList(
+            EncryptedData.ETYPE_DES_CBC_CRC,
+            EncryptedData.ETYPE_DES_CBC_MD5,
+            EncryptedData.ETYPE_DES3_CBC_HMAC_SHA1_KD,
+            EncryptedData.ETYPE_ARCFOUR_HMAC
+    );
+
     public static void main(String[] args) throws Exception {
+
         String conf = "[libdefaults]\n" +
                 (args.length > 0 ? ("allow_weak_crypto = " + args[0]) : "");
         Files.write(Paths.get("krb5.conf"), conf.getBytes());
         System.setProperty("java.security.krb5.conf", "krb5.conf");
 
-        boolean expected = args.length != 0 && args[0].equals("true");
-        int[] etypes = EType.getBuiltInDefaults();
-
-        boolean found = false;
-        for (int i=0, length = etypes.length; i<length; i++) {
-            if (etypes[i] == EncryptedData.ETYPE_DES_CBC_CRC ||
-                    etypes[i] == EncryptedData.ETYPE_DES_CBC_MD4 ||
-                    etypes[i] == EncryptedData.ETYPE_DES_CBC_MD5) {
-                found = true;
-            }
+        // expected number of supported weak etypes
+        int expected = 0;
+        if (args.length != 0 && args[0].equals("true")) {
+            expected = weakOnes.size();
         }
-        if (expected != found) {
-            throw new Exception();
+
+        // Ensure EType.getBuiltInDefaults() has the correct etypes
+        if (Arrays.stream(EType.getBuiltInDefaults())
+                .filter(weakOnes::contains)
+                .count() != expected) {
+            throw new Exception("getBuiltInDefaults fails");
+        }
+
+        // Ensure keys generated have the correct etypes
+        if (Arrays.stream(EncryptionKey.acquireSecretKeys(
+                    "password".toCharArray(), "salt"))
+                .map(EncryptionKey::getEType)
+                .filter(weakOnes::contains)
+                .count() != expected) {
+            throw new Exception("acquireSecretKeys fails");
         }
     }
 }

--- a/jdk/test/sun/security/krb5/etype/weakcrypto.conf
+++ b/jdk/test/sun/security/krb5/etype/weakcrypto.conf
@@ -1,2 +1,0 @@
-[libdefaults]
-allow_weak_crypto = false

--- a/jdk/test/sun/security/krb5/tools/ktcheck.sh
+++ b/jdk/test/sun/security/krb5/tools/ktcheck.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2010, 2012, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
 #
 
 # @test
-# @bug 6950546
+# @bug 6950546 8139348
 # @summary "ktab -d name etype" to "ktab -d name [-e etype] [kvno | all | old]"
 # @run shell ktcheck.sh
 #
@@ -62,33 +62,35 @@ CHECK="${TESTJAVA}${FS}bin${FS}java ${TESTVMOPTS} ${EXTRA_OPTIONS} KtabCheck $KE
 
 echo ${EXTRA_OPTIONS}
 
+# This test uses a krb5.conf file (onlythree.conf) in which
+# only 2 etypes in the default_tkt_enctypes setting are enabled
+# by default: aes128-cts(17), aes256-cts(18).
+
 $KTAB -a me mine
-$CHECK 1 16 1 23 1 17 || exit 1
+$CHECK 1 17 1 18 || exit 1
 $KTAB -a me mine -n 0
-$CHECK 0 16 0 23 0 17 || exit 1
+$CHECK 0 17 0 18 || exit 1
 $KTAB -a me mine -n 1 -append
-$CHECK 0 16 0 23 0 17 1 16 1 23 1 17 || exit 1
+$CHECK 0 17 0 18 1 17 1 18 || exit 1
 $KTAB -a me mine -append
-$CHECK 0 16 0 23 0 17 1 16 1 23 1 17 2 16 2 23 2 17 || exit 1
+$CHECK 0 17 0 18 1 17 1 18 2 17 2 18 || exit 1
 $KTAB -a me mine
-$CHECK 3 16 3 23 3 17 || exit 1
+$CHECK 3 17 3 18 || exit 1
 $KTAB -a me mine -n 4 -append
-$CHECK 3 16 3 23 3 17 4 16 4 23 4 17 || exit 1
+$CHECK 3 17 3 18 4 17 4 18 || exit 1
 $KTAB -a me mine -n 5 -append
-$CHECK 3 16 3 23 3 17 4 16 4 23 4 17 5 16 5 23 5 17 || exit 1
+$CHECK 3 17 3 18 4 17 4 18 5 17 5 18 || exit 1
 $KTAB -a me mine -n 6 -append
-$CHECK 3 16 3 23 3 17 4 16 4 23 4 17 5 16 5 23 5 17 6 16 6 23 6 17 || exit 1
+$CHECK 3 17 3 18 4 17 4 18 5 17 5 18 6 17 6 18 || exit 1
 $KTAB -d me 3
-$CHECK 4 16 4 23 4 17 5 16 5 23 5 17 6 16 6 23 6 17 || exit 1
-$KTAB -d me -e 16 6
-$CHECK 4 16 4 23 4 17 5 16 5 23 5 17 6 23 6 17 || exit 1
+$CHECK 4 17 4 18 5 17 5 18 6 17 6 18 || exit 1
 $KTAB -d me -e 17 6
-$CHECK 4 16 4 23 4 17 5 16 5 23 5 17 6 23 || exit 1
-$KTAB -d me -e 16 5
-$CHECK 4 16 4 23 4 17 5 23 5 17 6 23 || exit 1
+$CHECK 4 17 4 18 5 17 5 18 6 18 || exit 1
+$KTAB -d me -e 17 5
+$CHECK 4 17 4 18 5 18 6 18 || exit 1
 $KTAB -d me old
-$CHECK 4 16 5 17 6 23 || exit 1
+$CHECK 4 17 6 18 || exit 1
 $KTAB -d me old
-$CHECK 4 16 5 17 6 23 || exit 1
+$CHECK 4 17 6 18 || exit 1
 $KTAB -d me
 $CHECK || exit 1

--- a/jdk/test/sun/security/krb5/tools/onlythree.conf
+++ b/jdk/test/sun/security/krb5/tools/onlythree.conf
@@ -1,6 +1,6 @@
 [libdefaults]
 default_realm = LOCAL.COM
-default_tkt_enctypes = des3-cbc-sha1 rc4-hmac aes128-cts
+default_tkt_enctypes = des-cbc-crc des-cbc-md5 des3-cbc-sha1 rc4-hmac aes128-cts aes256-cts
 
 [realms]
 LOCAL.COM = {


### PR DESCRIPTION
I'd like to backport JDK-8139348 to 8u for parity with Oracle 8u351. 
CSR JDK-8262273 is approved for 8-pool.

11u patch doesn't apply cleanly, some tests need to be adjusted:
- jdk/test/sun/security/krb5/auto/NewSalt.java
  - copyright years adjusted
  - "default_tgs_enctypes=aes128-sha1" changed to "default_tgs_enctypes=aes128-cts" since aes128-sha1 alias is not supported in 8u (JDK-8014628 is not backported to 8u)
- jdk/test/sun/security/krb5/auto/W83.java
  - copyright years adjusted
  - compile tag hunk applied manually due to context difference
- jdk/test/sun/security/krb5/etype/WeakCrypto.java
  - bug tag hunk applied manually due to context difference
  - List.of replaced with Arrays.asList 
- test/jdk/sun/security/krb5/tools/KtabCheck.java changes applied to jdk/test/sun/security/krb5/tools/ktcheck.sh (JDK-8180569 is not backported to 8u)
  - additionally, aes128-sha2 (19) values are removed since it is not supported in 8u (JDK-8014628 is not in 8u)
- jdk/test/sun/security/krb5/tools/onlythree.conf
  - aes128-sha2 removed from default_tkt_enctypes since it is not supported in 8u (JDK-8014628 is not in 8u)

Tested with jdk_security and tier1, no regressions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8139348](https://bugs.openjdk.org/browse/JDK-8139348): Deprecate 3DES and RC4 in Kerberos


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/312/head:pull/312` \
`$ git checkout pull/312`

Update a local copy of the PR: \
`$ git checkout pull/312` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/312/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 312`

View PR using the GUI difftool: \
`$ git pr show -t 312`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/312.diff">https://git.openjdk.org/jdk8u-dev/pull/312.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/312#issuecomment-1535187311)