### PR TITLE
8200468: Port the native GSS-API bridge to Windows

### DIFF
--- a/jdk/make/lib/SecurityLibraries.gmk
+++ b/jdk/make/lib/SecurityLibraries.gmk
@@ -94,27 +94,23 @@ BUILD_LIBRARIES += $(BUILD_LIBJ2PCSC)
 
 ##########################################################################################
 
-ifneq ($(OPENJDK_TARGET_OS), windows)
-  $(eval $(call SetupNativeCompilation,BUILD_LIBJ2GSS, \
-      LIBRARY := j2gss, \
-      OUTPUT_DIR := $(INSTALL_LIBRARIES_HERE), \
-      SRC := $(JDK_TOPDIR)/src/share/native/sun/security/jgss/wrapper \
-          $(JDK_TOPDIR)/src/$(OPENJDK_TARGET_OS_API_DIR)/native/sun/security/jgss/wrapper, \
-      LANG := C, \
-      OPTIMIZATION := LOW, \
-      CFLAGS := $(CFLAGS_JDKLIB) \
-          -I$(JDK_TOPDIR)/src/share/native/sun/security/jgss/wrapper \
-          -I$(JDK_TOPDIR)/src/$(OPENJDK_TARGET_OS_API_DIR)/native/sun/security/jgss/wrapper, \
-      MAPFILE := $(JDK_TOPDIR)/make/mapfiles/libj2gss/mapfile-vers, \
-      LDFLAGS := $(LDFLAGS_JDKLIB) \
-          $(call SET_SHARED_LIBRARY_ORIGIN), \
-      LDFLAGS_SUFFIX := $(LIBDL), \
-      LDFLAGS_SUFFIX_solaris := -lc, \
-      OBJECT_DIR := $(JDK_OUTPUTDIR)/objs/libj2gss, \
-      DEBUG_SYMBOLS := $(DEBUG_ALL_BINARIES)))
+$(eval $(call SetupNativeCompilation,BUILD_LIBJ2GSS, \
+    LIBRARY := j2gss, \
+    OUTPUT_DIR := $(INSTALL_LIBRARIES_HERE), \
+    SRC := $(JDK_TOPDIR)/src/share/native/sun/security/jgss/wrapper, \
+    LANG := C, \
+    OPTIMIZATION := LOW, \
+    CFLAGS := $(CFLAGS_JDKLIB) \
+        -I$(JDK_TOPDIR)/src/share/native/sun/security/jgss/wrapper, \
+    MAPFILE := $(JDK_TOPDIR)/make/mapfiles/libj2gss/mapfile-vers, \
+    LDFLAGS := $(LDFLAGS_JDKLIB) \
+        $(call SET_SHARED_LIBRARY_ORIGIN), \
+    LDFLAGS_SUFFIX := $(LIBDL), \
+    LDFLAGS_SUFFIX_solaris := -lc, \
+    OBJECT_DIR := $(JDK_OUTPUTDIR)/objs/libj2gss, \
+    DEBUG_SYMBOLS := $(DEBUG_ALL_BINARIES)))
 
-  BUILD_LIBRARIES += $(BUILD_LIBJ2GSS)
-endif
+BUILD_LIBRARIES += $(BUILD_LIBJ2GSS)
 
 ##########################################################################################
 

--- a/jdk/src/share/classes/sun/security/jgss/GSSManagerImpl.java
+++ b/jdk/src/share/classes/sun/security/jgss/GSSManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,14 +46,8 @@ public class GSSManagerImpl extends GSSManager {
         USE_NATIVE =
             AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
                     public Boolean run() {
-                            String osname = System.getProperty("os.name");
-                            if (osname.startsWith("SunOS") ||
-                                osname.contains("OS X") ||
-                                osname.startsWith("Linux")) {
-                                return new Boolean(System.getProperty
-                                    (USE_NATIVE_PROP));
-                            }
-                            return Boolean.FALSE;
+                        return Boolean.valueOf(System.getProperty
+                                (USE_NATIVE_PROP));
                     }
             });
 

