### PR TITLE
Backport 8bb3799029d34e7f5bbc3d9e5bc6da7068360bc7

### DIFF
--- a/hotspot/test/runtime/memory/ReserveMemory.java
+++ b/hotspot/test/runtime/memory/ReserveMemory.java
@@ -21,10 +21,12 @@
  * questions.
  */
 
+// Aix commits on touch, so this test won't work.
 /*
  * @test
  * @key regression
  * @bug 8012015
+ * @requires !(os.family == "aix")
  * @summary Make sure reserved (but uncommitted) memory is not accessible
  * @library /testlibrary /testlibrary/whitebox
  * @build ReserveMemory
@@ -37,14 +39,6 @@ import com.oracle.java.testlibrary.*;
 import sun.hotspot.WhiteBox;
 
 public class ReserveMemory {
-  private static boolean isWindows() {
-    return System.getProperty("os.name").toLowerCase().startsWith("win");
-  }
-
-  private static boolean isOsx() {
-    return System.getProperty("os.name").toLowerCase().startsWith("mac");
-  }
-
   public static void main(String args[]) throws Exception {
     if (args.length > 0) {
       WhiteBox.getWhiteBox().readReservedMemory();
@@ -61,9 +55,9 @@ public class ReserveMemory {
           "test");
 
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
-    if (isWindows()) {
+    if (Platform.isWindows()) {
       output.shouldContain("EXCEPTION_ACCESS_VIOLATION");
-    } else if (isOsx()) {
+    } else if (Platform.isOSX()) {
       output.shouldContain("SIGBUS");
     } else {
       output.shouldContain("SIGSEGV");


### PR DESCRIPTION
Backport of JDK-8159156 [TESTBUG] ReserveMemory test is not useful on Aix.
Applied cleanly. 