### PR TITLE
8307531: [aarch64] JDK8 single-step debugging is extremely slow

### DIFF
--- a/hotspot/src/share/vm/prims/jvmtiExport.cpp
+++ b/hotspot/src/share/vm/prims/jvmtiExport.cpp
@@ -1239,14 +1239,7 @@ void JvmtiExport::post_method_exit(JavaThread *thread, Method* method, frame cur
     }
   }
 
-#ifdef AARCH64
-  // FIXME: this is just a kludge to get JVMTI going.  Compiled
-  // MethodHandle code doesn't call the JVMTI notify routines, so the
-  // stack depth we see here is wrong.
-  state->invalidate_cur_stack_depth();
-#else
   state->decr_cur_stack_depth();
-#endif
 }
 
 

--- a/hotspot/src/share/vm/prims/jvmtiThreadState.cpp
+++ b/hotspot/src/share/vm/prims/jvmtiThreadState.cpp
@@ -63,6 +63,7 @@ JvmtiThreadState::JvmtiThreadState(JavaThread* thread)
   _vm_object_alloc_event_collector = NULL;
   _the_class_for_redefinition_verification = NULL;
   _scratch_class_for_redefinition_verification = NULL;
+  _cur_stack_depth = UNKNOWN_STACK_DEPTH;
 
   // JVMTI ForceEarlyReturn support
   _pending_step_for_earlyret = false;


### PR DESCRIPTION
This fix removes a workaround from the early days of aarch64 port development.  Not sure what the original reason was (@theRealAph could you please check?), now it literally blocks debugging on linux_aarch64. 

On the test (attached to jira) single step takes about 30s, while the debugerless run completes in 3s. jdk11+ is free of this bug.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307531](https://bugs.openjdk.org/browse/JDK-8307531): [aarch64] JDK8 single-step debugging is extremely slow


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/313/head:pull/313` \
`$ git checkout pull/313`

Update a local copy of the PR: \
`$ git checkout pull/313` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/313/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 313`

View PR using the GUI difftool: \
`$ git pr show -t 313`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/313.diff">https://git.openjdk.org/jdk8u-dev/pull/313.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/313#issuecomment-1536420872)