### PR TITLE
8310026: [8u] make java_lang_String::hash_code consistent across platforms

### DIFF
--- a/hotspot/agent/src/share/classes/sun/jvm/hotspot/utilities/Hashtable.java
+++ b/hotspot/agent/src/share/classes/sun/jvm/hotspot/utilities/Hashtable.java
@@ -63,7 +63,7 @@ public class Hashtable extends BasicHashtable {
     int len = buf.length;
     // Emulate the unsigned int in java_lang_String::hash_code
     while (len-- > 0) {
-      h = 31*h + (0xFFFFFFFFL & buf[s]);
+      h = 31*h + (0xFFL & buf[s]);
       s++;
     }
     return h & 0xFFFFFFFFL;

--- a/hotspot/src/share/vm/classfile/javaClasses.hpp
+++ b/hotspot/src/share/vm/classfile/javaClasses.hpp
@@ -177,7 +177,7 @@ class java_lang_String : AllStatic {
   // hash P(31) from Kernighan & Ritchie
   //
   // For this reason, THIS ALGORITHM MUST MATCH String.hashCode().
-  template <typename T> static unsigned int hash_code(T* s, int len) {
+  static unsigned int hash_code(const jchar* s, int len) {
     unsigned int h = 0;
     while (len-- > 0) {
       h = 31*h + (unsigned int) *s;
@@ -185,6 +185,16 @@ class java_lang_String : AllStatic {
     }
     return h;
   }
+
+  static unsigned int hash_code(const jbyte* s, int len) {
+    unsigned int h = 0;
+    while (len-- > 0) {
+      h = 31*h + (((unsigned int) *s) & 0xFF);
+      s++;
+    }
+    return h;
+  }
+
   static unsigned int hash_code(oop java_string);
 
   // This is the string hash code used by the StringTable, which may be

--- a/hotspot/src/share/vm/classfile/symbolTable.cpp
+++ b/hotspot/src/share/vm/classfile/symbolTable.cpp
@@ -225,7 +225,7 @@ Symbol* SymbolTable::lookup(int index, const char* name,
 unsigned int SymbolTable::hash_symbol(const char* s, int len) {
   return use_alternate_hashcode() ?
            AltHashing::halfsiphash_32(seed(), (const uint8_t*)s, len) :
-           java_lang_String::hash_code(s, len);
+           java_lang_String::hash_code((const jbyte*)s, len);
 }
 
 


### PR DESCRIPTION
`java_lang_String::hash_code` produces inconsistent results on different platforms, when `s` is `char*`.  This is because on some platforms `char` is signed, while on others unsigned (resulting in `char` to be either zero-extended or sign-extended, when cast to `unsigned int`). This causes 1 tier1 test failure on aarch64.

Details:
This was discovered by examining one failing test (from tier1) present on aarch64 builds:
`test/serviceability/sa/jmap-hashcode/Test8028623.java`
Test was introduced by [JDK-8028623](https://bugs.openjdk.org/browse/JDK-8028623). However fix done there does not work on aarch64. Code was later fixed (newer jdks) in [hotspot part](https://github.com/openjdk/jdk11u-dev/commit/7af927f9c10923b61f746eb6e566bcda853dd95a) of [JDK-8141132](https://bugs.openjdk.org/browse/JDK-8141132) (JEP 254: Compact Strings).

Fix:
Fixed by backporting very small portion of JDK-8141132.

Testing:
tier1 (x86, x86_64, aarch64): OK (tested by GH and in rhel-8 aarch64 VM)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310026](https://bugs.openjdk.org/browse/JDK-8310026): [8u] make java_lang_String::hash_code consistent across platforms (**Enhancement** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/336/head:pull/336` \
`$ git checkout pull/336`

Update a local copy of the PR: \
`$ git checkout pull/336` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/336/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 336`

View PR using the GUI difftool: \
`$ git pr show -t 336`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/336.diff">https://git.openjdk.org/jdk8u-dev/pull/336.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/336#issuecomment-1591182303)