### PR TITLE
8173072: zipfs fails to handle incorrect info-zip "extended timestamp extra field"

### DIFF
--- a/jdk/src/share/demo/nio/zipfs/src/com/sun/nio/zipfs/ZipFileSystem.java
+++ b/jdk/src/share/demo/nio/zipfs/src/com/sun/nio/zipfs/ZipFileSystem.java
@@ -2461,16 +2461,17 @@ public class ZipFileSystem extends FileSystem {
                             locPos += locSZ;
                              continue;
                         }
+                        int end = locPos + locSZ - 4;
                         int flag = CH(buf, locPos++);
-                        if ((flag & 0x1) != 0) {
+                        if ((flag & 0x1) != 0 && locPos <= end) {
                             mtime = unixToJavaTime(LG(buf, locPos));
                             locPos += 4;
                         }
-                        if ((flag & 0x2) != 0) {
+                        if ((flag & 0x2) != 0 && locPos <= end) {
                             atime = unixToJavaTime(LG(buf, locPos));
                             locPos += 4;
                         }
-                        if ((flag & 0x4) != 0) {
+                        if ((flag & 0x4) != 0 && locPos <= end) {
                             ctime = unixToJavaTime(LG(buf, locPos));
                             locPos += 4;
                         }


### PR DESCRIPTION
Package nio.zipfs is in demo directory of jdk8u. It is not the part of standard libraries until jdk9. However, we found that some Java8 applications use it and hit a bug. I guess this manifests Hyrum's Law again. 

This patch can *NOT* apply to jdk8u cleanly. I need to adjust the directory. I drop the cosmetic changes in nio/zipfs/ZipCoder.java. It helps minimize changeset. If we want to include them, we need to backport other patches. 

We test jtreg locally. I reckon the risk is minimal because the patch only adds a few boundary checks in nio/zipfs/EXTT. Without it, zipfs throws java.lang.ArrayIndexOutOfBoundsException when it encounters a problematic zip file.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8173072](https://bugs.openjdk.org/browse/JDK-8173072): zipfs fails to handle incorrect info-zip "extended timestamp extra field" (**Bug** - P3)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/349/head:pull/349` \
`$ git checkout pull/349`

Update a local copy of the PR: \
`$ git checkout pull/349` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/349/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 349`

View PR using the GUI difftool: \
`$ git pr show -t 349`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/349.diff">https://git.openjdk.org/jdk8u-dev/pull/349.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/349#issuecomment-1659305914)