### PR TITLE
8307837: [8u] Check step in GHA should also print errors

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -277,7 +277,7 @@ jobs:
         run: >
           if cat test-results/testoutput/*/exitcode.txt | grep -q -v '^0$'
           || ! cat test-results/testoutput/*/Stats.txt | grep -q 'fail=0' ; then
-            cat test-results/testoutput/*/JTreport/text/newfailures.txt ;
+            cat test-results/testoutput/*/JTreport/text/{newfailures,other_errors}.txt ;
             exit 1 ;
           fi
 
@@ -638,7 +638,7 @@ jobs:
         run: >
           if cat test-results/testoutput/*/exitcode.txt | grep -q -v '^0$'
           || ! cat test-results/testoutput/*/Stats.txt | grep -q 'fail=0' ; then
-            cat test-results/testoutput/*/JTreport/text/newfailures.txt ;
+            cat test-results/testoutput/*/JTreport/text/{newfailures,other_errors}.txt ;
             exit 1 ;
           fi
 
@@ -1143,6 +1143,7 @@ jobs:
         run: >
           if ((Get-ChildItem -Path test-results\testoutput\*\exitcode.txt -Recurse | Select-String -Pattern '^0$' -NotMatch ).Count -gt 0) {
             Get-Content -Path test-results\testoutput\*\JTreport\text\newfailures.txt ;
+            Get-Content -Path test-results\testoutput\*\JTreport\text\other_errors.txt ;
             exit 1
           }
 
@@ -1299,6 +1300,7 @@ jobs:
         run: >
           if ((Get-ChildItem -Path test-results\testoutput\*\exitcode.txt -Recurse | Select-String -Pattern '^0$' -NotMatch ).Count -gt 0) {
             Get-Content -Path test-results\testoutput\*\JTreport\text\newfailures.txt ;
+            Get-Content -Path test-results\testoutput\*\JTreport\text\other_errors.txt ;
             exit 1
           }
 
@@ -1529,7 +1531,7 @@ jobs:
         run: >
           if cat test-results/testoutput/*/exitcode.txt | grep -q -v '^0$'
           || ! cat test-results/testoutput/*/Stats.txt | grep -q 'fail=0' ; then
-            cat test-results/testoutput/*/JTreport/text/newfailures.txt ;
+            cat test-results/testoutput/*/JTreport/text/{newfailures,other_errors}.txt ;
             exit 1 ;
           fi
 


### PR DESCRIPTION
Check step currently only prints list of failed tests. It should also print tests, which finished with error (e.g. test ending on timeout). See e.g.: https://github.com/naotoj/jdk8u-dev/actions/runs/4931190096/jobs/8813500528

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8307837](https://bugs.openjdk.org/browse/JDK-8307837) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307837](https://bugs.openjdk.org/browse/JDK-8307837): [8u] Check step in GHA should also print errors (**Enhancement** - P4 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/317/head:pull/317` \
`$ git checkout pull/317`

Update a local copy of the PR: \
`$ git checkout pull/317` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/317/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 317`

View PR using the GUI difftool: \
`$ git pr show -t 317`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/317.diff">https://git.openjdk.org/jdk8u-dev/pull/317.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/317#issuecomment-1542413113)