### PR TITLE
8206179: com/sun/management/OperatingSystemMXBean/GetCommittedVirtualMemorySize.java fails with Committed virtual memory size illegal value

### DIFF
--- a/jdk/test/com/sun/management/OperatingSystemMXBean/GetCommittedVirtualMemorySize.java
+++ b/jdk/test/com/sun/management/OperatingSystemMXBean/GetCommittedVirtualMemorySize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,8 +56,7 @@ public class GetCommittedVirtualMemorySize {
 
     // Careful with these values.
     private static final long MIN_SIZE_FOR_PASS = 1;
-    // Max size for pass dynamically determined below
-    private static long       max_size_for_pass = Long.MAX_VALUE;
+    private static long       MAX_SIZE_FOR_PASS = Long.MAX_VALUE;
 
     private static boolean trace = false;
 
@@ -66,16 +65,6 @@ public class GetCommittedVirtualMemorySize {
             trace = true;
         }
 
-        // 4934082: On Linux, VM size *can* be larger than total swap
-        // size.  Linux might not reserve swap memory immediately when
-        // a page is mmaped.  This means that the reported committed
-        // memory size can grow beyond the swap limit.
-        long max_size = mbean.getTotalSwapSpaceSize() +
-                        mbean.getTotalPhysicalMemorySize();
-
-        if (max_size > 0) {
-            max_size_for_pass = max_size;
-        }
         long size = mbean.getCommittedVirtualMemorySize();
         if (size == -1) {
             System.out.println("getCommittedVirtualMemorySize() is not supported");
@@ -87,11 +76,11 @@ public class GetCommittedVirtualMemorySize {
                                size);
         }
 
-        if (size < MIN_SIZE_FOR_PASS || size > max_size_for_pass) {
+        if (size < MIN_SIZE_FOR_PASS || size > MAX_SIZE_FOR_PASS) {
             throw new RuntimeException("Committed virtual memory size " +
                                        "illegal value: " + size + " bytes " +
                                        "(MIN = " + MIN_SIZE_FOR_PASS + "; " +
-                                       "MAX = " + max_size_for_pass + ")");
+                                       "MAX = " + MAX_SIZE_FOR_PASS + ")");
         }
 
         System.out.println("Test passed.");


### PR DESCRIPTION
Backporting https://bugs.openjdk.org/browse/JDK-8206179 for parity with Oracle 8u.

Backport is clean, copyright was manually resolved.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8206179](https://bugs.openjdk.org/browse/JDK-8206179): com/sun/management/OperatingSystemMXBean/GetCommittedVirtualMemorySize.java fails with Committed virtual memory size illegal value (**Bug** - P4)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/352/head:pull/352` \
`$ git checkout pull/352`

Update a local copy of the PR: \
`$ git checkout pull/352` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/352/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 352`

View PR using the GUI difftool: \
`$ git pr show -t 352`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/352.diff">https://git.openjdk.org/jdk8u-dev/pull/352.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/352#issuecomment-1666168620)