### PR TITLE
8284033: Leak XVisualInfo in getAllConfigs in awt_GraphicsEnv.c

### DIFF
--- a/jdk/src/solaris/native/sun/awt/awt_GraphicsEnv.c
+++ b/jdk/src/solaris/native/sun/awt/awt_GraphicsEnv.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -576,6 +576,8 @@ getAllConfigs (JNIEnv *env, int screen, AwtScreenDataPtr screenDataPtr) {
        XFree (pVI8sg);
     if (n1sg != 0)
        XFree (pVI1sg);
+    if (nTrue != 0)
+       XFree (pVITrue);
 
     screenDataPtr->numConfigs = nConfig;
     screenDataPtr->configs = graphicsConfigs;


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit https://github.com/openjdk/jdk/commit/36b3bbc53de074647ce04de890dc99bd5a2373e8 from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Zhengyu Gu  on Apr 4, 2022 and was reviewed by Phil Race and Sergey Bylokhov

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8284033](https://bugs.openjdk.org/browse/JDK-8284033) needs maintainer approval

### Issue
 * [JDK-8284033](https://bugs.openjdk.org/browse/JDK-8284033): Leak XVisualInfo in getAllConfigs in awt_GraphicsEnv.c (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/344/head:pull/344` \
`$ git checkout pull/344`

Update a local copy of the PR: \
`$ git checkout pull/344` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/344/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 344`

View PR using the GUI difftool: \
`$ git pr show -t 344`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/344.diff">https://git.openjdk.org/jdk8u-dev/pull/344.diff</a>

</details>
