### PR TITLE
8287073: NPE from CgroupV2Subsystem.getInstance()

### DIFF
--- a/jdk/src/linux/classes/jdk/internal/platform/CgroupSubsystemFactory.java
+++ b/jdk/src/linux/classes/jdk/internal/platform/CgroupSubsystemFactory.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -104,9 +105,9 @@ public class CgroupSubsystemFactory {
         Map<String, CgroupInfo> infos = result.getInfos();
         if (result.isCgroupV2()) {
             // For unified it doesn't matter which controller we pick.
-            CgroupInfo anyController = infos.get(MEMORY_CTRL);
-            CgroupSubsystem subsystem = CgroupV2Subsystem.getInstance(anyController);
-            return subsystem != null ? new CgroupMetrics(subsystem) : null;
+            CgroupInfo anyController = infos.values().iterator().next();
+            CgroupSubsystem subsystem = CgroupV2Subsystem.getInstance(Objects.requireNonNull(anyController));
+            return new CgroupMetrics(subsystem);
         } else {
             CgroupV1Subsystem subsystem = CgroupV1Subsystem.getInstance(infos);
             return subsystem != null ? new CgroupV1MetricsImpl(subsystem) : null;


### PR DESCRIPTION
Simple low-risk backport avoiding a potential NPE on some cgroups v2 systems. Patch applies clean after path unshuffeling.

Testing:
 - [x] Container tests on Linux x86_64. Pass.
 - [x] Regression test from #323

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287073](https://bugs.openjdk.org/browse/JDK-8287073): NPE from CgroupV2Subsystem.getInstance() (**Bug** - P4)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/324/head:pull/324` \
`$ git checkout pull/324`

Update a local copy of the PR: \
`$ git checkout pull/324` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/324/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 324`

View PR using the GUI difftool: \
`$ git pr show -t 324`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/324.diff">https://git.openjdk.org/jdk8u-dev/pull/324.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/324#issuecomment-1564514414)