### PR TITLE
8207404: MulticastSocket tests failing on AIX

### DIFF
--- a/jdk/test/java/net/MulticastSocket/JoinLeave.java
+++ b/jdk/test/java/net/MulticastSocket/JoinLeave.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 1999, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,13 +21,15 @@
  * questions.
  */
 
-/*
+/**
  * @test
  * @bug 4091811 4148753 4102731
  * @summary Test java.net.MulticastSocket joinGroup and leaveGroup
- * @library /lib/testlibrary
- * @build jdk.testlibrary.NetworkConfiguration
+ * @library /lib
+ * @build jdk.test.lib.NetworkConfiguration
+ *        jdk.test.lib.Platform
  * @run main JoinLeave
+ * @run main/othervm -Djava.net.preferIPv4Stack=true JoinLeave
  */
 
 import java.io.IOException;
@@ -35,11 +37,11 @@ import java.io.UncheckedIOException;
 import java.net.InetAddress;
 import java.net.MulticastSocket;
 import java.net.NetworkInterface;
-import jdk.testlibrary.NetworkConfiguration;
+import jdk.test.lib.NetworkConfiguration;
 
 public class JoinLeave {
 
-    public static void main(String args[]) throws IOException  {
+    public static void main(String args[]) throws IOException {
         InetAddress ip4Group = InetAddress.getByName("224.80.80.80");
         InetAddress ip6Group = InetAddress.getByName("ff02::a");
 
@@ -48,8 +50,7 @@ public class JoinLeave {
         nc.ip6MulticastInterfaces().forEach(nic -> joinLeave(ip6Group, nic));
     }
 
-    static void joinLeave(InetAddress group, NetworkInterface nif)
-    {
+    static void joinLeave(InetAddress group, NetworkInterface nif) {
         System.out.println("Joining:" + group + " on " + nif);
         try (MulticastSocket soc = new MulticastSocket()) {
             soc.setNetworkInterface(nif);

--- a/jdk/test/java/net/MulticastSocket/SetGetNetworkInterfaceTest.java
+++ b/jdk/test/java/net/MulticastSocket/SetGetNetworkInterfaceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,105 +21,50 @@
  * questions.
  */
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.MulticastSocket;
+import java.net.NetworkInterface;
 
-/*
+import jdk.test.lib.NetworkConfiguration;
+
+/**
  * @test
  * @bug 6458027
  * @summary Disabling IPv6 on a specific network interface causes problems.
- *
- */
-
-import java.io.IOException;
-import java.net.InetAddress;
-import java.net.MulticastSocket;
-import java.net.NetworkInterface;
-import java.net.SocketException;
-import java.util.Arrays;
-import java.util.Enumeration;
-
-
-public class SetGetNetworkInterfaceTest  {
+ * @library /lib
+ * @build jdk.test.lib.NetworkConfiguration
+ *        jdk.test.lib.Platform
+ * @run main SetGetNetworkInterfaceTest
+ * @run main/othervm -Djava.net.preferIPv4Stack=true SetGetNetworkInterfaceTest
+*/
+public class SetGetNetworkInterfaceTest {
 
     public static void main(String[] args) throws Exception {
-
-        boolean passed = true;
-        try {
-            MulticastSocket ms = new MulticastSocket();
-            Enumeration<NetworkInterface> networkInterfaces = NetworkInterface
-                    .getNetworkInterfaces();
-            while (networkInterfaces.hasMoreElements()) {
-                NetworkInterface netIf = networkInterfaces.nextElement();
-                if (isNetworkInterfaceTestable(netIf)) {
-                    printNetIfDetails(netIf);
-                    ms.setNetworkInterface(netIf);
-                    NetworkInterface msNetIf = ms.getNetworkInterface();
-                    if (netIf.equals(msNetIf)) {
-                        System.out.println(" OK");
-                    } else {
-                        System.out.println("FAILED!!!");
-                        printNetIfDetails(msNetIf);
-                        passed = false;
-                    }
-                    System.out.println("------------------");
-                }
-            }
+        NetworkConfiguration nc = NetworkConfiguration.probe();
+        try (MulticastSocket ms = new MulticastSocket()) {
+            nc.multicastInterfaces(true).forEach(nif -> setGetNetworkInterface(ms, nif));
         } catch (IOException e) {
             e.printStackTrace();
-            passed = false;
         }
-        if (!passed) {
-            throw new RuntimeException("Test Fail");
-        }
-        System.out.println("Test passed ");
+        System.out.println("Test passed.");
     }
 
-    private static boolean isNetworkInterfaceTestable(NetworkInterface netIf) throws Exception {
-        System.out.println("checking netif == " + netIf.getName());
-        return  (netIf.isUp() && netIf.supportsMulticast() && isIpAddrAvailable(netIf));
-    }
-
-    private static boolean isIpAddrAvailable (NetworkInterface netIf) {
-        boolean ipAddrAvailable = false;
-        byte[] nullIpAddr = {'0', '0', '0', '0'};
-        byte[] testIpAddr = null;
-
-        Enumeration<InetAddress> ipAddresses = netIf.getInetAddresses();
-        while (ipAddresses.hasMoreElements()) {
-            InetAddress testAddr = ipAddresses.nextElement();
-            testIpAddr = testAddr.getAddress();
-            if ((testIpAddr != null) && (!Arrays.equals(testIpAddr, nullIpAddr))) {
-                ipAddrAvailable = true;
-                break;
+    static void setGetNetworkInterface(MulticastSocket ms, NetworkInterface nif) {
+        try {
+            System.out.println(NetworkConfiguration.interfaceInformation(nif));
+            ms.setNetworkInterface(nif);
+            NetworkInterface msNetIf = ms.getNetworkInterface();
+            if (nif.equals(msNetIf)) {
+                System.out.println(" OK");
             } else {
-                System.out.println("ignore netif " + netIf.getName());
+                System.out.println("FAILED!!!");
+                System.out.println(NetworkConfiguration.interfaceInformation(msNetIf));
+                throw new RuntimeException("Test Fail");
             }
+            System.out.println("------------------");
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
         }
-        return ipAddrAvailable;
-    }
-
-    private static void printNetIfDetails(NetworkInterface ni)
-            throws SocketException {
-        System.out.println("Name " + ni.getName() + " index " + ni.getIndex());
-        Enumeration<InetAddress> en = ni.getInetAddresses();
-        while (en.hasMoreElements()) {
-            System.out.println(" InetAdress: " + en.nextElement());
-        }
-        System.out.println("HardwareAddress: " + createMacAddrString(ni));
-        System.out.println("loopback: " + ni.isLoopback() + "; pointToPoint: "
-                + ni.isPointToPoint() + "; virtual: " + ni.isVirtual()
-                + "; MTU: " + ni.getMTU());
-    }
-
-    private static String createMacAddrString(NetworkInterface netIf)
-            throws SocketException {
-        byte[] macAddr = netIf.getHardwareAddress();
-        StringBuilder sb = new StringBuilder();
-        if (macAddr != null) {
-            for (int i = 0; i < macAddr.length; i++) {
-                sb.append(String.format("%02X%s", macAddr[i],
-                        (i < macAddr.length - 1) ? "-" : ""));
-            }
-        }
-        return sb.toString();
     }
 }

--- a/jdk/test/java/net/MulticastSocket/Test.java
+++ b/jdk/test/java/net/MulticastSocket/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,21 +21,31 @@
  * questions.
  */
 
-/*
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.MulticastSocket;
+import java.net.SocketTimeoutException;
+
+import jdk.test.lib.NetworkConfiguration;
+
+/**
  * @test
  * @bug 4488458
  * @summary IPv4 and IPv6 multicasting broken on Linux
+ * @library /lib
+ * @build jdk.test.lib.NetworkConfiguration
+ *        jdk.test.lib.Platform
+ * @run main Test
+ * @run main/othervm -Djava.net.preferIPv4Stack=true Test
  */
-import java.net.*;
-import java.io.IOException;
-import java.util.Enumeration;
-
 public class Test {
 
     static int count = 0;
     static int failures = 0;
 
-    void doTest(String address) throws Exception {
+    void doTest(String address) throws IOException {
         boolean failed = false;
 
         InetAddress ia = InetAddress.getByName(address);
@@ -61,7 +71,7 @@ public class Test {
 
                 /* packets should be received */
 
-                for (int j=0; j<2; j++) {
+                for (int j = 0; j < 2; j++) {
                     p.setAddress(ia);
                     p.setPort(port);
 
@@ -123,59 +133,26 @@ public class Test {
         }
     }
 
-    void allTests() throws Exception {
+    void allTests() throws IOException {
+        NetworkConfiguration nc = NetworkConfiguration.probe();
 
-        /*
-         * Assume machine has IPv4 address
-         */
+        // unconditionally test IPv4 address
         doTest("224.80.80.80");
 
-        /*
-         * Check if IPv6 is enabled and the scope of the addresses
-         */
-        boolean has_ipv6 = false;
-        boolean has_siteaddress = false;
-        boolean has_linklocaladdress = false;
-        boolean has_globaladdress = false;
-
-        Enumeration nifs = NetworkInterface.getNetworkInterfaces();
-        while (nifs.hasMoreElements()) {
-            NetworkInterface ni = (NetworkInterface)nifs.nextElement();
-            Enumeration addrs = ni.getInetAddresses();
-
-            while (addrs.hasMoreElements()) {
-                InetAddress ia = (InetAddress)addrs.nextElement();
-
-                if (ia instanceof Inet6Address) {
-                    has_ipv6 = true;
-                    if (ia.isLinkLocalAddress()) has_linklocaladdress = true;
-                    if (ia.isSiteLocalAddress()) has_siteaddress = true;
-
-                    if (!ia.isLinkLocalAddress() &&
-                        !ia.isSiteLocalAddress() &&
-                        !ia.isLoopbackAddress()) {
-                        has_globaladdress = true;
-                    }
-                }
-            }
-        }
-
-        /*
-         * If IPv6 is enabled perform multicast tests with various scopes
-         */
-        if (has_ipv6) {
+        // If IPv6 is enabled perform multicast tests with various scopes
+        if (nc.hasTestableIPv6Address()) {
             doTest("ff01::a");
         }
 
-        if (has_linklocaladdress) {
+        if (nc.hasLinkLocalAddress()) {
             doTest("ff02::a");
         }
 
-        if (has_siteaddress) {
+        if (nc.hasSiteLocalAddress()) {
             doTest("ff05::a");
         }
 
-        if (has_globaladdress) {
+        if (nc.has_globaladdress()) {
             doTest("ff0e::a");
         }
     }
@@ -186,7 +163,7 @@ public class Test {
         if (args.length == 0) {
             t.allTests();
         } else {
-            for (int i=0; i<args.length; i++) {
+            for (int i = 0; i < args.length; i++) {
                 t.doTest(args[i]);
             }
         }


### PR DESCRIPTION
This backport fixes the tier2 test:
FAILED: java/net/MulticastSocket/JoinLeave.java -- The socket name is not available on this system. (Error setting socket option)

Changes are applied non-cleanly. 
Tested on AIX 7.2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8207404](https://bugs.openjdk.org/browse/JDK-8207404) needs maintainer approval

### Issue
 * [JDK-8207404](https://bugs.openjdk.org/browse/JDK-8207404): MulticastSocket tests failing on AIX (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/347/head:pull/347` \
`$ git checkout pull/347`

Update a local copy of the PR: \
`$ git checkout pull/347` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/347/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 347`

View PR using the GUI difftool: \
`$ git pr show -t 347`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/347.diff">https://git.openjdk.org/jdk8u-dev/pull/347.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/347#issuecomment-1649675116)