### PR TITLE
8274471: Add support for RSASSA-PSS in OCSP Response

### DIFF
--- a/jdk/src/share/classes/sun/security/provider/certpath/OCSP.java
+++ b/jdk/src/share/classes/sun/security/provider/certpath/OCSP.java
@@ -31,7 +31,6 @@ import java.net.URI;
 import java.net.URL;
 import java.net.HttpURLConnection;
 import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.security.cert.CertificateException;
 import java.security.cert.CertPathValidatorException;
 import java.security.cert.CertPathValidatorException.BasicReason;

--- a/jdk/src/share/classes/sun/security/provider/certpath/OCSP.java
+++ b/jdk/src/share/classes/sun/security/provider/certpath/OCSP.java
@@ -31,6 +31,7 @@ import java.net.URI;
 import java.net.URL;
 import java.net.HttpURLConnection;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.security.cert.CertificateException;
 import java.security.cert.CertPathValidatorException;
 import java.security.cert.CertPathValidatorException.BasicReason;
@@ -225,20 +226,24 @@ public final class OCSP {
             List<Extension> extensions) throws IOException {
         OCSPRequest request = new OCSPRequest(certIds, extensions);
         byte[] bytes = request.encodeBytes();
+        String responder = responderURI.toString();
 
         if (debug != null) {
-            debug.println("connecting to OCSP service at: " + responderURI);
+            debug.println("connecting to OCSP service at: " + responder);
         }
 
         HttpURLConnection con = null;
 
         try {
-            String encodedGetReq = responderURI.toString() + "/" +
-                    URLEncoder.encode(Base64.getEncoder().encodeToString(bytes),
-                            "UTF-8");
+            StringBuilder encodedGetReq = new StringBuilder(responder);
+            if (!responder.endsWith("/")) {
+                encodedGetReq.append("/");
+            }
+            encodedGetReq.append(URLEncoder.encode(
+                    Base64.getEncoder().encodeToString(bytes), "UTF-8"));
 
             if (encodedGetReq.length() <= 255) {
-                URL url = new URL(encodedGetReq);
+                URL url = new URL(encodedGetReq.toString());
                 con = (HttpURLConnection)url.openConnection();
                 con.setDoOutput(true);
                 con.setDoInput(true);

--- a/jdk/src/share/classes/sun/security/provider/certpath/OCSPResponse.java
+++ b/jdk/src/share/classes/sun/security/provider/certpath/OCSPResponse.java
@@ -639,7 +639,10 @@ public final class OCSPResponse {
 
         try {
             Signature respSignature = Signature.getInstance(sigAlgId.getName());
-            respSignature.initVerify(cert.getPublicKey());
+            SignatureUtil.initVerifyWithParam(respSignature,
+                    cert.getPublicKey(),
+                    SignatureUtil.getParamSpec(sigAlgId.getName(),
+                            sigAlgId.getEncodedParams()));
             respSignature.update(tbsResponseData);
 
             if (respSignature.verify(signature)) {
@@ -655,8 +658,8 @@ public final class OCSPResponse {
                 }
                 return false;
             }
-        } catch (InvalidKeyException | NoSuchAlgorithmException |
-                 SignatureException e)
+        } catch (InvalidAlgorithmParameterException | InvalidKeyException
+                | NoSuchAlgorithmException | SignatureException e)
         {
             throw new CertPathValidatorException(e);
         }

--- a/jdk/src/share/classes/sun/security/util/SignatureUtil.java
+++ b/jdk/src/share/classes/sun/security/util/SignatureUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import java.security.*;
 import java.security.spec.*;
 import java.util.Locale;
 import sun.security.rsa.RSAUtil;
+import sun.security.x509.AlgorithmId;
 import sun.misc.SharedSecrets;
 
 /**
@@ -145,8 +146,7 @@ public class SignatureUtil {
     // for verification with the specified key and params (may be null)
     public static void initVerifyWithParam(Signature s, PublicKey key,
             AlgorithmParameterSpec params)
-            throws ProviderException, InvalidAlgorithmParameterException,
-            InvalidKeyException {
+            throws InvalidAlgorithmParameterException, InvalidKeyException {
         SharedSecrets.getJavaSecuritySignatureAccess().initVerify(s, key, params);
     }
 
@@ -155,8 +155,7 @@ public class SignatureUtil {
     public static void initVerifyWithParam(Signature s,
             java.security.cert.Certificate cert,
             AlgorithmParameterSpec params)
-            throws ProviderException, InvalidAlgorithmParameterException,
-            InvalidKeyException {
+            throws InvalidAlgorithmParameterException, InvalidKeyException {
         SharedSecrets.getJavaSecuritySignatureAccess().initVerify(s, cert, params);
     }
 
@@ -164,8 +163,83 @@ public class SignatureUtil {
     // for signing with the specified key and params (may be null)
     public static void initSignWithParam(Signature s, PrivateKey key,
             AlgorithmParameterSpec params, SecureRandom sr)
-            throws ProviderException, InvalidAlgorithmParameterException,
-            InvalidKeyException {
+            throws InvalidAlgorithmParameterException, InvalidKeyException {
         SharedSecrets.getJavaSecuritySignatureAccess().initSign(s, key, params, sr);
+    }
+
+    /**
+     * Create a Signature that has been initialized with proper key and params.
+     *
+     * @param sigAlg signature algorithms
+     * @param key private key
+     * @param provider (optional) provider
+     */
+    public static Signature fromKey(String sigAlg, PrivateKey key, String provider)
+        throws NoSuchAlgorithmException, NoSuchProviderException,
+        InvalidKeyException{
+        Signature sigEngine = (provider == null || provider.isEmpty())
+            ? Signature.getInstance(sigAlg)
+            : Signature.getInstance(sigAlg, provider);
+        return autoInitInternal(sigAlg, key, sigEngine);
+    }
+
+    /**
+     * Create a Signature that has been initialized with proper key and params.
+     *
+     * @param sigAlg signature algorithms
+     * @param key private key
+     * @param provider (optional) provider
+     */
+    public static Signature fromKey(String sigAlg, PrivateKey key, Provider provider)
+            throws NoSuchAlgorithmException, InvalidKeyException{
+        Signature sigEngine = (provider == null)
+                ? Signature.getInstance(sigAlg)
+                : Signature.getInstance(sigAlg, provider);
+        return autoInitInternal(sigAlg, key, sigEngine);
+    }
+
+    private static Signature autoInitInternal(String alg, PrivateKey key, Signature s)
+        throws InvalidKeyException {
+        AlgorithmParameterSpec params = AlgorithmId
+                .getDefaultAlgorithmParameterSpec(alg, key);
+        try {
+            SignatureUtil.initSignWithParam(s, key, params, null);
+        } catch (InvalidAlgorithmParameterException e) {
+            throw new AssertionError("Should not happen", e);
+        }
+        return s;
+    }
+
+    /**
+     * Derives AlgorithmId from a signature object and a key.
+     * @param sigEngine the signature object
+     * @param key the private key
+     * @return the AlgorithmId, not null
+     * @throws SignatureException if cannot find one
+     */
+    public static AlgorithmId fromSignature(Signature sigEngine, PrivateKey key)
+        throws SignatureException {
+        try {
+            AlgorithmParameters params = null;
+            try {
+                params = sigEngine.getParameters();
+            } catch (UnsupportedOperationException e) {
+                // some provider does not support it
+            }
+            if (params != null) {
+                return AlgorithmId.get(sigEngine.getParameters());
+            } else {
+                String sigAlg = sigEngine.getAlgorithm();
+                if (sigAlg.equalsIgnoreCase("EdDSA")) {
+                    // Hopefully key knows if it's Ed25519 or Ed448
+                    sigAlg = key.getAlgorithm();
+                }
+                return AlgorithmId.get(sigAlg);
+            }
+        } catch (NoSuchAlgorithmException e) {
+            // This could happen if both sig alg and key alg is EdDSA,
+            // we don't know which provider does this.
+            throw new SignatureException("Cannot derive AlgorithmIdentifier", e);
+        }
     }
 }

--- a/jdk/src/share/classes/sun/security/x509/X509CRLImpl.java
+++ b/jdk/src/share/classes/sun/security/x509/X509CRLImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -809,13 +809,7 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
      *         null if no parameters are present.
      */
     public byte[] getSigAlgParams() {
-        if (sigAlgId == null)
-            return null;
-        try {
-            return sigAlgId.getEncodedParams();
-        } catch (IOException e) {
-            return null;
-        }
+        return sigAlgId == null ? null : sigAlgId.getEncodedParams();
     }
 
     /**

--- a/jdk/src/share/classes/sun/security/x509/X509CertImpl.java
+++ b/jdk/src/share/classes/sun/security/x509/X509CertImpl.java
@@ -1095,13 +1095,7 @@ public class X509CertImpl extends X509Certificate implements DerEncoder {
      *         null if no parameters are present.
      */
     public byte[] getSigAlgParams() {
-        if (algId == null)
-            return null;
-        try {
-            return algId.getEncodedParams();
-        } catch (IOException e) {
-            return null;
-        }
+        return algId == null ? null : algId.getEncodedParams();
     }
 
     /**

--- a/jdk/test/java/security/testlibrary/CertificateBuilder.java
+++ b/jdk/test/java/security/testlibrary/CertificateBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@ import java.math.BigInteger;
 import sun.security.util.DerOutputStream;
 import sun.security.util.DerValue;
 import sun.security.util.ObjectIdentifier;
+import sun.security.util.SignatureUtil;
 import sun.security.x509.AccessDescription;
 import sun.security.x509.AlgorithmId;
 import sun.security.x509.AuthorityInfoAccessExtension;
@@ -364,8 +365,7 @@ public class CertificateBuilder {
             throws IOException, CertificateException, NoSuchAlgorithmException {
         // TODO: add some basic checks (key usage, basic constraints maybe)
 
-        AlgorithmId signAlg = AlgorithmId.get(algName);
-        byte[] encodedCert = encodeTopLevel(issuerCert, issuerKey, signAlg);
+        byte[] encodedCert = encodeTopLevel(issuerCert, issuerKey, algName);
         ByteArrayInputStream bais = new ByteArrayInputStream(encodedCert);
         return (X509Certificate)factory.generateCertificate(bais);
     }
@@ -392,18 +392,24 @@ public class CertificateBuilder {
      * @throws IOException if an encoding error occurs.
      */
     private byte[] encodeTopLevel(X509Certificate issuerCert,
-            PrivateKey issuerKey, AlgorithmId signAlg)
-            throws CertificateException, IOException {
+            PrivateKey issuerKey, String algName)
+            throws CertificateException, IOException, NoSuchAlgorithmException {
+
+        AlgorithmId signAlg = AlgorithmId.get(algName);
         DerOutputStream outerSeq = new DerOutputStream();
         DerOutputStream topLevelItems = new DerOutputStream();
 
-        tbsCertBytes = encodeTbsCert(issuerCert, signAlg);
-        topLevelItems.write(tbsCertBytes);
         try {
-            signatureBytes = signCert(issuerKey, signAlg);
+            Signature sig = SignatureUtil.fromKey(signAlg.getName(), issuerKey, (Provider)null);
+            // Rewrite signAlg, RSASSA-PSS needs some parameters.
+            signAlg = SignatureUtil.fromSignature(sig, issuerKey);
+            tbsCertBytes = encodeTbsCert(issuerCert, signAlg);
+            sig.update(tbsCertBytes);
+            signatureBytes = sig.sign();
         } catch (GeneralSecurityException ge) {
             throw new CertificateException(ge);
         }
+        topLevelItems.write(tbsCertBytes);
         signAlg.derEncode(topLevelItems);
         topLevelItems.putBitString(signatureBytes);
         outerSeq.write(DerValue.tag_Sequence, topLevelItems);
@@ -516,24 +522,5 @@ public class CertificateBuilder {
         extSequence.write(DerValue.tag_Sequence, extItems);
         tbsStream.write(DerValue.createTag(DerValue.TAG_CONTEXT, true,
                 (byte)3), extSequence);
-    }
-
-    /**
-     * Digitally sign the X.509 certificate.
-     *
-     * @param issuerKey The private key of the issuing authority
-     * @param signAlg The signature algorithm object
-     *
-     * @return The digital signature bytes.
-     *
-     * @throws GeneralSecurityException If any errors occur during the
-     * digital signature process.
-     */
-    private byte[] signCert(PrivateKey issuerKey, AlgorithmId signAlg)
-            throws GeneralSecurityException {
-        Signature sig = Signature.getInstance(signAlg.getName());
-        sig.initSign(issuerKey);
-        sig.update(tbsCertBytes);
-        return sig.sign();
     }
  }

--- a/jdk/test/java/security/testlibrary/SimpleOCSPServer.java
+++ b/jdk/test/java/security/testlibrary/SimpleOCSPServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,6 +50,7 @@ import sun.security.util.DerInputStream;
 import sun.security.util.DerOutputStream;
 import sun.security.util.DerValue;
 import sun.security.util.ObjectIdentifier;
+import sun.security.util.SignatureUtil;
 
 
 /**
@@ -179,7 +180,7 @@ public class SimpleOCSPServer {
             }
         }
 
-        sigAlgId = AlgorithmId.get("Sha256withRSA");
+        sigAlgId = AlgorithmId.get(AlgorithmId.getDefaultSigAlgForKey(signerKey));
         respId = new ResponderId(signerCert.getSubjectX500Principal());
         listenAddress = addr;
         listenPort = port;
@@ -1352,13 +1353,14 @@ public class SimpleOCSPServer {
             basicORItemStream.write(tbsResponseBytes);
 
             try {
-                sigAlgId.derEncode(basicORItemStream);
-
                 // Create the signature
-                Signature sig = Signature.getInstance(sigAlgId.getName());
-                sig.initSign(signerKey);
+                Signature sig = SignatureUtil.fromKey(
+                sigAlgId.getName(), signerKey, (Provider)null);
                 sig.update(tbsResponseBytes);
                 signature = sig.sign();
+                // Rewrite signAlg, RSASSA-PSS needs some parameters.
+                sigAlgId = SignatureUtil.fromSignature(sig, signerKey);
+                sigAlgId.derEncode(basicORItemStream);
                 basicORItemStream.putBitString(signature);
             } catch (GeneralSecurityException exc) {
                 err(exc);

--- a/jdk/test/javax/net/ssl/Stapling/HttpsUrlConnClient.java
+++ b/jdk/test/javax/net/ssl/Stapling/HttpsUrlConnClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,8 @@
  * @summary OCSP Stapling for TLS
  * @library ../../../../java/security/testlibrary
  * @build CertificateBuilder SimpleOCSPServer
- * @run main/othervm HttpsUrlConnClient
+ * @run main/othervm HttpsUrlConnClient RSA SHA256withRSA
+ * @run main/othervm HttpsUrlConnClient RSASSA-PSS RSASSA-PSS
  */
 
 import java.io.*;
@@ -60,7 +61,6 @@ import java.util.concurrent.TimeUnit;
 
 import sun.security.testlibrary.SimpleOCSPServer;
 import sun.security.testlibrary.CertificateBuilder;
-import sun.security.validator.ValidatorException;
 
 public class HttpsUrlConnClient {
 
@@ -72,6 +72,9 @@ public class HttpsUrlConnClient {
 
     static final byte[] LINESEP = { 10 };
     static final Base64.Encoder B64E = Base64.getMimeEncoder(64, LINESEP);
+
+    static String SIGALG;
+    static String KEYALG;
 
     // Turn on TLS debugging
     static boolean debug = true;
@@ -136,6 +139,9 @@ public class HttpsUrlConnClient {
         System.setProperty("javax.net.ssl.keyStorePassword", "");
         System.setProperty("javax.net.ssl.trustStore", "");
         System.setProperty("javax.net.ssl.trustStorePassword", "");
+
+        KEYALG = args[0];
+        SIGALG = args[1];
 
         // Create the PKI we will use for the test and start the OCSP servers
         createPKI();
@@ -514,7 +520,7 @@ public class HttpsUrlConnClient {
      */
     private static void createPKI() throws Exception {
         CertificateBuilder cbld = new CertificateBuilder();
-        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance(KEYALG);
         keyGen.initialize(2048);
         KeyStore.Builder keyStoreBuilder =
                 KeyStore.Builder.newInstance("PKCS12", null,
@@ -540,7 +546,7 @@ public class HttpsUrlConnClient {
         addCommonCAExts(cbld);
         // Make our Root CA Cert!
         X509Certificate rootCert = cbld.build(null, rootCaKP.getPrivate(),
-                "SHA256withRSA");
+                SIGALG);
         log("Root CA Created:\n" + certInfo(rootCert));
 
         // Now build a keystore and add the keys and cert
@@ -582,7 +588,7 @@ public class HttpsUrlConnClient {
         cbld.addAIAExt(Collections.singletonList(rootRespURI));
         // Make our Intermediate CA Cert!
         X509Certificate intCaCert = cbld.build(rootCert, rootCaKP.getPrivate(),
-                "SHA256withRSA");
+                SIGALG);
         log("Intermediate CA Created:\n" + certInfo(intCaCert));
 
         // Provide intermediate CA cert revocation info to the Root CA
@@ -644,7 +650,7 @@ public class HttpsUrlConnClient {
         cbld.addAIAExt(Collections.singletonList(intCaRespURI));
         // Make our SSL Server Cert!
         X509Certificate sslCert = cbld.build(intCaCert, intCaKP.getPrivate(),
-                "SHA256withRSA");
+                SIGALG);
         log("SSL Certificate Created:\n" + certInfo(sslCert));
 
         // Provide SSL server cert revocation info to the Intermeidate CA


### PR DESCRIPTION
Hi!

I'd like to backport **[JDK-8274471: Add support for RSASSA-PSS in OCSP Response](https://bugs.openjdk.org/browse/JDK-8274471)** for parity with Oracle JDK.

The patch from `11u` applied with the following changes (except the path shuffling):

**`jdk/src/share/classes/sun/security/provider/certpath/OCSP.java`**
- `URLEncoder.encode()` accepts desired charset as a string, charset constants are not supported in `8`, so import of `java.nio.charset.StandardCharsets` also skipped
- resolved little baseline conflict

**`jdk/src/share/classes/sun/security/x509/AlgorithmId.java`**
- required `public static String getDefaultSigAlgForKey(PrivateKey k)` and `private static String ecStrength (int bitLength)` copied from `11`

Verification (amd64/20.04): `jdk/test/javax/net/ssl/Stapling/HttpsUrlConnClient.java` with new `RSASSA-PSS` case
Regression (amd64/20.04): `jdk_security`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8274471](https://bugs.openjdk.org/browse/JDK-8274471) needs maintainer approval

### Integration blocker
&nbsp;⚠️ Dependency #330 must be integrated first

### Issue
 * [JDK-8274471](https://bugs.openjdk.org/browse/JDK-8274471): Add support for RSASSA-PSS in OCSP Response (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/331/head:pull/331` \
`$ git checkout pull/331`

Update a local copy of the PR: \
`$ git checkout pull/331` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/331/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 331`

View PR using the GUI difftool: \
`$ git pr show -t 331`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/331.diff">https://git.openjdk.org/jdk8u-dev/pull/331.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/331#issuecomment-1578301564)