--- a/jdk/src/share/native/sun/security/jgss/wrapper/GSSLibStub.c
+++ b/jdk/src/share/native/sun/security/jgss/wrapper/GSSLibStub.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,6 +45,7 @@ Java_sun_security_jgss_wrapper_GSSLibStub_init(JNIEnv *env,
                                                jstring jlibName,
                                                jboolean jDebug) {
     const char *libName;
+    int failed;
     char *error = NULL;
 
     if (!jDebug) {
@@ -65,13 +66,38 @@ Java_sun_security_jgss_wrapper_GSSLibStub_init(JNIEnv *env,
     TRACE1("[GSSLibStub_init] libName=%s", libName);
 
     /* initialize global function table */
-    error = loadNative(libName);
+    failed = loadNative(libName);
     (*env)->ReleaseStringUTFChars(env, jlibName, libName);
 
-    if (error == NULL) {
+    if (!failed) {
         return JNI_TRUE;
     } else {
-        TRACE0(error);
+        if (JGSS_DEBUG) {
+#ifdef WIN32
+            #define MAX_MSG_SIZE 256
+            static CHAR szMsgBuf[MAX_MSG_SIZE];
+            DWORD dwRes;
+            DWORD dwError = GetLastError();
+            dwRes = FormatMessage (
+                    FORMAT_MESSAGE_FROM_SYSTEM,
+                    NULL,
+                    dwError,
+                    0,
+                    szMsgBuf,
+                    MAX_MSG_SIZE,
+                    NULL);
+            if (0 == dwRes) {
+                printf("GSS-API: Unknown failure %d\n", dwError);
+            } else {
+                printf("GSS-API: %s\n",szMsgBuf);
+            }
+#else
+            char* error = dlerror();
+            if (error) {
+                TRACE0(error);
+            }
+#endif
+        }
         return JNI_FALSE;
     }
 }
@@ -88,7 +114,6 @@ Java_sun_security_jgss_wrapper_GSSLibStub_getMechPtr(JNIEnv *env,
   gss_OID cOid;
   unsigned int i, len;
   jbyte* bytes;
-  jthrowable gssEx;
   int found;
 
   if (jbytes != NULL) {
@@ -125,8 +150,6 @@ Java_sun_security_jgss_wrapper_GSSLibStub_getMechPtr(JNIEnv *env,
  * structure.
  */
 void deleteGSSCB(gss_channel_bindings_t cb) {
-  jobject jinetAddr;
-  jbyteArray value;
 
   if (cb == GSS_C_NO_CHANNEL_BINDINGS) return;
 
@@ -154,7 +177,6 @@ gss_channel_bindings_t newGSSCB(JNIEnv *env, jobject jcb) {
   gss_channel_bindings_t cb;
   jobject jinetAddr;
   jbyteArray value;
-  int i;
 
   if (jcb == NULL) {
     return GSS_C_NO_CHANNEL_BINDINGS;
@@ -355,7 +377,7 @@ Java_sun_security_jgss_wrapper_GSSLibStub_importName(JNIEnv *env,
      GSS_S_BAD_MECH */
   major = (*ftab->importName)(&minor, &nameVal, nameType, &nameHdl);
 
-  TRACE1("[GSSLibStub_importName] %ld", (long) nameHdl);
+  TRACE1("[GSSLibStub_importName] %" PRIuPTR  "", (uintptr_t) nameHdl);
 
   /* release intermediate buffers */
   deleteGSSOID(nameType);
@@ -426,7 +448,7 @@ Java_sun_security_jgss_wrapper_GSSLibStub_canonicalizeName(JNIEnv *env,
        GSS_S_BAD_NAME, GSS_S_BAD_MECH */
     major = (*ftab->canonicalizeName)(&minor, nameHdl, mech, &mnNameHdl);
 
-    TRACE1("[GSSLibStub_canonicalizeName] MN=%ld", (long)mnNameHdl);
+    TRACE1("[GSSLibStub_canonicalizeName] MN=%" PRIuPTR "", (uintptr_t)mnNameHdl);
 
     checkStatus(env, jobj, major, minor, "[GSSLibStub_canonicalizeName]");
     if ((*env)->ExceptionCheck(env)) {
@@ -596,7 +618,7 @@ Java_sun_security_jgss_wrapper_GSSLibStub_acquireCred(JNIEnv *env,
   /* release intermediate buffers */
   deleteGSSOIDSet(mechs);
 
-  TRACE1("[GSSLibStub_acquireCred] pCred=%ld", (long) credHdl);
+  TRACE1("[GSSLibStub_acquireCred] pCred=%" PRIuPTR "", (uintptr_t) credHdl);
 
   checkStatus(env, jobj, major, minor, "[GSSLibStub_acquireCred]");
   if ((*env)->ExceptionCheck(env)) {
@@ -645,7 +667,7 @@ void inquireCred(JNIEnv *env, jobject jobj, gss_cred_id_t pCred,
 
   credHdl = pCred;
 
-  TRACE1("[gss_inquire_cred] %ld", (long) pCred);
+  TRACE1("[gss_inquire_cred] %" PRIuPTR "", (uintptr_t) pCred);
 
   /* gss_inquire_cred(...) => GSS_S_DEFECTIVE_CREDENTIAL(!),
      GSS_S_CREDENTIALS_EXPIRED(!), GSS_S_NO_CRED(!) */
@@ -694,7 +716,7 @@ Java_sun_security_jgss_wrapper_GSSLibStub_getCredName(JNIEnv *env,
     return jlong_zero;
   }
 
-  TRACE1("[GSSLibStub_getCredName] pName=%ld", (long) nameHdl);
+  TRACE1("[GSSLibStub_getCredName] pName=%" PRIuPTR "", (uintptr_t) nameHdl);
   return ptr_to_jlong(nameHdl);
 }
 
@@ -775,7 +797,7 @@ Java_sun_security_jgss_wrapper_GSSLibStub_importContext(JNIEnv *env,
      GSS_S_UNAVAILABLE, GSS_S_UNAUTHORIZED */
   major = (*ftab->importSecContext)(&minor, &ctxtToken, &contextHdl);
 
-  TRACE1("[GSSLibStub_importContext] pContext=%ld", (long) contextHdl);
+  TRACE1("[GSSLibStub_importContext] pContext=%" PRIuPTR "", (uintptr_t) contextHdl);
 
   /* release intermediate buffers */
   resetGSSBuffer(&ctxtToken);
@@ -866,8 +888,8 @@ Java_sun_security_jgss_wrapper_GSSLibStub_initContext(JNIEnv *env,
     return NULL;
   }
 
-  TRACE2( "[GSSLibStub_initContext] before: pCred=%ld, pContext=%ld",
-          (long)credHdl, (long)contextHdl);
+  TRACE2( "[GSSLibStub_initContext] before: pCred=%" PRIuPTR ", pContext=%" PRIuPTR "",
+          (uintptr_t)credHdl, (uintptr_t)contextHdl);
 
   /* gss_init_sec_context(...) => GSS_S_CONTINUE_NEEDED(!),
      GSS_S_DEFECTIVE_TOKEN, GSS_S_NO_CRED, GSS_S_DEFECTIVE_CREDENTIAL(!),
@@ -879,8 +901,8 @@ Java_sun_security_jgss_wrapper_GSSLibStub_initContext(JNIEnv *env,
                                  flags, time, cb, &inToken, NULL /*aMech*/,
                                  &outToken, &aFlags, &aTime);
 
-  TRACE2("[GSSLibStub_initContext] after: pContext=%ld, outToken len=%ld",
-            (long)contextHdl, (long)outToken.length);
+  TRACE2("[GSSLibStub_initContext] after: pContext=%" PRIuPTR ", outToken len=%ld",
+            (uintptr_t)contextHdl, (long)outToken.length);
 
   // update context handle with the latest value if changed
   // this is to work with both MIT and Solaris. Former deletes half-built
@@ -888,7 +910,7 @@ Java_sun_security_jgss_wrapper_GSSLibStub_initContext(JNIEnv *env,
   if (contextHdl != contextHdlSave) {
     (*env)->SetLongField(env, jcontextSpi, FID_NativeGSSContext_pContext,
                          ptr_to_jlong(contextHdl));
-    TRACE1("[GSSLibStub_initContext] set pContext=%ld", (long)contextHdl);
+    TRACE1("[GSSLibStub_initContext] set pContext=%" PRIuPTR "", (uintptr_t)contextHdl);
   }
 
   if (GSS_ERROR(major) == GSS_S_COMPLETE) {
@@ -959,7 +981,6 @@ Java_sun_security_jgss_wrapper_GSSLibStub_acceptContext(JNIEnv *env,
   jobject jsrcName=GSS_C_NO_NAME;
   jobject jdelCred;
   jobject jMech;
-  jbyteArray jresult;
   jboolean setTarget;
   gss_name_t targetName;
   jobject jtargetName;
@@ -983,8 +1004,8 @@ Java_sun_security_jgss_wrapper_GSSLibStub_acceptContext(JNIEnv *env,
   setTarget = (credHdl == GSS_C_NO_CREDENTIAL);
   aFlags = 0;
 
-  TRACE2( "[GSSLibStub_acceptContext] before: pCred=%ld, pContext=%ld",
-          (long) credHdl, (long) contextHdl);
+  TRACE2( "[GSSLibStub_acceptContext] before: pCred=%" PRIuPTR ", pContext=%" PRIuPTR "",
+          (uintptr_t) credHdl, (uintptr_t) contextHdl);
 
   /* gss_accept_sec_context(...) => GSS_S_CONTINUE_NEEDED(!),
      GSS_S_DEFECTIVE_TOKEN, GSS_S_DEFECTIVE_CREDENTIAL(!),
@@ -1000,8 +1021,8 @@ Java_sun_security_jgss_wrapper_GSSLibStub_acceptContext(JNIEnv *env,
   deleteGSSCB(cb);
   resetGSSBuffer(&inToken);
 
-  TRACE3("[GSSLibStub_acceptContext] after: pCred=%ld, pContext=%ld, pDelegCred=%ld",
-        (long)credHdl, (long)contextHdl, (long) delCred);
+  TRACE3("[GSSLibStub_acceptContext] after: pCred=%" PRIuPTR ", pContext=%" PRIuPTR ", pDelegCred=%" PRIuPTR "",
+        (uintptr_t)credHdl, (uintptr_t)contextHdl, (uintptr_t) delCred);
 
   // update context handle with the latest value if changed
   // this is to work with both MIT and Solaris. Former deletes half-built
@@ -1009,7 +1030,7 @@ Java_sun_security_jgss_wrapper_GSSLibStub_acceptContext(JNIEnv *env,
   if (contextHdl != contextHdlSave) {
     (*env)->SetLongField(env, jcontextSpi, FID_NativeGSSContext_pContext,
                          ptr_to_jlong(contextHdl));
-    TRACE1("[GSSLibStub_acceptContext] set pContext=%ld", (long)contextHdl);
+    TRACE1("[GSSLibStub_acceptContext] set pContext=%" PRIuPTR "", (uintptr_t)contextHdl);
   }
 
   if (GSS_ERROR(major) == GSS_S_COMPLETE) {
@@ -1038,8 +1059,8 @@ Java_sun_security_jgss_wrapper_GSSLibStub_acceptContext(JNIEnv *env,
         goto error;
       }
 
-      TRACE1("[GSSLibStub_acceptContext] set targetName=%ld",
-              (long)targetName);
+      TRACE1("[GSSLibStub_acceptContext] set targetName=%" PRIuPTR "",
+              (uintptr_t)targetName);
 
       (*env)->SetObjectField(env, jcontextSpi, FID_NativeGSSContext_targetName,
                              jtargetName);
@@ -1055,7 +1076,7 @@ Java_sun_security_jgss_wrapper_GSSLibStub_acceptContext(JNIEnv *env,
         goto error;
       }
 
-      TRACE1("[GSSLibStub_acceptContext] set srcName=%ld", (long)srcName);
+      TRACE1("[GSSLibStub_acceptContext] set srcName=%" PRIuPTR "", (uintptr_t)srcName);
 
       (*env)->SetObjectField(env, jcontextSpi, FID_NativeGSSContext_srcName,
                              jsrcName);
@@ -1090,8 +1111,8 @@ Java_sun_security_jgss_wrapper_GSSLibStub_acceptContext(JNIEnv *env,
         (*env)->SetObjectField(env, jcontextSpi,
                                FID_NativeGSSContext_delegatedCred,
                                jdelCred);
-        TRACE1("[GSSLibStub_acceptContext] set delegatedCred=%ld",
-                (long) delCred);
+        TRACE1("[GSSLibStub_acceptContext] set delegatedCred=%" PRIuPTR "",
+                (uintptr_t) delCred);
 
         if ((*env)->ExceptionCheck(env)) {
           goto error;
@@ -1144,7 +1165,7 @@ Java_sun_security_jgss_wrapper_GSSLibStub_inquireContext(JNIEnv *env,
 
   contextHdl = (gss_ctx_id_t) jlong_to_ptr(pContext);
 
-  TRACE1("[GSSLibStub_inquireContext] %ld", (long)contextHdl);
+  TRACE1("[GSSLibStub_inquireContext] %" PRIuPTR "", (uintptr_t)contextHdl);
 
   srcName = targetName = GSS_C_NO_NAME;
   time = 0;
@@ -1155,8 +1176,8 @@ Java_sun_security_jgss_wrapper_GSSLibStub_inquireContext(JNIEnv *env,
                               &targetName, &time, NULL, &flags,
                               &isInitiator, &isEstablished);
   /* update member values if needed */
-  TRACE2("[GSSLibStub_inquireContext] srcName %ld, targetName %ld",
-      (long)srcName, (long)targetName);
+  TRACE2("[GSSLibStub_inquireContext] srcName %" PRIuPTR ", targetName %" PRIuPTR "",
+      (uintptr_t)srcName, (uintptr_t)targetName);
 
   checkStatus(env, jobj, major, minor, "[GSSLibStub_inquireContext]");
   if ((*env)->ExceptionCheck(env)) {
@@ -1225,8 +1246,8 @@ Java_sun_security_jgss_wrapper_GSSLibStub_getContextName(JNIEnv *env,
 
   contextHdl = (gss_ctx_id_t) jlong_to_ptr(pContext);
 
-  TRACE2("[GSSLibStub_getContextName] %ld, isSrc=%d",
-          (long)contextHdl, isSrc);
+  TRACE2("[GSSLibStub_getContextName] %" PRIuPTR ", isSrc=%d",
+          (uintptr_t)contextHdl, isSrc);
 
   nameHdl = GSS_C_NO_NAME;
   if (isSrc == JNI_TRUE) {
@@ -1243,7 +1264,7 @@ Java_sun_security_jgss_wrapper_GSSLibStub_getContextName(JNIEnv *env,
     return jlong_zero;
   }
 
-  TRACE1("[GSSLibStub_getContextName] pName=%ld", (long) nameHdl);
+  TRACE1("[GSSLibStub_getContextName] pName=%" PRIuPTR "", (uintptr_t) nameHdl);
 
   return ptr_to_jlong(nameHdl);
 }
@@ -1263,7 +1284,7 @@ Java_sun_security_jgss_wrapper_GSSLibStub_getContextTime(JNIEnv *env,
 
   contextHdl = (gss_ctx_id_t) jlong_to_ptr(pContext);
 
-  TRACE1("[GSSLibStub_getContextTime] %ld", (long)contextHdl);
+  TRACE1("[GSSLibStub_getContextTime] %" PRIuPTR "", (uintptr_t)contextHdl);
 
   if (contextHdl == GSS_C_NO_CONTEXT) return 0;
 
@@ -1295,7 +1316,7 @@ Java_sun_security_jgss_wrapper_GSSLibStub_deleteContext(JNIEnv *env,
 
   contextHdl = (gss_ctx_id_t) jlong_to_ptr(pContext);
 
-  TRACE1("[GSSLibStub_deleteContext] %ld", (long)contextHdl);
+  TRACE1("[GSSLibStub_deleteContext] %" PRIuPTR "", (uintptr_t)contextHdl);
 
   if (contextHdl == GSS_C_NO_CONTEXT) return ptr_to_jlong(GSS_C_NO_CONTEXT);
 
@@ -1329,7 +1350,7 @@ Java_sun_security_jgss_wrapper_GSSLibStub_wrapSizeLimit(JNIEnv *env,
 
   contextHdl = (gss_ctx_id_t) jlong_to_ptr(pContext);
 
-  TRACE1("[GSSLibStub_wrapSizeLimit] %ld", (long)contextHdl);
+  TRACE1("[GSSLibStub_wrapSizeLimit] %" PRIuPTR "", (uintptr_t)contextHdl);
 
   if (contextHdl == GSS_C_NO_CONTEXT) {
     // Twik per javadoc
@@ -1369,7 +1390,7 @@ Java_sun_security_jgss_wrapper_GSSLibStub_exportContext(JNIEnv *env,
 
   contextHdl = (gss_ctx_id_t) jlong_to_ptr(pContext);
 
-  TRACE1("[GSSLibStub_exportContext] %ld", (long)contextHdl);
+  TRACE1("[GSSLibStub_exportContext] %" PRIuPTR "", (uintptr_t)contextHdl);
 
   if (contextHdl == GSS_C_NO_CONTEXT) {
     // Twik per javadoc
@@ -1413,7 +1434,7 @@ Java_sun_security_jgss_wrapper_GSSLibStub_getMic(JNIEnv *env, jobject jobj,
 
   contextHdl = (gss_ctx_id_t) jlong_to_ptr(pContext);
 
-  TRACE1("[GSSLibStub_getMic] %ld", (long)contextHdl);
+  TRACE1("[GSSLibStub_getMic] %" PRIuPTR "", (uintptr_t)contextHdl);
 
   if (contextHdl == GSS_C_NO_CONTEXT) {
     // Twik per javadoc
@@ -1467,7 +1488,7 @@ Java_sun_security_jgss_wrapper_GSSLibStub_verifyMic(JNIEnv *env,
 
   contextHdl = (gss_ctx_id_t) jlong_to_ptr(pContext);
 
-  TRACE1("[GSSLibStub_verifyMic] %ld", (long)contextHdl);
+  TRACE1("[GSSLibStub_verifyMic] %" PRIuPTR "", (uintptr_t)contextHdl);
 
   if (contextHdl == GSS_C_NO_CONTEXT) {
     // Twik per javadoc
@@ -1538,7 +1559,7 @@ Java_sun_security_jgss_wrapper_GSSLibStub_wrap(JNIEnv *env,
 
   contextHdl = (gss_ctx_id_t) jlong_to_ptr(pContext);
 
-  TRACE1("[GSSLibStub_wrap] %ld", (long)contextHdl);
+  TRACE1("[GSSLibStub_wrap] %" PRIuPTR "", (uintptr_t)contextHdl);
 
   if (contextHdl == GSS_C_NO_CONTEXT) {
     // Twik per javadoc
@@ -1610,7 +1631,7 @@ Java_sun_security_jgss_wrapper_GSSLibStub_unwrap(JNIEnv *env,
 
   contextHdl = (gss_ctx_id_t) jlong_to_ptr(pContext);
 
-  TRACE1("[GSSLibStub_unwrap] %ld", (long)contextHdl);
+  TRACE1("[GSSLibStub_unwrap] %" PRIuPTR "", (uintptr_t)contextHdl);
 
   if (contextHdl == GSS_C_NO_CONTEXT) {
     // Twik per javadoc

--- a/jdk/src/share/native/sun/security/jgss/wrapper/NativeFunc.c
+++ b/jdk/src/share/native/sun/security/jgss/wrapper/NativeFunc.c
@@ -25,7 +25,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <dlfcn.h>
 #include "NativeFunc.h"
 
 /* global GSS function table */
@@ -67,18 +66,16 @@ static const char RELEASE_BUFFER[]              = "gss_release_buffer";
 /**
  * Initialize native GSS function pointers
  */
-char* loadNative(const char *libName) {
+int loadNative(const char *libName) {
 
-    char *error;
     void *gssLib;
     int failed;
     OM_uint32 minor, major;
 
     ftab = NULL;
     failed = FALSE;
-    error = NULL;
 
-    gssLib = dlopen(libName, RTLD_NOW);
+    gssLib = GETLIB(libName);
     if (gssLib == NULL) {
         failed = TRUE;
         goto out;
@@ -91,183 +88,183 @@ char* loadNative(const char *libName) {
         goto out;
     }
 
-    ftab->releaseName = (RELEASE_NAME_FN_PTR)dlsym(gssLib, RELEASE_NAME);
+    ftab->releaseName = (RELEASE_NAME_FN_PTR)GETFUNC(gssLib, RELEASE_NAME);
     if (ftab->releaseName == NULL) {
         failed = TRUE;
         goto out;
     }
 
-    ftab->importName = (IMPORT_NAME_FN_PTR)dlsym(gssLib, IMPORT_NAME);
+    ftab->importName = (IMPORT_NAME_FN_PTR)GETFUNC(gssLib, IMPORT_NAME);
     if (ftab->importName == NULL) {
         failed = TRUE;
         goto out;
     }
 
-    ftab->compareName = (COMPARE_NAME_FN_PTR)dlsym(gssLib, COMPARE_NAME);
+    ftab->compareName = (COMPARE_NAME_FN_PTR)GETFUNC(gssLib, COMPARE_NAME);
     if (ftab->compareName == NULL) {
         failed = TRUE;
         goto out;
     }
 
     ftab->canonicalizeName = (CANONICALIZE_NAME_FN_PTR)
-                                dlsym(gssLib, CANONICALIZE_NAME);
+                                GETFUNC(gssLib, CANONICALIZE_NAME);
     if (ftab->canonicalizeName == NULL) {
         failed = TRUE;
         goto out;
     }
 
-    ftab->exportName = (EXPORT_NAME_FN_PTR)dlsym(gssLib, EXPORT_NAME);
+    ftab->exportName = (EXPORT_NAME_FN_PTR)GETFUNC(gssLib, EXPORT_NAME);
     if (ftab->exportName == NULL) {
         failed = TRUE;
         goto out;
     }
 
-    ftab->displayName = (DISPLAY_NAME_FN_PTR)dlsym(gssLib, DISPLAY_NAME);
+    ftab->displayName = (DISPLAY_NAME_FN_PTR)GETFUNC(gssLib, DISPLAY_NAME);
     if (ftab->displayName == NULL) {
         failed = TRUE;
         goto out;
     }
 
-    ftab->acquireCred = (ACQUIRE_CRED_FN_PTR)dlsym(gssLib, ACQUIRE_CRED);
+    ftab->acquireCred = (ACQUIRE_CRED_FN_PTR)GETFUNC(gssLib, ACQUIRE_CRED);
     if (ftab->acquireCred == NULL) {
         failed = TRUE;
         goto out;
     }
 
-    ftab->releaseCred = (RELEASE_CRED_FN_PTR)dlsym(gssLib, RELEASE_CRED);
+    ftab->releaseCred = (RELEASE_CRED_FN_PTR)GETFUNC(gssLib, RELEASE_CRED);
     if (ftab->releaseCred == NULL) {
         failed = TRUE;
         goto out;
     }
 
-    ftab->inquireCred = (INQUIRE_CRED_FN_PTR)dlsym(gssLib, INQUIRE_CRED);
+    ftab->inquireCred = (INQUIRE_CRED_FN_PTR)GETFUNC(gssLib, INQUIRE_CRED);
     if (ftab->inquireCred == NULL) {
         failed = TRUE;
         goto out;
     }
 
     ftab->importSecContext = (IMPORT_SEC_CONTEXT_FN_PTR)
-                        dlsym(gssLib, IMPORT_SEC_CONTEXT);
+                        GETFUNC(gssLib, IMPORT_SEC_CONTEXT);
     if (ftab->importSecContext == NULL) {
         failed = TRUE;
         goto out;
     }
 
     ftab->initSecContext = (INIT_SEC_CONTEXT_FN_PTR)
-                        dlsym(gssLib, INIT_SEC_CONTEXT);
+                        GETFUNC(gssLib, INIT_SEC_CONTEXT);
     if (ftab->initSecContext == NULL) {
         failed = TRUE;
         goto out;
     }
 
     ftab->acceptSecContext = (ACCEPT_SEC_CONTEXT_FN_PTR)
-                        dlsym(gssLib, ACCEPT_SEC_CONTEXT);
+                        GETFUNC(gssLib, ACCEPT_SEC_CONTEXT);
     if (ftab->acceptSecContext == NULL) {
         failed = TRUE;
         goto out;
     }
 
     ftab->inquireContext = (INQUIRE_CONTEXT_FN_PTR)
-                        dlsym(gssLib, INQUIRE_CONTEXT);
+                        GETFUNC(gssLib, INQUIRE_CONTEXT);
     if (ftab->inquireContext == NULL) {
         failed = TRUE;
         goto out;
     }
 
     ftab->deleteSecContext = (DELETE_SEC_CONTEXT_FN_PTR)
-                        dlsym(gssLib, DELETE_SEC_CONTEXT);
+                        GETFUNC(gssLib, DELETE_SEC_CONTEXT);
     if (ftab->deleteSecContext == NULL) {
         failed = TRUE;
         goto out;
     }
 
-    ftab->contextTime = (CONTEXT_TIME_FN_PTR)dlsym(gssLib, CONTEXT_TIME);
+    ftab->contextTime = (CONTEXT_TIME_FN_PTR)GETFUNC(gssLib, CONTEXT_TIME);
     if (ftab->contextTime == NULL) {
         failed = TRUE;
         goto out;
     }
 
     ftab->wrapSizeLimit = (WRAP_SIZE_LIMIT_FN_PTR)
-                        dlsym(gssLib, WRAP_SIZE_LIMIT);
+                        GETFUNC(gssLib, WRAP_SIZE_LIMIT);
     if (ftab->wrapSizeLimit == NULL) {
         failed = TRUE;
         goto out;
     }
 
     ftab->exportSecContext = (EXPORT_SEC_CONTEXT_FN_PTR)
-                        dlsym(gssLib, EXPORT_SEC_CONTEXT);
+                        GETFUNC(gssLib, EXPORT_SEC_CONTEXT);
     if (ftab->exportSecContext == NULL) {
         failed = TRUE;
         goto out;
     }
 
-    ftab->getMic = (GET_MIC_FN_PTR)dlsym(gssLib, GET_MIC);
+    ftab->getMic = (GET_MIC_FN_PTR)GETFUNC(gssLib, GET_MIC);
     if (ftab->getMic == NULL) {
         failed = TRUE;
         goto out;
     }
 
-    ftab->verifyMic = (VERIFY_MIC_FN_PTR)dlsym(gssLib, VERIFY_MIC);
+    ftab->verifyMic = (VERIFY_MIC_FN_PTR)GETFUNC(gssLib, VERIFY_MIC);
     if (ftab->verifyMic == NULL) {
         failed = TRUE;
         goto out;
     }
 
-    ftab->wrap = (WRAP_FN_PTR)dlsym(gssLib, WRAP);
+    ftab->wrap = (WRAP_FN_PTR)GETFUNC(gssLib, WRAP);
     if (ftab->wrap == NULL) {
         failed = TRUE;
         goto out;
     }
 
-    ftab->unwrap = (UNWRAP_FN_PTR)dlsym(gssLib, UNWRAP);
+    ftab->unwrap = (UNWRAP_FN_PTR)GETFUNC(gssLib, UNWRAP);
     if (ftab->unwrap == NULL) {
         failed = TRUE;
         goto out;
     }
 
-    ftab->indicateMechs = (INDICATE_MECHS_FN_PTR)dlsym(gssLib, INDICATE_MECHS);
+    ftab->indicateMechs = (INDICATE_MECHS_FN_PTR)GETFUNC(gssLib, INDICATE_MECHS);
     if (ftab->indicateMechs == NULL) {
         failed = TRUE;
         goto out;
     }
 
     ftab->inquireNamesForMech = (INQUIRE_NAMES_FOR_MECH_FN_PTR)
-                        dlsym(gssLib, INQUIRE_NAMES_FOR_MECH);
+                        GETFUNC(gssLib, INQUIRE_NAMES_FOR_MECH);
     if (ftab->inquireNamesForMech == NULL) {
         failed = TRUE;
         goto out;
     }
 
     ftab->addOidSetMember = (ADD_OID_SET_MEMBER_FN_PTR)
-                        dlsym(gssLib, ADD_OID_SET_MEMBER);
+                        GETFUNC(gssLib, ADD_OID_SET_MEMBER);
     if (ftab->addOidSetMember == NULL) {
         failed = TRUE;
         goto out;
     }
 
     ftab->displayStatus = (DISPLAY_STATUS_FN_PTR)
-                        dlsym(gssLib, DISPLAY_STATUS);
+                        GETFUNC(gssLib, DISPLAY_STATUS);
     if (ftab->displayStatus == NULL) {
         failed = TRUE;
         goto out;
     }
 
     ftab->createEmptyOidSet = (CREATE_EMPTY_OID_SET_FN_PTR)
-                        dlsym(gssLib, CREATE_EMPTY_OID_SET);
+                        GETFUNC(gssLib, CREATE_EMPTY_OID_SET);
     if (ftab->createEmptyOidSet == NULL) {
         failed = TRUE;
         goto out;
     }
 
     ftab->releaseOidSet = (RELEASE_OID_SET_FN_PTR)
-                        dlsym(gssLib, RELEASE_OID_SET);
+                        GETFUNC(gssLib, RELEASE_OID_SET);
     if (ftab->releaseOidSet == NULL) {
         failed = TRUE;
         goto out;
     }
 
     ftab->releaseBuffer = (RELEASE_BUFFER_FN_PTR)
-                        dlsym(gssLib, RELEASE_BUFFER);
+                        GETFUNC(gssLib, RELEASE_BUFFER);
     if (ftab->releaseBuffer == NULL) {
         failed = TRUE;
         goto out;
@@ -283,9 +280,8 @@ char* loadNative(const char *libName) {
 
 out:
     if (failed == TRUE) {
-        error = dlerror();
-        if (gssLib != NULL) dlclose(gssLib);
+        if (gssLib != NULL) CLOSELIB(gssLib);
         if (ftab != NULL) free(ftab);
     }
-    return error;
+    return failed;
 }

--- a/jdk/src/share/native/sun/security/jgss/wrapper/NativeFunc.h
+++ b/jdk/src/share/native/sun/security/jgss/wrapper/NativeFunc.h
@@ -28,6 +28,18 @@
 
 #include "gssapi.h"
 
+#ifdef WIN32
+#include <windows.h>
+#define GETLIB(libName) LoadLibrary(libName)
+#define GETFUNC(lib,name) GetProcAddress(lib,name)
+#define CLOSELIB(lib) CloseHandle(lib)
+#else
+#include <dlfcn.h>
+#define GETLIB(libName) dlopen(libName, RTLD_NOW)
+#define GETFUNC(lib,name) dlsym(lib,name)
+#define CLOSELIB(lib) dlclose(lib)
+#endif
+
 #ifndef TRUE
 #define TRUE    1
 #endif
@@ -36,7 +48,7 @@
 #define FALSE   0
 #endif
 
-char* loadNative(const char *libName);
+int loadNative(const char *libName);
 
 /* function pointer definitions */
 typedef OM_uint32 (*RELEASE_NAME_FN_PTR)

--- a/jdk/src/share/native/sun/security/jgss/wrapper/NativeUtil.c
+++ b/jdk/src/share/native/sun/security/jgss/wrapper/NativeUtil.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/jdk/src/share/native/sun/security/jgss/wrapper/NativeUtil.c
+++ b/jdk/src/share/native/sun/security/jgss/wrapper/NativeUtil.c
@@ -468,7 +468,7 @@ jstring getJavaString(JNIEnv *env, gss_buffer_t bytes) {
   if (bytes != NULL) {
     /* constructs the String object with new String(byte[])
        NOTE: do NOT include the trailing NULL */
-    len = bytes->length;
+    len = (int) bytes->length;
     jbytes = (*env)->NewByteArray(env, len);
     if (jbytes == NULL) {
       goto finish;
@@ -496,7 +496,6 @@ jstring getMinorMessage(JNIEnv *env, jobject jstub, OM_uint32 statusValue) {
   OM_uint32 messageContext, minor, major;
   gss_buffer_desc statusString;
   gss_OID mech;
-  jstring msg;
 
   messageContext = 0;
   if (jstub != NULL) {
@@ -635,11 +634,11 @@ jbyteArray getJavaBuffer(JNIEnv *env, gss_buffer_t cbytes) {
 
   if (cbytes != NULL) {
     if ((cbytes != GSS_C_NO_BUFFER) && (cbytes->length != 0)) {
-      result = (*env)->NewByteArray(env, cbytes->length);
+      result = (*env)->NewByteArray(env, (int) cbytes->length);
       if (result == NULL) {
         goto finish;
       }
-      (*env)->SetByteArrayRegion(env, result, 0, cbytes->length,
+      (*env)->SetByteArrayRegion(env, result, 0, (int) cbytes->length,
                                  cbytes->value);
       if ((*env)->ExceptionCheck(env)) {
         result = NULL;
@@ -660,7 +659,6 @@ jbyteArray getJavaBuffer(JNIEnv *env, gss_buffer_t cbytes) {
 gss_OID newGSSOID(JNIEnv *env, jobject jOid) {
   jbyteArray jbytes;
   gss_OID cOid;
-  jthrowable gssEx;
   if (jOid != NULL) {
     jbytes = (*env)->CallObjectMethod(env, jOid, MID_Oid_getDER);
     if ((*env)->ExceptionCheck(env)) {
@@ -782,10 +780,9 @@ jobjectArray getJavaOIDArray(JNIEnv *env, gss_OID_set cOidSet) {
   jobjectArray jOidSet;
   jobject jOid;
   int i;
-  jthrowable gssEx;
 
   if (cOidSet != NULL && cOidSet != GSS_C_NO_OID_SET) {
-    numOfOids = cOidSet->count;
+    numOfOids = (int) cOidSet->count;
     jOidSet = (*env)->NewObjectArray(env, numOfOids, CLS_Oid, NULL);
     if ((*env)->ExceptionCheck(env)) {
       return NULL;

--- a/jdk/src/share/native/sun/security/jgss/wrapper/NativeUtil.h
+++ b/jdk/src/share/native/sun/security/jgss/wrapper/NativeUtil.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/jdk/src/share/native/sun/security/jgss/wrapper/NativeUtil.h
+++ b/jdk/src/share/native/sun/security/jgss/wrapper/NativeUtil.h
@@ -26,6 +26,9 @@
 #include <jni.h>
 #include <stdlib.h>
 #include <string.h>
+#if _MSC_VER >= 1800
+# include <inttypes.h>
+#endif
 #include "gssapi.h"
 
 #ifndef _Included_NATIVE_Util
@@ -90,6 +93,14 @@ extern "C" {
   #define TRACE2(s, p1, p2) { if (JGSS_DEBUG) { printf(s"\n", p1, p2); fflush(stdout); }}
   #define TRACE3(s, p1, p2, p3) { if (JGSS_DEBUG) { printf(s"\n", p1, p2, p3); fflush(stdout); }}
 
+  // Visual Studio 2010-2012 doesn't provide inttypes.h so provide appropriate definitions here.
+  #if _MSC_VER < 1800
+  #ifdef _LP64
+  #define PRIuPTR       "I64u"
+  #else
+  #define PRIuPTR       "u"
+  #endif
+  #endif
 
 #ifdef __cplusplus
 }

--- a/jdk/src/share/native/sun/security/jgss/wrapper/gssapi.h
+++ b/jdk/src/share/native/sun/security/jgss/wrapper/gssapi.h
@@ -387,7 +387,7 @@ GSS_DLLIMP extern gss_OID GSS_C_NT_EXPORT_NAME;
 
 /* Function Prototypes */
 
-OM_uint32 gss_acquire_cred(
+GSS_DLLIMP OM_uint32 gss_acquire_cred(
         OM_uint32 *,            /* minor_status */
         gss_name_t,             /* desired_name */
         OM_uint32,              /* time_req */
@@ -398,12 +398,12 @@ OM_uint32 gss_acquire_cred(
         OM_uint32 *             /* time_rec */
 );
 
-OM_uint32 gss_release_cred(
+GSS_DLLIMP OM_uint32 gss_release_cred(
         OM_uint32 *,            /* minor_status */
         gss_cred_id_t *         /* cred_handle */
 );
 
-OM_uint32 gss_init_sec_context(
+GSS_DLLIMP OM_uint32 gss_init_sec_context(
         OM_uint32 *,            /* minor_status */
         gss_cred_id_t,          /* claimant_cred_handle */
         gss_ctx_id_t *,         /* context_handle */
@@ -419,7 +419,7 @@ OM_uint32 gss_init_sec_context(
         OM_uint32 *             /* time_rec */
 );
 
-OM_uint32 gss_accept_sec_context(
+GSS_DLLIMP OM_uint32 gss_accept_sec_context(
         OM_uint32 *,            /* minor_status */
         gss_ctx_id_t *,         /* context_handle */
         gss_cred_id_t,          /* acceptor_cred_handle */
@@ -433,26 +433,26 @@ OM_uint32 gss_accept_sec_context(
         gss_cred_id_t *         /* delegated_cred_handle */
 );
 
-OM_uint32 gss_process_context_token(
+GSS_DLLIMP OM_uint32 gss_process_context_token(
         OM_uint32 *,            /* minor_status */
         gss_ctx_id_t,           /* context_handle */
         gss_buffer_t            /* token_buffer */
 );
 
-OM_uint32 gss_delete_sec_context(
+GSS_DLLIMP OM_uint32 gss_delete_sec_context(
         OM_uint32 *,            /* minor_status */
         gss_ctx_id_t *,         /* context_handle */
         gss_buffer_t            /* output_token */
 );
 
-OM_uint32 gss_context_time(
+GSS_DLLIMP OM_uint32 gss_context_time(
         OM_uint32 *,            /* minor_status */
         gss_ctx_id_t,           /* context_handle */
         OM_uint32 *             /* time_rec */
 );
 
 /* New for V2 */
-OM_uint32 gss_get_mic(
+GSS_DLLIMP OM_uint32 gss_get_mic(
         OM_uint32 *,            /* minor_status */
         gss_ctx_id_t,           /* context_handle */
         gss_qop_t,              /* qop_req */
@@ -461,7 +461,7 @@ OM_uint32 gss_get_mic(
 );
 
 /* New for V2 */
-OM_uint32 gss_verify_mic(
+GSS_DLLIMP OM_uint32 gss_verify_mic(
         OM_uint32 *,            /* minor_status */
         gss_ctx_id_t,           /* context_handle */
         gss_buffer_t,           /* message_buffer */
@@ -470,7 +470,7 @@ OM_uint32 gss_verify_mic(
 );
 
 /* New for V2 */
-OM_uint32 gss_wrap(
+GSS_DLLIMP OM_uint32 gss_wrap(
         OM_uint32 *,            /* minor_status */
         gss_ctx_id_t,           /* context_handle */
         int,                    /* conf_req_flag */
@@ -481,7 +481,7 @@ OM_uint32 gss_wrap(
 );
 
 /* New for V2 */
-OM_uint32 gss_unwrap(
+GSS_DLLIMP OM_uint32 gss_unwrap(
         OM_uint32 *,            /* minor_status */
         gss_ctx_id_t,           /* context_handle */
         gss_buffer_t,           /* input_message_buffer */
@@ -490,7 +490,7 @@ OM_uint32 gss_unwrap(
         gss_qop_t *             /* qop_state */
 );
 
-OM_uint32 gss_display_status(
+GSS_DLLIMP OM_uint32 gss_display_status(
         OM_uint32 *,            /* minor_status */
         OM_uint32,              /* status_value */
         int,                    /* status_type */
@@ -499,48 +499,48 @@ OM_uint32 gss_display_status(
         gss_buffer_t            /* status_string */
 );
 
-OM_uint32 gss_indicate_mechs(
+GSS_DLLIMP OM_uint32 gss_indicate_mechs(
         OM_uint32 *,            /* minor_status */
         gss_OID_set *           /* mech_set */
 );
 
-OM_uint32 gss_compare_name(
+GSS_DLLIMP OM_uint32 gss_compare_name(
         OM_uint32 *,            /* minor_status */
         gss_name_t,             /* name1 */
         gss_name_t,             /* name2 */
         int *                   /* name_equal */
 );
 
-OM_uint32 gss_display_name(
+GSS_DLLIMP OM_uint32 gss_display_name(
         OM_uint32 *,            /* minor_status */
         gss_name_t,             /* input_name */
         gss_buffer_t,           /* output_name_buffer */
         gss_OID *               /* output_name_type */
 );
 
-OM_uint32 gss_import_name(
+GSS_DLLIMP OM_uint32 gss_import_name(
         OM_uint32 *,            /* minor_status */
         gss_buffer_t,           /* input_name_buffer */
         gss_OID,                /* input_name_type(used to be const) */
         gss_name_t *            /* output_name */
 );
 
-OM_uint32 gss_release_name(
+GSS_DLLIMP OM_uint32 gss_release_name(
         OM_uint32 *,            /* minor_status */
         gss_name_t *            /* input_name */
 );
 
-OM_uint32 gss_release_buffer(
+GSS_DLLIMP OM_uint32 gss_release_buffer(
         OM_uint32 *,            /* minor_status */
         gss_buffer_t            /* buffer */
 );
 
-OM_uint32 gss_release_oid_set(
+GSS_DLLIMP OM_uint32 gss_release_oid_set(
         OM_uint32 *,            /* minor_status */
         gss_OID_set *           /* set */
 );
 
-OM_uint32 gss_inquire_cred(
+GSS_DLLIMP OM_uint32 gss_inquire_cred(
         OM_uint32 *,            /* minor_status */
         gss_cred_id_t,          /* cred_handle */
         gss_name_t *,           /* name */
@@ -550,7 +550,7 @@ OM_uint32 gss_inquire_cred(
 );
 
 /* Last argument new for V2 */
-OM_uint32 gss_inquire_context(
+GSS_DLLIMP OM_uint32 gss_inquire_context(
         OM_uint32 *,            /* minor_status */
         gss_ctx_id_t,           /* context_handle */
         gss_name_t *,           /* src_name */
@@ -563,7 +563,7 @@ OM_uint32 gss_inquire_context(
 );
 
 /* New for V2 */
-OM_uint32 gss_wrap_size_limit(
+GSS_DLLIMP OM_uint32 gss_wrap_size_limit(
         OM_uint32 *,            /* minor_status */
         gss_ctx_id_t,           /* context_handle */
         int,                    /* conf_req_flag */
@@ -573,7 +573,7 @@ OM_uint32 gss_wrap_size_limit(
 );
 
 /* New for V2 */
-OM_uint32 gss_add_cred(
+GSS_DLLIMP OM_uint32 gss_add_cred(
         OM_uint32 *,            /* minor_status */
         gss_cred_id_t,          /* input_cred_handle */
         gss_name_t,             /* desired_name */
@@ -588,7 +588,7 @@ OM_uint32 gss_add_cred(
 );
 
 /* New for V2 */
-OM_uint32 gss_inquire_cred_by_mech(
+GSS_DLLIMP OM_uint32 gss_inquire_cred_by_mech(
         OM_uint32 *,            /* minor_status */
         gss_cred_id_t,          /* cred_handle */
         gss_OID,                /* mech_type */
@@ -599,40 +599,40 @@ OM_uint32 gss_inquire_cred_by_mech(
 );
 
 /* New for V2 */
-OM_uint32 gss_export_sec_context(
+GSS_DLLIMP OM_uint32 gss_export_sec_context(
         OM_uint32 *,            /* minor_status */
         gss_ctx_id_t *,         /* context_handle */
         gss_buffer_t            /* interprocess_token */
 );
 
 /* New for V2 */
-OM_uint32 gss_import_sec_context(
+GSS_DLLIMP OM_uint32 gss_import_sec_context(
         OM_uint32 *,            /* minor_status */
         gss_buffer_t,           /* interprocess_token */
         gss_ctx_id_t *          /* context_handle */
 );
 
 /* New for V2 */
-OM_uint32 gss_release_oid(
+GSS_DLLIMP OM_uint32 gss_release_oid(
         OM_uint32 *,            /* minor_status */
         gss_OID *               /* oid */
 );
 
 /* New for V2 */
-OM_uint32 gss_create_empty_oid_set(
+GSS_DLLIMP OM_uint32 gss_create_empty_oid_set(
         OM_uint32 *,            /* minor_status */
         gss_OID_set *           /* oid_set */
 );
 
 /* New for V2 */
-OM_uint32 gss_add_oid_set_member(
+GSS_DLLIMP OM_uint32 gss_add_oid_set_member(
         OM_uint32 *,            /* minor_status */
         gss_OID,                /* member_oid */
         gss_OID_set *           /* oid_set */
 );
 
 /* New for V2 */
-OM_uint32 gss_test_oid_set_member(
+GSS_DLLIMP OM_uint32 gss_test_oid_set_member(
         OM_uint32 *,            /* minor_status */
         gss_OID,                /* member */
         gss_OID_set,            /* set */
@@ -640,42 +640,42 @@ OM_uint32 gss_test_oid_set_member(
 );
 
 /* New for V2 */
-OM_uint32 gss_str_to_oid(
+GSS_DLLIMP OM_uint32 gss_str_to_oid(
         OM_uint32 *,            /* minor_status */
         gss_buffer_t,           /* oid_str */
         gss_OID *               /* oid */
 );
 
 /* New for V2 */
-OM_uint32 gss_oid_to_str(
+GSS_DLLIMP OM_uint32 gss_oid_to_str(
         OM_uint32 *,            /* minor_status */
         gss_OID,                /* oid */
         gss_buffer_t            /* oid_str */
 );
 
 /* New for V2 */
-OM_uint32 gss_inquire_names_for_mech(
+GSS_DLLIMP OM_uint32 gss_inquire_names_for_mech(
         OM_uint32 *,            /* minor_status */
         gss_OID,                /* mechanism */
         gss_OID_set *           /* name_types */
 );
 
 /* New for V2 */
-OM_uint32 gss_export_name(
+GSS_DLLIMP OM_uint32 gss_export_name(
         OM_uint32  *,           /* minor_status */
         const gss_name_t,       /* input_name */
         gss_buffer_t            /* exported_name */
 );
 
 /* New for V2 */
-OM_uint32 gss_duplicate_name(
+GSS_DLLIMP OM_uint32 gss_duplicate_name(
         OM_uint32  *,           /* minor_status */
         const gss_name_t,       /* input_name */
         gss_name_t *            /* dest_name */
 );
 
 /* New for V2 */
-OM_uint32 gss_canonicalize_name(
+GSS_DLLIMP OM_uint32 gss_canonicalize_name(
         OM_uint32  *,           /* minor_status */
         const gss_name_t,       /* input_name */
         const gss_OID,          /* mech_type */

--- a/jdk/test/java/security/testlibrary/Proc.java
+++ b/jdk/test/java/security/testlibrary/Proc.java
@@ -239,6 +239,9 @@ public class Proc {
         }
         if (debug != null) {
             System.out.println("PROC: " + debug + " cmdline: " + cmd);
+            for (String e : env.keySet()) {
+                System.out.print(e + "=" + env.get(e) + " ");
+            }
         }
         ProcessBuilder pb = new ProcessBuilder(cmd);
         for (Entry<String,String> e: env.entrySet()) {

--- a/jdk/test/sun/security/krb5/auto/BasicProc.java
+++ b/jdk/test/sun/security/krb5/auto/BasicProc.java
@@ -26,7 +26,7 @@
  * @bug 8009977 8186884 8201627
  * @summary A test to launch multiple Java processes using either Java GSS
  *          or native GSS
- * @library ../../../../java/security/testlibrary /lib/testlibrary /lib
+ * @library ../../../../java/security/testlibrary /lib/testlibrary
  * @compile -XDignore.symbol.file BasicProc.java
  * @run main/othervm -Dsun.net.spi.nameservice.provider.1=ns,mock BasicProc launcher
  */
@@ -40,8 +40,8 @@ import java.util.HashSet;
 import java.util.PropertyPermission;
 import java.util.Set;
 
-import jdk.test.lib.Platform;
 import jdk.testlibrary.Asserts;
+import jdk.testlibrary.Platform;
 import org.ietf.jgss.Oid;
 import sun.security.krb5.Config;
 
@@ -236,8 +236,8 @@ public class BasicProc {
                 perms.add(PosixFilePermission.OWNER_WRITE);
                 Files.setPosixFilePermissions(Paths.get(label + ".ccache"),
                                           Collections.unmodifiableSet(perms));
-                pc.env("KRB5CCNAME", label + ".ccache");
             }
+            pc.env("KRB5CCNAME", label + ".ccache");
             // Do not try system ktab if ccache fails
             pc.env("KRB5_KTNAME", "none");
         }

--- a/jdk/test/sun/security/krb5/auto/BasicProc.java
+++ b/jdk/test/sun/security/krb5/auto/BasicProc.java
@@ -26,7 +26,7 @@
  * @bug 8009977 8186884 8201627
  * @summary A test to launch multiple Java processes using either Java GSS
  *          or native GSS
- * @library ../../../../java/security/testlibrary /lib/testlibrary
+ * @library ../../../../java/security/testlibrary /lib/testlibrary /lib
  * @compile -XDignore.symbol.file BasicProc.java
  * @run main/othervm -Dsun.net.spi.nameservice.provider.1=ns,mock BasicProc launcher
  */
@@ -40,6 +40,7 @@ import java.util.HashSet;
 import java.util.PropertyPermission;
 import java.util.Set;
 
+import jdk.test.lib.Platform;
 import jdk.testlibrary.Asserts;
 import org.ietf.jgss.Oid;
 import sun.security.krb5.Config;
@@ -229,12 +230,14 @@ public class BasicProc {
             pc.perm(new PropertyPermission("user.name", "read"));
         } else {
             Files.copy(Paths.get("base.ccache"), Paths.get(label + ".ccache"));
-            Set<PosixFilePermission> perms = new HashSet<>();
-            perms.add(PosixFilePermission.OWNER_READ);
-            perms.add(PosixFilePermission.OWNER_WRITE);
-            Files.setPosixFilePermissions(Paths.get(label + ".ccache"),
+            if (!Platform.isWindows()) {
+                Set<PosixFilePermission> perms = new HashSet<>();
+                perms.add(PosixFilePermission.OWNER_READ);
+                perms.add(PosixFilePermission.OWNER_WRITE);
+                Files.setPosixFilePermissions(Paths.get(label + ".ccache"),
                                           Collections.unmodifiableSet(perms));
-            pc.env("KRB5CCNAME", label + ".ccache");
+                pc.env("KRB5CCNAME", label + ".ccache");
+            }
             // Do not try system ktab if ccache fails
             pc.env("KRB5_KTNAME", "none");
         }
@@ -300,7 +303,7 @@ public class BasicProc {
                 .perm(new javax.security.auth.AuthPermission("doAs"));
         if (lib != null) {
             p.env("KRB5_CONFIG", CONF)
-                    .env("KRB5_TRACE", "/dev/stderr")
+                    .env("KRB5_TRACE", Platform.isWindows() ? "CON" : "/dev/stderr")
                     .prop("sun.security.jgss.native", "true")
                     .prop("sun.security.jgss.lib", lib)
                     .prop("javax.security.auth.useSubjectCredsOnly", "false")


### PR DESCRIPTION
Hello,
I'd like to backport JDK-8200568: port the native GSS-API bridge to Windows to JDK8u
This is a prerequisite of the JDK-6722928 and JDK-8225687

The backport is not clean. I have to to make the following changes:
jdk/make/lib/SecurityLibraries.gmk
- Patched manually, just removed platform dependency

jdk/src/share/native/sun/security/jgss/wrapper/NativeUtil.c
- Clean merge except for copyright year

jdk/src/share/native/sun/security/jgss/wrapper/NativeUtil.h
- Visual Studio 2010-2012 doesn't provide inttypes.h so provide appropriate definitions the header file
- Manually updated copyright year

jdk/src/share/classes/sun/security/jgss/GSSManagerImpl.java
- Manually removed platform OS dependency

jdk/src/solaris/native/sun/security/jgss/wrapper/NativeFunc.c is moved to jdk/src/share/native/sun/security/jgss/wrapper/NativeFunc.c
- All changes applied manually because of JDK-8238388 already applied 

jdk/src/solaris/native/sun/security/jgss/wrapper/NativeFunc.h is moved to jdk/src/share/native/sun/security/jgss/wrapper/NativeFunc.h
- All changes applied clean 

jdk/test/sun/security/krb5/auto/BasicProc.java
- Manually added Windows platform dependency code

jdk/test/java/security/testlibrary/Proc.java
- Manually extended debug output

All related jtreg tests passed successfully on Windows

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8200468](https://bugs.openjdk.org/browse/JDK-8200468): Port the native GSS-API bridge to Windows (**Enhancement** - P4)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/335/head:pull/335` \
`$ git checkout pull/335`

Update a local copy of the PR: \
`$ git checkout pull/335` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/335/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 335`

View PR using the GUI difftool: \
`$ git pr show -t 335`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/335.diff">https://git.openjdk.org/jdk8u-dev/pull/335.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/335#issuecomment-1586669566)