### PR TITLE
8212677: X11 default visual support for IM status window on VNC

### DIFF
--- a/jdk/src/solaris/native/sun/awt/awt_GraphicsEnv.c
+++ b/jdk/src/solaris/native/sun/awt/awt_GraphicsEnv.c
@@ -205,6 +205,8 @@ findWithTemplate(XVisualInfo *vinfo,
     visualList = XGetVisualInfo(awt_display,
                                 mask, vinfo, &visualsMatched);
     if (visualList) {
+        int id = -1;
+        VisualID defaultVisual = XVisualIDFromVisual(DefaultVisual(awt_display, vinfo->screen));
         defaultConfig = ZALLOC(_AwtGraphicsConfigData);
         for (i = 0; i < visualsMatched; i++) {
             memcpy(&defaultConfig->awt_visInfo, &visualList[i], sizeof(XVisualInfo));
@@ -213,19 +215,30 @@ findWithTemplate(XVisualInfo *vinfo,
             /* we can't use awtJNI_CreateColorData here, because it'll pull,
                SystemColor, which in turn will cause toolkit to be reinitialized */
             if (awtCreateX11Colormap(defaultConfig)) {
-                /* Allocate white and black pixels for this visual */
-                color.flags = DoRed | DoGreen | DoBlue;
-                color.red = color.green = color.blue = 0x0000;
-                XAllocColor(awt_display, defaultConfig->awt_cmap, &color);
-                x11Screens[visualList[i].screen].blackpixel = color.pixel;
-                color.flags = DoRed | DoGreen | DoBlue;
-                color.red = color.green = color.blue = 0xffff;
-                XAllocColor(awt_display, defaultConfig->awt_cmap, &color);
-                x11Screens[visualList[i].screen].whitepixel = color.pixel;
-
-                XFree(visualList);
-                return defaultConfig;
+                if (visualList[i].visualid == defaultVisual) {
+                    id = i;
+                    break;
+                } else if (-1 == id) {
+                    // Keep 1st match for fallback
+                    id = i;
+                }
             }
+        }
+        if (-1 != id) {
+            memcpy(&defaultConfig->awt_visInfo, &visualList[id], sizeof(XVisualInfo));
+            defaultConfig->awt_depth = visualList[id].depth;
+            /* Allocate white and black pixels for this visual */
+            color.flags = DoRed | DoGreen | DoBlue;
+            color.red = color.green = color.blue = 0x0000;
+            XAllocColor(awt_display, defaultConfig->awt_cmap, &color);
+            x11Screens[visualList[id].screen].blackpixel = color.pixel;
+            color.flags = DoRed | DoGreen | DoBlue;
+            color.red = color.green = color.blue = 0xffff;
+            XAllocColor(awt_display, defaultConfig->awt_cmap, &color);
+            x11Screens[visualList[id].screen].whitepixel = color.pixel;
+
+            XFree(visualList);
+            return defaultConfig;
         }
         XFree(visualList);
         free((void *)defaultConfig);

--- a/jdk/src/solaris/native/sun/awt/awt_InputMethod.c
+++ b/jdk/src/solaris/native/sun/awt/awt_InputMethod.c
@@ -676,9 +676,10 @@ static StatusWindow *createStatusWindow(
         return NULL;
     }
     statusWindow->w = status;
-    //12-point font
+    //12, 13-point fonts
     statusWindow->fontset = XCreateFontSet(dpy,
-                                           "-*-*-medium-r-normal-*-*-120-*-*-*-*",
+                                           "-*-*-medium-r-normal-*-*-120-*-*-*-*," \
+                                           "-*-*-medium-r-normal-*-*-130-*-*-*-*",
                                            &mclr, &mccr, &dsr);
     /* In case we didn't find the font set, release the list of missing characters */
     if (mccr > 0) {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit https://github.com/openjdk/jdk/commit/86cf7f8768977aea7b9ea1c90da498a1d91d2891 from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Ichiroh Takiguchi on Feb 1, 2019 and was reviewed by Naoto Sato and Sergey Bylokhov

@takiguc please take a look.

Thanks!

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8212677](https://bugs.openjdk.org/browse/JDK-8212677): X11 default visual support for IM status window on VNC (**Bug** - P3)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/345/head:pull/345` \
`$ git checkout pull/345`

Update a local copy of the PR: \
`$ git checkout pull/345` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/345/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 345`

View PR using the GUI difftool: \
`$ git pr show -t 345`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/345.diff">https://git.openjdk.org/jdk8u-dev/pull/345.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/345#issuecomment-1648582484)