### PR TITLE
8219804: java/net/MulticastSocket/Promiscuous.java fails intermittently due to NumberFormatException

### DIFF
--- a/jdk/test/java/net/MulticastSocket/Promiscuous.java
+++ b/jdk/test/java/net/MulticastSocket/Promiscuous.java
@@ -22,7 +22,7 @@
  *
 
 /* @test
- * @bug 8014499
+ * @bug 8014499 8219804
  * @summary Test for interference when two sockets are bound to the same
  *          port but joined to different multicast groups
  * @run main Promiscuous
@@ -30,6 +30,7 @@
  */
 
 import java.io.IOException;
+import java.lang.management.ManagementFactory;
 import static java.lang.System.out;
 import java.net.*;
 
@@ -42,11 +43,20 @@ public class Promiscuous {
         throws IOException
     {
         byte[] ba = new byte[100];
-        DatagramPacket p = new DatagramPacket(ba, ba.length);
+        DatagramPacket p;
         try {
-            mc.receive(p);
-            int recvId = Integer.parseInt(
-                    new String(p.getData(), 0, p.getLength(), "UTF-8"));
+            String data = null;
+            while (true) {
+                p = new DatagramPacket(ba, ba.length);
+                mc.receive(p);
+                data = new String(p.getData(), 0, p.getLength(), "UTF-8");
+                if (data.length() > UUID.length() && data.startsWith(UUID)) {
+                    data = data.substring(UUID.length());
+                    break;
+                }
+                logUnexpected(p);
+            }
+            int recvId = Integer.parseInt(data);
             if (datagramExpected) {
                 if (recvId != id)
                     throw new RuntimeException("Unexpected id, got " + recvId
@@ -65,6 +75,20 @@ public class Promiscuous {
         }
     }
 
+    static void logUnexpected(DatagramPacket p) {
+        byte[] ba = p.getData();
+        System.out.printf("Unexpected packet: length: %d. First three bytes: %d, %d, %d\n",
+                          p.getLength(), ba[0], ba[1], ba[2]);
+    }
+
+    static final String UUID; // process-id : currentTimeMillis
+
+    static {
+        String s1 = ManagementFactory.getRuntimeMXBean().getName().split("@")[0];
+        String s2 = Long.toString(System.currentTimeMillis());
+        UUID = "<" + s1 + s2 + ">";
+    }
+
     static void test(InetAddress group1, InetAddress group2)
         throws IOException
     {
@@ -77,7 +101,7 @@ public class Promiscuous {
             mc1.setSoTimeout(TIMEOUT);
             mc2.setSoTimeout(TIMEOUT);
             int nextId = id;
-            byte[] msg = Integer.toString(nextId).getBytes("UTF-8");
+            byte[] msg = (UUID + Integer.toString(nextId)).getBytes("UTF-8");
             DatagramPacket p = new DatagramPacket(msg, msg.length);
             p.setAddress(group1);
             p.setPort(port);
@@ -95,7 +119,7 @@ public class Promiscuous {
             receive(mc2, false, 0);
 
             nextId = ++id;
-            msg = Integer.toString(nextId).getBytes("UTF-8");
+            msg = (UUID + Integer.toString(nextId)).getBytes("UTF-8");
             p = new DatagramPacket(msg, msg.length);
             p.setAddress(group2);
             p.setPort(port);
@@ -129,8 +153,8 @@ public class Promiscuous {
         }
 
         // multicast groups used for the test
-        InetAddress ip4Group1 = InetAddress.getByName("224.7.8.9");
-        InetAddress ip4Group2 = InetAddress.getByName("225.4.5.6");
+        InetAddress ip4Group1 = InetAddress.getByName("224.0.0.120");
+        InetAddress ip4Group2 = InetAddress.getByName("224.0.0.121");
 
         test(ip4Group1, ip4Group2);
     }


### PR DESCRIPTION
8219804: java/net/MulticastSocket/Promiscuous.java fails intermittently due to NumberFormatException

Reviewed-by: Yi Yang

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8219804](https://bugs.openjdk.org/browse/JDK-8219804): java/net/MulticastSocket/Promiscuous.java fails intermittently due to NumberFormatException (**Bug** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/337/head:pull/337` \
`$ git checkout pull/337`

Update a local copy of the PR: \
`$ git checkout pull/337` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/337/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 337`

View PR using the GUI difftool: \
`$ git pr show -t 337`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/337.diff">https://git.openjdk.org/jdk8u-dev/pull/337.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/337#issuecomment-1625077075)