### PR TITLE
8214046: [macosx] Undecorated Frame does not Iconify when set to

### DIFF
--- a/jdk/src/macosx/native/sun/awt/AWTWindow.m
+++ b/jdk/src/macosx/native/sun/awt/AWTWindow.m
@@ -203,13 +203,13 @@ AWT_NS_WINDOW_IMPLEMENTATION
     if (IS(styleBits, DECORATED)) {
         type |= NSTitledWindowMask;
         if (IS(styleBits, CLOSEABLE))            type |= NSClosableWindowMask;
-        if (IS(styleBits, MINIMIZABLE))          type |= NSMiniaturizableWindowMask;
         if (IS(styleBits, RESIZABLE))            type |= NSResizableWindowMask;
         if (IS(styleBits, FULL_WINDOW_CONTENT))  type |= NSFullSizeContentViewWindowMask;
     } else {
         type |= NSBorderlessWindowMask;
     }
 
+    if (IS(styleBits, MINIMIZABLE))   type |= NSMiniaturizableWindowMask;
     if (IS(styleBits, TEXTURED))      type |= NSTexturedBackgroundWindowMask;
     if (IS(styleBits, UNIFIED))       type |= NSUnifiedTitleAndToolbarWindowMask;
     if (IS(styleBits, UTILITY))       type |= NSUtilityWindowMask;

--- a/jdk/test/java/awt/Frame/NormalToIconified/NormalToIconifiedTest.java
+++ b/jdk/test/java/awt/Frame/NormalToIconified/NormalToIconifiedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8171949
+ * @bug 8171949 8214046
  * @summary Tests that bitwise mask is set and state listener is notified during state transition.
  * @author Dmitry Markov
  * @library ../../regtesthelpers
@@ -40,12 +40,19 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import test.java.awt.regtesthelpers.Util;
 
 public class NormalToIconifiedTest {
-    private static final AtomicBoolean listenerNotified = new AtomicBoolean(false);
 
     public static void main(String[] args) {
+        test(false);
+        test(true);
+    }
+
+    private static void test(final boolean undecorated) {
+        AtomicBoolean listenerNotified = new AtomicBoolean(false);
+
         Robot robot = Util.createRobot();
 
         Frame testFrame = new Frame("Test Frame");
+        testFrame.setUndecorated(undecorated);
         testFrame.setSize(200, 200);
         testFrame.addWindowStateListener(new WindowStateListener() {
             @Override


### PR DESCRIPTION
See https://bugs.openjdk.org/browse/JDK-8214046 with the original patch at https://hg.openjdk.org/jdk/jdk/rev/769dbf384c44. I used https://github.com/openjdk/jdk11u-dev/commit/ab97f65242dad6ad1a7bfb8284954f202eb37369 as backport commit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8214046](https://bugs.openjdk.org/browse/JDK-8214046): [macosx] Undecorated Frame does not Iconify when set to (**Bug** - P2)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/341/head:pull/341` \
`$ git checkout pull/341`

Update a local copy of the PR: \
`$ git checkout pull/341` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/341/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 341`

View PR using the GUI difftool: \
`$ git pr show -t 341`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/341.diff">https://git.openjdk.org/jdk8u-dev/pull/341.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/341#issuecomment-1640181615)