### PR TITLE
8042726: [TESTBUG] TEST.groups file was not updated after runtime/6925573/SortMethodsTest.java removal

### DIFF
--- a/hotspot/test/TEST.groups
+++ b/hotspot/test/TEST.groups
@@ -65,7 +65,6 @@ needs_jdk = \
   gc/metaspace/TestMetaspacePerfCounters.java \
   gc/metaspace/TestPerfCountersAndMemoryPools.java \
   runtime/6819213/TestBootNativeLibraryPath.java \
-  runtime/6925573/SortMethodsTest.java \
   runtime/7107135/Test7107135.sh \
   runtime/7158988/FieldMonitor.java \
   runtime/7194254/Test7194254.java \


### PR DESCRIPTION
Backport [JDK-8042726](https://bugs.openjdk.org/browse/JDK-8042726) as a follow-up to #351, to resolve a bug in that backport. Change has merge conflicts due to changes in context line, but the change itself is clean as it is a single-line deletion.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8042726](https://bugs.openjdk.org/browse/JDK-8042726): [TESTBUG] TEST.groups file was not updated after runtime/6925573/SortMethodsTest.java removal (**Bug** - P4)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/355/head:pull/355` \
`$ git checkout pull/355`

Update a local copy of the PR: \
`$ git checkout pull/355` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/355/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 355`

View PR using the GUI difftool: \
`$ git pr show -t 355`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/355.diff">https://git.openjdk.org/jdk8u-dev/pull/355.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/355#issuecomment-1677766937)