### PR TITLE
8271838: AmazonCA.java interop test fails

### DIFF
--- a/jdk/test/security/infra/java/security/cert/CertPathValidator/certification/AmazonCA.java
+++ b/jdk/test/security/infra/java/security/cert/CertPathValidator/certification/AmazonCA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -100,76 +100,64 @@ class AmazonCA_1 {
             "843t4By6YT/PVlePU2PCWejkrJQnKQAPOov7IA8kuO2RDWuzE/zF6Hotdg==\n" +
             "-----END CERTIFICATE-----";
 
-    // Owner: CN=good.sca1a.amazontrust.com, O=Amazon Trust Services, L=Seattle, ST=Washington, C=US, \
-    // SERIALNUMBER=5846743, OID.2.5.4.15=Private Organization, OID.1.3.6.1.4.1.311.60.2.1.2=Delaware, \
-    // OID.1.3.6.1.4.1.311.60.2.1.3=US
+    // Owner: CN=good.sca1a.amazontrust.com
     // Issuer: CN=Amazon, OU=Server CA 1A, O=Amazon, C=US
-    // Serial number: 703e4e4bbd78e2b6db5634f36c4ee944cb1a4
-    // Valid from: Mon Jul 29 16:53:36 PDT 2019 until: Sat Aug 29 16:53:36 PDT 2020
+    // Serial number: 75a5dd4b767bedc94a4239da65ed9dfef8218
+    // Valid from: Fri Dec 17 12:21:50 PST 2021 until: Tue Jan 17 12:21:50 PST 2023
     private static final String VALID = "-----BEGIN CERTIFICATE-----\n" +
-            "MIIFEzCCA/ugAwIBAgITBwPk5LvXjitttWNPNsTulEyxpDANBgkqhkiG9w0BAQsF\n" +
+            "MIIEIDCCAwigAwIBAgITB1pd1LdnvtyUpCOdpl7Z3++CGDANBgkqhkiG9w0BAQsF\n" +
             "ADBGMQswCQYDVQQGEwJVUzEPMA0GA1UEChMGQW1hem9uMRUwEwYDVQQLEwxTZXJ2\n" +
-            "ZXIgQ0EgMUExDzANBgNVBAMTBkFtYXpvbjAeFw0xOTA3MjkyMzUzMzZaFw0yMDA4\n" +
-            "MjkyMzUzMzZaMIHaMRMwEQYLKwYBBAGCNzwCAQMTAlVTMRkwFwYLKwYBBAGCNzwC\n" +
-            "AQITCERlbGF3YXJlMR0wGwYDVQQPExRQcml2YXRlIE9yZ2FuaXphdGlvbjEQMA4G\n" +
-            "A1UEBRMHNTg0Njc0MzELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24x\n" +
-            "EDAOBgNVBAcTB1NlYXR0bGUxHjAcBgNVBAoTFUFtYXpvbiBUcnVzdCBTZXJ2aWNl\n" +
-            "czEjMCEGA1UEAxMaZ29vZC5zY2ExYS5hbWF6b250cnVzdC5jb20wggEiMA0GCSqG\n" +
-            "SIb3DQEBAQUAA4IBDwAwggEKAoIBAQDQyuJ83c2Zf9k29f6iLqd8nJSuHSk1v+SS\n" +
-            "0sYyG8tjscfCC1HcOdNj37vtiNN65sXh/e/kBKH9wvzhCLOJbBqVKRHOZuHdJEpH\n" +
-            "35R6C/PbcV/tp49g6mNmBe+lcmm/cwwCtYvkL0rgL/OKB0liFhhRIqy2TPg08op/\n" +
-            "RlY2DdbgBA2B3g7wdMo0hK3SO56/QUccUtLRm43km9Yd4E3U+CEUyDd0Bmc/YbPa\n" +
-            "htuXVsXJwiwlwooomujIIENhFw3htdcsu2apRj8EYUrKL8Mvvn+h16gDyobj0f01\n" +
-            "jWXlUgmH2lzUzca5eGuphfvmWN/ME/yqC2mMvWGnWySycqtT8VdJAgMBAAGjggFj\n" +
-            "MIIBXzAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0OBBYEFFENOZBwFkjVdQX0iK32c77z\n" +
-            "SUl6MB8GA1UdIwQYMBaAFGLUQl6GcHVqkLzGuNJNYMI0ulE6MB0GA1UdJQQWMBQG\n" +
-            "CCsGAQUFBwMBBggrBgEFBQcDAjB1BggrBgEFBQcBAQRpMGcwLQYIKwYBBQUHMAGG\n" +
-            "IWh0dHA6Ly9vY3NwLnNjYTFhLmFtYXpvbnRydXN0LmNvbTA2BggrBgEFBQcwAoYq\n" +
-            "aHR0cDovL2NydC5zY2ExYS5hbWF6b250cnVzdC5jb20vc2NhMWEuY2VyMCUGA1Ud\n" +
-            "EQQeMByCGmdvb2Quc2NhMWEuYW1hem9udHJ1c3QuY29tMFAGA1UdIARJMEcwDQYL\n" +
-            "YIZIAYb9bgEHGAMwNgYFZ4EMAQEwLTArBggrBgEFBQcCARYfaHR0cHM6Ly93d3cu\n" +
-            "YW1hem9udHJ1c3QuY29tL2NwczANBgkqhkiG9w0BAQsFAAOCAQEAmn7z6Ub1sL77\n" +
-            "wyUEaCq/Odqm+2RtYYMJ1MeW6nTXTfAgZ/iLx/6hStafd9AK9gHiTCggBpj6KgnF\n" +
-            "UsGMDeX879jP675fH6SEk710QPDhIrfAzwE0pF/eUNsd7pLwne32zHX0ouCoAt4d\n" +
-            "KwBCZkKNUkdj4U+bpOJzvtcTP9JlzziLp9IFRjjQh3xKgfblx57CmRJbqH3fT5JJ\n" +
-            "IAIDVTz3ZUcqhPTFAnNsO1oNBEyrO5X9rwCiSy7aRijY/11R75mIIvyA9zyd9ss1\n" +
-            "kvrrER0GWMTDvC84FZD2vhkXgPTFrB1Dn9f3QgO5APT9GCFY5hdpqqPEXOSdRzQo\n" +
-            "h9j4OQAqtA==\n" +
+            "ZXIgQ0EgMUExDzANBgNVBAMTBkFtYXpvbjAeFw0yMTEyMTcyMDIxNTBaFw0yMzAx\n" +
+            "MTcyMDIxNTBaMCUxIzAhBgNVBAMTGmdvb2Quc2NhMWEuYW1hem9udHJ1c3QuY29t\n" +
+            "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5SadXE1HIzUp4ob40roo\n" +
+            "qBiJy57vLcZklkWoxRU2JtIauuZUl8fLT/KOjzW71fqMMTxnvEbtKtRtZKDFjrg7\n" +
+            "uPf8Q1J9tqxme6iFlrBlou+moQQ7Spi3H9q7v08vX19XIREGIwHbicbxVujdeA0w\n" +
+            "G0fGMlw+Gs8GNiBQplr+oXC7i2CoPmwnR/T8iHjCEznKQIMxiZL4gOHLwh4EKdBA\n" +
+            "auirpTq0iXUtC2BcM/w1Zx1UTLu0idmclcxVSYE8hXfV8e7JGpNI1gCqkgrskof3\n" +
+            "A6CMCIH/D1VETFtGKn+gGWenWwnELmKuvHObQGXmcwOV3aXBdNFTmfzcshwqm/mE\n" +
+            "zQIDAQABo4IBJjCCASIwDgYDVR0PAQH/BAQDAgWgMB0GA1UdDgQWBBTURzXdgGMB\n" +
+            "tNyiP16WXB1oM2qqmzAfBgNVHSMEGDAWgBRi1EJehnB1apC8xrjSTWDCNLpROjAd\n" +
+            "BgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwdQYIKwYBBQUHAQEEaTBnMC0G\n" +
+            "CCsGAQUFBzABhiFodHRwOi8vb2NzcC5zY2ExYS5hbWF6b250cnVzdC5jb20wNgYI\n" +
+            "KwYBBQUHMAKGKmh0dHA6Ly9jcnQuc2NhMWEuYW1hem9udHJ1c3QuY29tL3NjYTFh\n" +
+            "LmNlcjAlBgNVHREEHjAcghpnb29kLnNjYTFhLmFtYXpvbnRydXN0LmNvbTATBgNV\n" +
+            "HSAEDDAKMAgGBmeBDAECATANBgkqhkiG9w0BAQsFAAOCAQEAVNyn7lB3IOstAJj+\n" +
+            "avkPfojb+QaUpFjnkKyb7c5kUBEWaaEl27W58OLoIHoEJvfOypv2bTq1fuIx9P88\n" +
+            "1HP7DrI7vBtfnAgyIjF2mzL6Jyt7buR7u/cXTO0fsl/uk3wfrJBl860/Nab+WYoj\n" +
+            "pvJm0b75WVnU30Khy/xrhNfN2nvCJ5VMoHqV6KnKrMjA5KpdeTvVaIgyxtV6B8vY\n" +
+            "VsBbtzJ6n8mN7N8YkEkHV6TG7l+FVPHQdJFtD/qhTd5C4uu4XUehxOta894hLy6z\n" +
+            "8Mv9BGtmwyUIEd0KQQdkXrWx/iAq6zo0imAeN/s8tjqAzxnw6M5F9cDqjqkYqgXZ\n" +
+            "eIkPBA==\n" +
             "-----END CERTIFICATE-----";
 
-    // Owner: CN=revoked.sca1a.amazontrust.com, O=Amazon Trust Services, L=Seattle, ST=Washington, C=US, \
-    // SERIALNUMBER=5846743, OID.2.5.4.15=PrivateOrganization, OID.1.3.6.1.4.1.311.60.2.1.2=Delaware, \
-    // OID.1.3.6.1.4.1.311.60.2.1.3=US
+    // Owner: CN=revoked.sca1a.amazontrust.com
     // Issuer: CN=Amazon, OU=Server CA 1A, O=Amazon, C=US
-    // Serial number: 6f1d774ad5e7b6d251d217661782bbdb6f37d
-    // Valid from: Mon Jan 28 15:34:38 PST 2019 until: Thu Apr 28 16:34:38 PDT 2022
+    // Serial number: 75a5de4434092b2cd6ed81eb5e6248e1e5f2a
+    // Valid from: Fri Dec 17 12:25:17 PST 2021 until: Tue Jan 17 12:25:17 PST 2023
     private static final String REVOKED = "-----BEGIN CERTIFICATE-----\n" +
-            "MIIE2zCCA8OgAwIBAgITBvHXdK1ee20lHSF2YXgrvbbzfTANBgkqhkiG9w0BAQsF\n" +
+            "MIIEJjCCAw6gAwIBAgITB1pd5ENAkrLNbtgeteYkjh5fKjANBgkqhkiG9w0BAQsF\n" +
             "ADBGMQswCQYDVQQGEwJVUzEPMA0GA1UEChMGQW1hem9uMRUwEwYDVQQLEwxTZXJ2\n" +
-            "ZXIgQ0EgMUExDzANBgNVBAMTBkFtYXpvbjAeFw0xOTAxMjgyMzM0MzhaFw0yMjA0\n" +
-            "MjgyMzM0MzhaMIHcMRMwEQYLKwYBBAGCNzwCAQMTAlVTMRkwFwYLKwYBBAGCNzwC\n" +
-            "AQITCERlbGF3YXJlMRwwGgYDVQQPExNQcml2YXRlT3JnYW5pemF0aW9uMRAwDgYD\n" +
-            "VQQFEwc1ODQ2NzQzMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQ\n" +
-            "MA4GA1UEBxMHU2VhdHRsZTEeMBwGA1UEChMVQW1hem9uIFRydXN0IFNlcnZpY2Vz\n" +
-            "MSYwJAYDVQQDEx1yZXZva2VkLnNjYTFhLmFtYXpvbnRydXN0LmNvbTCCASIwDQYJ\n" +
-            "KoZIhvcNAQEBBQADggEPADCCAQoCggEBANUoHop9sW+QlgVsdtacioraTAWHcSTd\n" +
-            "MNkOkOEMgJIFPyfdcDvW/H2NvpdYeIQqzaCgT2kcsONWTZTPJMirCPnzl1ohHOZU\n" +
-            "uTnOVkamGxvNmQCURLBXmlCMRTCI5RY3CuYntFFbSPAnbumsF+K/gKqcE6ME53Bw\n" +
-            "PAwn4qwavB0i5Ib7Jk8XYzxSYXC9l8QLxt6fshPJRlecpXzfmVFvMAm3IbaLcpuv\n" +
-            "AtD+8I2KwjNtBPRPNYeFsWxwsgUGAyHEGa61oTGUqqAXu5YmPfyK+YTOJdoofsh4\n" +
-            "Tf3K7AKxnPWuvY3RNTs1pzEVwJYZqSsNwbgyKJJ4+0Xe4iP7qB8SYf8CAwEAAaOC\n" +
-            "ASkwggElMA4GA1UdDwEB/wQEAwIFoDAdBgNVHQ4EFgQUGHreoz+LP/Wr+RKzuexO\n" +
-            "V8ICtmEwHwYDVR0jBBgwFoAUYtRCXoZwdWqQvMa40k1gwjS6UTowHQYDVR0lBBYw\n" +
-            "FAYIKwYBBQUHAwEGCCsGAQUFBwMCMHUGCCsGAQUFBwEBBGkwZzAtBggrBgEFBQcw\n" +
-            "AYYhaHR0cDovL29jc3Auc2NhMWEuYW1hem9udHJ1c3QuY29tMDYGCCsGAQUFBzAC\n" +
-            "hipodHRwOi8vY3J0LnNjYTFhLmFtYXpvbnRydXN0LmNvbS9zY2ExYS5jZXIwKAYD\n" +
-            "VR0RBCEwH4IdcmV2b2tlZC5zY2ExYS5hbWF6b250cnVzdC5jb20wEwYDVR0gBAww\n" +
-            "CjAIBgZngQwBAgEwDQYJKoZIhvcNAQELBQADggEBABSbe1UCLL7Qay6XK5wD8B5a\n" +
-            "wvR1XG3UrggpVIz/w5cutEm/yE71hzE0gag/3YPbNYEnaLbJH+9jz4YW9wd/cEPj\n" +
-            "xSK5PErAQjCd+aA4LKN1xqkSysgYknl0y47hJBXGnWf+hxvBBHeSoUzM0KIC21pC\n" +
-            "ZyXrmfaPCQAz13ruYIYdQaETqXGVORmKbf/a+Zn18/tfQt0LeeCYVoSopbXWQvcJ\n" +
-            "gUMtdIqYQmb8aVj0pdZXwKl4yZ2DtlS3Z9MpWNgQNlhRPmiYlu28y2yTtZ9SwD6m\n" +
-            "2f+cwc19aJrDT4Y280px+jRU7dIE6oZVJU+yBRVIZYpUFAB7extCMVxnTkCf8Dk=\n" +
+            "ZXIgQ0EgMUExDzANBgNVBAMTBkFtYXpvbjAeFw0yMTEyMTcyMDI1MTdaFw0yMzAx\n" +
+            "MTcyMDI1MTdaMCgxJjAkBgNVBAMTHXJldm9rZWQuc2NhMWEuYW1hem9udHJ1c3Qu\n" +
+            "Y29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqYk4ZkF9yJgRa0fL\n" +
+            "96gmxwlJlyvsQmqumxUGw0u1L+nDgGMFD1bHILOw2AO+feNy8kuTnJVb+zN+2f6l\n" +
+            "rMGM1sGKh8W/ZRIdvmcdeZ2kEDyxLotMRXDQ6hJXDj30DSAYNkdqairJItdcev8+\n" +
+            "t9LRRNRQwL0sXf5FITQPBnlVCrF9Q42p9hhYUhvsS8jSWPIvUbZajOXKs6AfxyPV\n" +
+            "2Q7TybgnRlawznXxflPzXRMpCSQZ9WdI/kYbFOjDNtYA05EI4d8IYm+C5U1eJT30\n" +
+            "dKFeU0xzFsrPirzifFMPIhXKxS5rUELuFRUq4sFTN28Sj7Ij/rr+O9Im8jJZq0lo\n" +
+            "bqLoQwIDAQABo4IBKTCCASUwDgYDVR0PAQH/BAQDAgWgMB0GA1UdDgQWBBRugPQP\n" +
+            "CWEwQp0pw2dEMw/gT7F4gzAfBgNVHSMEGDAWgBRi1EJehnB1apC8xrjSTWDCNLpR\n" +
+            "OjAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwdQYIKwYBBQUHAQEEaTBn\n" +
+            "MC0GCCsGAQUFBzABhiFodHRwOi8vb2NzcC5zY2ExYS5hbWF6b250cnVzdC5jb20w\n" +
+            "NgYIKwYBBQUHMAKGKmh0dHA6Ly9jcnQuc2NhMWEuYW1hem9udHJ1c3QuY29tL3Nj\n" +
+            "YTFhLmNlcjAoBgNVHREEITAfgh1yZXZva2VkLnNjYTFhLmFtYXpvbnRydXN0LmNv\n" +
+            "bTATBgNVHSAEDDAKMAgGBmeBDAECATANBgkqhkiG9w0BAQsFAAOCAQEAQF9QvedW\n" +
+            "gqD5LPsZ5cg+DkGFBVqhWgsvp8so4gmKHklSHvisEek/Yfi7tvHCUAP2P0MuV/49\n" +
+            "O2A+1tXQL1+hVM1auSfDOQdUy4xsKSWV+PofQe82iz+6dwRf+HNgOtyNcQ6aGD3t\n" +
+            "87DXnJPkBTEPHGxDkjnOwurSffaV1m00bxfb6T1Txvyjs9ClnZf68Jv6oj+2rbs1\n" +
+            "+TqKXP0Ma3AgXB37Cq2ozYzpAxy9GBIKIahGX2d2qsuZ2aj6XwJwUayIuU0WTOHK\n" +
+            "eeXvKS2uvY9UaIvTeepSWXyAbBMKagQhgAtf3X6ILodQi5Gk7lCuY48oArKziTgN\n" +
+            "vB7mK7JqaM2P4g==\n" +
             "-----END CERTIFICATE-----";
 
     public void runTest(ValidatePathWithParams pathValidator, boolean ocspEnabled) throws Exception {
@@ -188,7 +176,7 @@ class AmazonCA_1 {
         // Validate Revoked
         pathValidator.validate(new String[]{REVOKED, INT},
                 ValidatePathWithParams.Status.REVOKED,
-                "Mon Jan 28 15:35:56 PST 2019", System.out);
+                "Fri Dec 17 12:28:05 PST 2021", System.out);
     }
 }
 
@@ -235,97 +223,84 @@ class AmazonCA_2 {
             "o5LAuRo/LO1xVRH49KFRoaznzU3Ch9+kbPb3\n" +
             "-----END CERTIFICATE-----";
 
-    // Owner: CN=good.sca2a.amazontrust.com, O=Amazon Trust Services, L=Seattle, ST=Washington, C=US, \
-    // SERIALNUMBER=5846743, OID.2.5.4.15=Private Organization, OID.1.3.6.1.4.1.311.60.2.1.2=Delaware, \
-    // OID.1.3.6.1.4.1.311.60.2.1.3=US
+    // Owner: CN=good.sca2a.amazontrust.com
     // Issuer: CN=Amazon, OU=Server CA 2A, O=Amazon, C=US
-    // Serial number: 703e4e70616c90d611fd04a5ecc635665184e
-    // Valid from: Mon Jul 29 16:54:06 PDT 2019 until: Sat Aug 29 16:54:06 PDT 2020
+    // Serial number: 75a5dd7d82269ed466af69794f34050bdffa2
+    // Valid from: Fri Dec 17 12:22:32 PST 2021 until: Tue Jan 17 12:22:32 PST 2023
     private static final String VALID = "-----BEGIN CERTIFICATE-----\n" +
-            "MIIHEzCCBPugAwIBAgITBwPk5wYWyQ1hH9BKXsxjVmUYTjANBgkqhkiG9w0BAQwF\n" +
+            "MIIGIDCCBAigAwIBAgITB1pd19giae1GavaXlPNAUL3/ojANBgkqhkiG9w0BAQwF\n" +
             "ADBGMQswCQYDVQQGEwJVUzEPMA0GA1UEChMGQW1hem9uMRUwEwYDVQQLEwxTZXJ2\n" +
-            "ZXIgQ0EgMkExDzANBgNVBAMTBkFtYXpvbjAeFw0xOTA3MjkyMzU0MDZaFw0yMDA4\n" +
-            "MjkyMzU0MDZaMIHaMRMwEQYLKwYBBAGCNzwCAQMTAlVTMRkwFwYLKwYBBAGCNzwC\n" +
-            "AQITCERlbGF3YXJlMR0wGwYDVQQPExRQcml2YXRlIE9yZ2FuaXphdGlvbjEQMA4G\n" +
-            "A1UEBRMHNTg0Njc0MzELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24x\n" +
-            "EDAOBgNVBAcTB1NlYXR0bGUxHjAcBgNVBAoTFUFtYXpvbiBUcnVzdCBTZXJ2aWNl\n" +
-            "czEjMCEGA1UEAxMaZ29vZC5zY2EyYS5hbWF6b250cnVzdC5jb20wggIiMA0GCSqG\n" +
-            "SIb3DQEBAQUAA4ICDwAwggIKAoICAQC+XjOB3ZCFX+b9y9reP+e6EAQz4ytiMSqU\n" +
-            "O4s5MyYLkY6n4BIZHmgWeQ2IgW1VrH8ho+Iu3UsTiuhd3/L/q/w+T0OJfcrWngTs\n" +
-            "uVcIuvUr32ObPeeWbg/m/lkN7hqH1jY62iybYVrFXiLo1+0G92PUazcyNvyA20+G\n" +
-            "HsvGG5jlArWNgRLdc8KUXxvnDUxx5vu4jeHEZnqSwuulV1h9ve0UutkmoK0Sk7Rz\n" +
-            "HMxYK0LmUT5OvcNQSkUi5nLi+M1FxnYYgsELwSiKSSEDfEdgxooMAiVTgw51Q/DB\n" +
-            "lTOjAIDL3K3J0yGfIG3bwLvE1qz2Z5yWn8f3JibIah7LrC4PiZDDLHFM6V9l+YqU\n" +
-            "RqimJ5BltSyAx7bxQNZ1AW3Lxvvm894i4k6/Vdf1CDovRuTMPCDAQmKA/A/AQ7TN\n" +
-            "q3bBimX6UyuJu0I8RyvAYKzFhOOqe4vXrbndTbje/jnzTNQPeIIcuRa9cgXTOrbw\n" +
-            "86FTUKj6AZXihRWjKWsQpDwdgE0tQETZ3ynCXfbBKfFmn0MSjeX0CEEAZdYHR8EV\n" +
-            "F271Yt7UJjS/FP702aHTOWk7zFbIRfFQODvBhn0I8p/Stk2sDq4/YsbXVZOe3+ad\n" +
-            "YavoiODGSAH6ZcZzULumgK9eii0koAOPB/xqXnkcTS63gEHOKjLQl3hqdVZRCugv\n" +
-            "1CwUXLvoSwIDAQABo4IBYzCCAV8wDgYDVR0PAQH/BAQDAgWgMB0GA1UdDgQWBBTa\n" +
-            "j6dHgPdOxTGLcwaNDeaMnlSxNjAfBgNVHSMEGDAWgBTaQ0rQ/AHAS79YJ4x2zQqB\n" +
-            "85Qu9DAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwdQYIKwYBBQUHAQEE\n" +
-            "aTBnMC0GCCsGAQUFBzABhiFodHRwOi8vb2NzcC5zY2EyYS5hbWF6b250cnVzdC5j\n" +
-            "b20wNgYIKwYBBQUHMAKGKmh0dHA6Ly9jcnQuc2NhMmEuYW1hem9udHJ1c3QuY29t\n" +
-            "L3NjYTJhLmNlcjAlBgNVHREEHjAcghpnb29kLnNjYTJhLmFtYXpvbnRydXN0LmNv\n" +
-            "bTBQBgNVHSAESTBHMA0GC2CGSAGG/W4BBxgDMDYGBWeBDAEBMC0wKwYIKwYBBQUH\n" +
-            "AgEWH2h0dHBzOi8vd3d3LmFtYXpvbnRydXN0LmNvbS9jcHMwDQYJKoZIhvcNAQEM\n" +
-            "BQADggIBAE6RwZAZvN0i9ygwzqoX9DhSPtvZ3xIO0G0Bhgjkb986+p8XJstU3gEM\n" +
-            "8P2i1J/YthXCnRGedm+Odxx+31G6xIYfP5S5g7HyRGkj/aXNXy4s3KjH8HJgOY9N\n" +
-            "ra3XfC05OKq5FpyZQDZ+hxCdLrH3Gs+UxREbu+LuIKUpI7nMVEjn9XynKyOdKN21\n" +
-            "Kq5VsuI0fDWCYvUN1M+lI/LgE5HbNJVQJs+dB7g1/kaOeaLia7Wk1ys+uRzB58rp\n" +
-            "FKAoLk++HWTfNDkbN8vKRfHhJ/xhI9ju3TWcci6EyFVAym1C62UkJNI0KHgQ+zc7\n" +
-            "nl1tv/ytj8N/eJoysyp23lJ5qrVetlQORfgXryGkWBMYBvYF8zbBb/f+UXHDKVWt\n" +
-            "9l1lL6HQGY/tTo253pj6/FgDD35bZdjLQeUVmbnz679S5oUmoH5ZtSdnpUTghU3p\n" +
-            "bae9adBFY9S1pm50Q3ckRVBAwNqNmI0KKUh14Ms8KSAUHg19NvGsBonqwOT2rdbv\n" +
-            "xZ47N6c2eCl/cjMvzre0v0NoUO+3og2GHeAoOwVos6480YDbMqp739tOFPxBcsII\n" +
-            "6SjpDVh+14dkSW6kEKeaCFLR+eChqutri1VQbQ49nmADQWw9Al8vBytSnPv0YN6W\n" +
-            "XfIE1Qj7YmHu/UuoeKVsqDqoP/no29+96dtfd4afJqlIoyZUqXpt\n" +
+            "ZXIgQ0EgMkExDzANBgNVBAMTBkFtYXpvbjAeFw0yMTEyMTcyMDIyMzJaFw0yMzAx\n" +
+            "MTcyMDIyMzJaMCUxIzAhBgNVBAMTGmdvb2Quc2NhMmEuYW1hem9udHJ1c3QuY29t\n" +
+            "MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAsCQonlc6fSTDJbH2y6wC\n" +
+            "mLeTD3noluSM4LPO53RgLTUvNqrxh/iy9jDGgYP2xN8GGngRI8C65jZqGpJb0Hcp\n" +
+            "ADYssYKWcTR5OH8rUVsJ6DkJLx0AUOG+iJcCaqPudkw7WBReFEok7E058gCTbXps\n" +
+            "kNRT3w92CzzXa+49yxaAP0I6AQ9BqZP6gbAR1hmd9BDMCdak1JIswGVC3wGAKJFi\n" +
+            "c3FS3YeY7VyuXofeEwutvMH4Iag9DZU2puqskrGSmtrVju8CY6w1E/cmBWD9kfpu\n" +
+            "Qet2LBZuzmws8XhCjU5cHOeA8pg2m7ZnyNBeZajg4hrbPq8ACjjDmEHiDgazoOGN\n" +
+            "1mV1BXZ2qonK+zJAMqE/L0czEPjdROaF786pPY5Cpi1Rzk0R3KKjGhSHgzfCa2eX\n" +
+            "cQjBtA7AxLkK+1cI18hYg+okaV+EBrkxXGzeyTjvWbliotIQ9utabXGqJvJtIDeX\n" +
+            "OQSdSXlBKgwGTE5/Ju8/6NkJgSMEku/Q9SYvfkzPXrj5VAHgPz4KhholeC4A4hRd\n" +
+            "Y3Xtr/U5Xr3fTzLdOcLDKYW4/OGCl8byjwx8bqO7q8YmgDg572Go3gUbNmlm2QN+\n" +
+            "NaXhBhPrl4KoHzawApTcod3adhSQziIMGjKYoKhV+ZGNoaLe7IUX0jyX3zygRS6k\n" +
+            "n6yeyeh1unDfqSvne9+hDEsCAwEAAaOCASYwggEiMA4GA1UdDwEB/wQEAwIFoDAd\n" +
+            "BgNVHQ4EFgQU71fB1r7/l2pFd0ydSNEiGaD+9uIwHwYDVR0jBBgwFoAU2kNK0PwB\n" +
+            "wEu/WCeMds0KgfOULvQwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMHUG\n" +
+            "CCsGAQUFBwEBBGkwZzAtBggrBgEFBQcwAYYhaHR0cDovL29jc3Auc2NhMmEuYW1h\n" +
+            "em9udHJ1c3QuY29tMDYGCCsGAQUFBzAChipodHRwOi8vY3J0LnNjYTJhLmFtYXpv\n" +
+            "bnRydXN0LmNvbS9zY2EyYS5jZXIwJQYDVR0RBB4wHIIaZ29vZC5zY2EyYS5hbWF6\n" +
+            "b250cnVzdC5jb20wEwYDVR0gBAwwCjAIBgZngQwBAgEwDQYJKoZIhvcNAQEMBQAD\n" +
+            "ggIBAKULtBRmu4CtBTfBG6hXkBdFGneJlomw02h8dj7xkXof+DoLYtkuJ6XRp89f\n" +
+            "9UgYJMBjwKaAFjZzcVYvTd8YKdXzCXy4phxuHTfaV6ZH0WyvOlcTXsfdhJA4oD1G\n" +
+            "prB4/PaymwSbv8ZQAE3eg1hytLLlR9+YUS0HfpwaH/PIa0TzKG8Vuu5zKGSlJjeh\n" +
+            "Thp/uMBC4twM558Jv2sxoUA5HjgPUyZW7r2eLFbOM1H4oR1US5zFYgzrEK1W12DO\n" +
+            "t65mI2YHbDepm5FoizwWYe4uaDCqWjCgzQw8pMGoiDABMaoNQ83Zi8r2sLGibAlb\n" +
+            "cVLcjsORsF6TNmYTW1KDT/9hXlOaAhFwfAwKg6cZw51WEg51sPdi5USk/oszavc5\n" +
+            "Ft/IZaWSfkA1Xm0EyFwOwCOvGJIb9PWv5PfGZz4xnZlWhp6LfN31e3TagTUbzLVX\n" +
+            "XwbDI1cofCl18z6pidXXCASBCAajQ8N4GxNP6qqX9ou0yOBEXxwVqIJLcu3tueCI\n" +
+            "3Cb3rWfbybAVhuuP2ERKHJMY8XDCt0O/g8Kj6O69NABOWvNkU3ARzszGzgBfv4IR\n" +
+            "jJJEskjxX7Q085iXlaRX/mu+TpTkqK1ZbpBB1Z2PeVMujP+qsWSWGTZBXuI8eqyU\n" +
+            "dhq+VlyoVtWeMqKYMtakCJxnhwMZnn0sTzZk/Yno+k9Jn0Rk\n" +
             "-----END CERTIFICATE-----";
 
-    // Owner: CN=revoked.sca2a.amazontrust.com, O=Amazon Trust Services, L=Seattle, ST=Washington, C=US, \
-    // SERIALNUMBER=5846743, OID.2.5.4.15=PrivateOrganization, OID.1.3.6.1.4.1.311.60.2.1.2=Delaware, \
-    // OID.1.3.6.1.4.1.311.60.2.1.3=US
-    //Issuer: CN=Amazon, OU=Server CA 2A, O=Amazon, C=US
-    //Serial number: 6f1d782c0aa2f4866b7b522c279b939b92369
-    //Valid from: Mon Jan 28 15:37:45 PST 2019 until: Thu Apr 28 16:37:45 PDT 2022
+    // Owner: CN=revoked.sca2a.amazontrust.com
+    // Issuer: CN=Amazon, OU=Server CA 2A, O=Amazon, C=US
+    // Serial number: 75a5df2d3387cfe5fd4cad9ff00f8c882b98d
+    // Valid from: Fri Dec 17 12:28:31 PST 2021 until: Tue Jan 17 12:28:31 PST 2023
     private static final String REVOKED = "-----BEGIN CERTIFICATE-----\n" +
-            "MIIG2zCCBMOgAwIBAgITBvHXgsCqL0hmt7Uiwnm5ObkjaTANBgkqhkiG9w0BAQwF\n" +
+            "MIIGJjCCBA6gAwIBAgITB1pd8tM4fP5f1MrZ/wD4yIK5jTANBgkqhkiG9w0BAQwF\n" +
             "ADBGMQswCQYDVQQGEwJVUzEPMA0GA1UEChMGQW1hem9uMRUwEwYDVQQLEwxTZXJ2\n" +
-            "ZXIgQ0EgMkExDzANBgNVBAMTBkFtYXpvbjAeFw0xOTAxMjgyMzM3NDVaFw0yMjA0\n" +
-            "MjgyMzM3NDVaMIHcMRMwEQYLKwYBBAGCNzwCAQMTAlVTMRkwFwYLKwYBBAGCNzwC\n" +
-            "AQITCERlbGF3YXJlMRwwGgYDVQQPExNQcml2YXRlT3JnYW5pemF0aW9uMRAwDgYD\n" +
-            "VQQFEwc1ODQ2NzQzMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQ\n" +
-            "MA4GA1UEBxMHU2VhdHRsZTEeMBwGA1UEChMVQW1hem9uIFRydXN0IFNlcnZpY2Vz\n" +
-            "MSYwJAYDVQQDEx1yZXZva2VkLnNjYTJhLmFtYXpvbnRydXN0LmNvbTCCAiIwDQYJ\n" +
-            "KoZIhvcNAQEBBQADggIPADCCAgoCggIBAKFm418X8hN1YTgD2XpMb4sp78mw8k3j\n" +
-            "Dq/vnpX48evVUzNpHpy4qRz/ZHBR4HUJO4lhfnX+CO0uRqqqx4F0JZRQB3KevaU8\n" +
-            "QGWHdJGhEddnurDhrgOUa+ZroqUnMCsTJfbyGtC6aiEXeu/eMhEUFkuBxJH1JtwD\n" +
-            "dQXMXuMjG07SVjOkhTkbMDzA/YbUqkDeOIybifDuvA5LEsl+kReY0b6RYFo2Tt/M\n" +
-            "dPhJD8q3Wsu+XCiCnbpcwlEVGxiD2RVRXJJ9o3ALGOxqU69V+lYS0kkwNHT7oV9J\n" +
-            "rhgt7iOCq0aoTAxu2j4FCp0JHNhGoW9pXoMXnmS6kK80hzLNYDxvKEaVaKkiYHw5\n" +
-            "CV0Vwii05ICa14nrStH/jcRNLyU+gp+6OeerPV3jpKWshGKWewF+2UiWU2WHTSrd\n" +
-            "Wis0/qEfFK/kSraAxpd+KavEEavKeudoMAHIxMACOk9E/fF5zhd2y4G1q1BdoRlR\n" +
-            "KP4GIV2v6qH6Ru2mNSuge9il6kDXxFNucrYKLDbAqkqalohkvDavcPoG9gZT3etv\n" +
-            "4IcgJriIWRxbJwKPpwJM+6wa6RpwoeJMuEp3ZBP7KDaQ8YX4rlf4zXLAsOKCNA9K\n" +
-            "OS/qYQ/I4g0E1WhfgEKClaLPS2u7jeVR6s1t4txGo4vq5Dkt17KTCew/WsX3rckf\n" +
-            "a2p5zvFcfpCNAgMBAAGjggEpMIIBJTAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0OBBYE\n" +
-            "FAF8N1wV8EoYFkMXH6tEnmR/7vI+MB8GA1UdIwQYMBaAFNpDStD8AcBLv1gnjHbN\n" +
-            "CoHzlC70MB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjB1BggrBgEFBQcB\n" +
-            "AQRpMGcwLQYIKwYBBQUHMAGGIWh0dHA6Ly9vY3NwLnNjYTJhLmFtYXpvbnRydXN0\n" +
-            "LmNvbTA2BggrBgEFBQcwAoYqaHR0cDovL2NydC5zY2EyYS5hbWF6b250cnVzdC5j\n" +
-            "b20vc2NhMmEuY2VyMCgGA1UdEQQhMB+CHXJldm9rZWQuc2NhMmEuYW1hem9udHJ1\n" +
-            "c3QuY29tMBMGA1UdIAQMMAowCAYGZ4EMAQIBMA0GCSqGSIb3DQEBDAUAA4ICAQBC\n" +
-            "VwR1NFk1IYIF4cjU7ML1aj8OIn+8mtakGQnuSJLK6ypSysINJBS48ZDdP6XZXvyD\n" +
-            "iTS0xEAPjAZHTqrABdNYmvJeL2RnN99DIwVzBpZp4NLTXbiSW7jb0Y5cEPDGJMOo\n" +
-            "SUAAM6fsiPRfz5vX4XVPznbcF2AwE/NVV+L3n9LVRt7qv2VqIEvLioR56Dq+5ofR\n" +
-            "4bw0BVlEYWF4Gsy7WDDTL1iLNBUwZTqBHwTv0fgDRiPqb/odmLQuRANwcJy8B8Zr\n" +
-            "s/yX4SeESaRdA82lAlQilksQitXS2qvQN06GEDOgUxYE6EabFdgklV5JypKqdOly\n" +
-            "vzpaDpF3z5W8Bj3D4fns1Kjrh1pPh5JRvg+616diKnQRt4X5q+EtmnXhDvIGMISI\n" +
-            "FuGwj57CNQ2x2MY2HHKWPrOccpQfEEvoSNR+ntYWrtSSttZq948O+zZBk1TXWuXV\n" +
-            "TVXllqTg8lp6d5cfKgvtHKgt98WkpPOcLVrNuVnMAIfDw6ar54dVKqrvkeEcF6mJ\n" +
-            "7oMKjJX/Vu9lYoGViBIfdeqcCPWSI8BpnCKaG7dTQO3Q1ObGmLdGBRlsRh+d+S5l\n" +
-            "Fq326ckbjx537e5/ai31lOR7OwVh9TDweKLqIACjs987C0EJSEfoOue25WRww2va\n" +
-            "iX9SrTPm4GxQ2OJgYwx0+HbezJXFN+dhaOFUavTSFw==\n" +
+            "ZXIgQ0EgMkExDzANBgNVBAMTBkFtYXpvbjAeFw0yMTEyMTcyMDI4MzFaFw0yMzAx\n" +
+            "MTcyMDI4MzFaMCgxJjAkBgNVBAMTHXJldm9rZWQuc2NhMmEuYW1hem9udHJ1c3Qu\n" +
+            "Y29tMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAu/9+ky4Z5U24pBYd\n" +
+            "6xyb1BGQHTXS5nW8QjLWx+xaunRitgIBB8ZZ8OzUmH2mp2S/9Vq1nqii9TvuzA9K\n" +
+            "JJQZLK8K+OJX/ZwFdSxTgLcyeJ9cCswj/C3SBA1NopZ3DmEWeXlh7aZhl8IXB6kp\n" +
+            "zI87Tg72F2JJokWNPYdx7xXhf/WVeDeNRkz1iE5UTwL+qaNuzT7S8BdnFWqa3l4a\n" +
+            "Q1J/YVww0XRhsYJulNVGhoKNf71q8KWw8hJ/zgMxrBFywu7d3OBw6NX3bowZ+jMQ\n" +
+            "apJEWiwUYOjH3XcOO6TiChwQMypBrcbGgrD/msTlvIBinHwpWaAgX0kT80+wH1Bq\n" +
+            "mw72fEjeE/Y6EL6WIUr1HQdLhvBDxtPgxnAaxptmg126cF4jV/e+D+IGf6qpN1gR\n" +
+            "JQC/0+AnASAJ0cGKjSODbl5miqtc0kFSReMsOJeT7gdoPCMg4gWyo62GSvdaAA0I\n" +
+            "DA8a0HWLAzXU7SwbytTUTYeVI8QeNm2ZGKvMoHDWSDz69V6gGmNl/YSvyJ2zPOZL\n" +
+            "8oRKRUCOA2LPdK0s7nebe0EBXF09FzzE4HdegRe7r86t6FE400W4wxwJjvjdHXcF\n" +
+            "s9fI+mgofMvVuK2u3wTdHOrEbfm1GXmj3BlFBORUI11A7K0lmIA02M2jkAN13foe\n" +
+            "rFLYg+28UjT4aN62zkynKD1iNwkCAwEAAaOCASkwggElMA4GA1UdDwEB/wQEAwIF\n" +
+            "oDAdBgNVHQ4EFgQUOzuuTB9A8p71qwA3qxqOABf69nkwHwYDVR0jBBgwFoAU2kNK\n" +
+            "0PwBwEu/WCeMds0KgfOULvQwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMC\n" +
+            "MHUGCCsGAQUFBwEBBGkwZzAtBggrBgEFBQcwAYYhaHR0cDovL29jc3Auc2NhMmEu\n" +
+            "YW1hem9udHJ1c3QuY29tMDYGCCsGAQUFBzAChipodHRwOi8vY3J0LnNjYTJhLmFt\n" +
+            "YXpvbnRydXN0LmNvbS9zY2EyYS5jZXIwKAYDVR0RBCEwH4IdcmV2b2tlZC5zY2Ey\n" +
+            "YS5hbWF6b250cnVzdC5jb20wEwYDVR0gBAwwCjAIBgZngQwBAgEwDQYJKoZIhvcN\n" +
+            "AQEMBQADggIBALAPC6I/k/WqJ8dxt7yhhSKA5RyGjd16kh+zq57Cjy0Wmj3BtSFJ\n" +
+            "l0652ULeHZDjhtEAEMFlWdxuuUJ82UhzPzujeVv5e8CLROYWp52Jb9CFPTwF54ow\n" +
+            "0a6recetYvOHBTeQ0cmo3nY6Z8eHDRUdk/aGQku1cesntFOIWm+EDj7SDYnUm3Ub\n" +
+            "ECdMv8entU5yjo/herVNMT6GGnKfjRxM0FWJWoHKKC/EPIka34VN6LOZO4Ftl9wI\n" +
+            "Ms7w3EgweEqLOyaGSAFwzrcQwKkPBm8fW5CefDtB64CtC8NUuo+XOQ2/JlRnWGLk\n" +
+            "CHxesJBUNk5c/IBDPLmyrKCLbGUqwsehQGQdSrLIH0857pTJi30D+/KDvgQynaay\n" +
+            "zPWLrSJvXUOQ9Vir+RQtbiMOqUDXX15Vty2mxLqjos1zCAxgrorZ7H2OSBZIWYzE\n" +
+            "8UgF1/vOlAtMjYyLLgb2UyqAY2HybKjtYYAyV/oIPjVRXygaOGkDZseqqXuslq5I\n" +
+            "ZSDU5hF6Hy6D6gsCVdshswwuRg39248M79qsMDw0Xa7xGcwqdfwTHv4Rb3G/kTrA\n" +
+            "8iR2YP/RdABKkTkUKRXs0kYPFoJ0wQPDD5slkLjdZNeezoNrw1rWEEUh1iildiRA\n" +
+            "i1p+pwXSyZ+m5Gv0/W84DDhLmAdvFov5muga8UccNbHuObtt1vHIhHe1\n" +
             "-----END CERTIFICATE-----";
 
     public void runTest(ValidatePathWithParams pathValidator, boolean ocspEnabled) throws Exception {
@@ -344,7 +319,7 @@ class AmazonCA_2 {
         // Validate Revoked
         pathValidator.validate(new String[]{REVOKED, INT},
                 ValidatePathWithParams.Status.REVOKED,
-                "Mon Jan 28 15:38:57 PST 2019", System.out);
+                "Fri Dec 17 12:29:36 PST 2021", System.out);
     }
 }
 
@@ -372,59 +347,46 @@ class AmazonCA_3 {
             "WSQ6F6JHLoeOWLyFFF658eNKEKbkEGMHz34gLX/N3g==\n" +
             "-----END CERTIFICATE-----";
 
-    // Owner: CN=good.sca3a.amazontrust.com, O=Amazon Trust Services, L=Seattle, ST=Washington, C=US, \
-    // SERIALNUMBER=5846743, OID.2.5.4.15=Private Organization, OID.1.3.6.1.4.1.311.60.2.1.2=Delaware, \
-    // OID.1.3.6.1.4.1.311.60.2.1.3=US
+    // Owner: CN=good.sca3a.amazontrust.com
     // Issuer: CN=Amazon, OU=Server CA 3A, O=Amazon, C=US
-    // Serial number: 703e4e9bbc2605f37967a0e95f31f4789a677
-    // Valid from: Mon Jul 29 16:54:43 PDT 2019 until: Sat Aug 29 16:54:43 PDT 2020
+    // Serial number: 75a5dd9ec12f37f4bbed4bada4b75164a642f
+    // Valid from: Fri Dec 17 12:23:00 PST 2021 until: Tue Jan 17 12:23:00 PST 2023
     private static final String VALID = "-----BEGIN CERTIFICATE-----\n" +
-            "MIIDhzCCAy2gAwIBAgITBwPk6bvCYF83lnoOlfMfR4mmdzAKBggqhkjOPQQDAjBG\n" +
+            "MIIClDCCAjqgAwIBAgITB1pd2ewS839LvtS62kt1FkpkLzAKBggqhkjOPQQDAjBG\n" +
             "MQswCQYDVQQGEwJVUzEPMA0GA1UEChMGQW1hem9uMRUwEwYDVQQLEwxTZXJ2ZXIg\n" +
-            "Q0EgM0ExDzANBgNVBAMTBkFtYXpvbjAeFw0xOTA3MjkyMzU0NDNaFw0yMDA4Mjky\n" +
-            "MzU0NDNaMIHaMRMwEQYLKwYBBAGCNzwCAQMTAlVTMRkwFwYLKwYBBAGCNzwCAQIT\n" +
-            "CERlbGF3YXJlMR0wGwYDVQQPExRQcml2YXRlIE9yZ2FuaXphdGlvbjEQMA4GA1UE\n" +
-            "BRMHNTg0Njc0MzELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAO\n" +
-            "BgNVBAcTB1NlYXR0bGUxHjAcBgNVBAoTFUFtYXpvbiBUcnVzdCBTZXJ2aWNlczEj\n" +
-            "MCEGA1UEAxMaZ29vZC5zY2EzYS5hbWF6b250cnVzdC5jb20wWTATBgcqhkjOPQIB\n" +
-            "BggqhkjOPQMBBwNCAARl4yxf8XcvWR0LZ+YuBC0CpkwtU2NiMdlIM7eX0lxhQp53\n" +
-            "NpLlCrPRNzOWrjCJDdn21D0u7PrtN94UHLHOg9X0o4IBYzCCAV8wDgYDVR0PAQH/\n" +
-            "BAQDAgeAMB0GA1UdDgQWBBT2cHmOJFLWfg1Op7xAdAnqYcwaPzAfBgNVHSMEGDAW\n" +
-            "gBQE3OCV5ei5a5Sh74xbMR4TflWX2jAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYB\n" +
-            "BQUHAwIwdQYIKwYBBQUHAQEEaTBnMC0GCCsGAQUFBzABhiFodHRwOi8vb2NzcC5z\n" +
-            "Y2EzYS5hbWF6b250cnVzdC5jb20wNgYIKwYBBQUHMAKGKmh0dHA6Ly9jcnQuc2Nh\n" +
-            "M2EuYW1hem9udHJ1c3QuY29tL3NjYTNhLmNlcjAlBgNVHREEHjAcghpnb29kLnNj\n" +
-            "YTNhLmFtYXpvbnRydXN0LmNvbTBQBgNVHSAESTBHMA0GC2CGSAGG/W4BBxgDMDYG\n" +
-            "BWeBDAEBMC0wKwYIKwYBBQUHAgEWH2h0dHBzOi8vd3d3LmFtYXpvbnRydXN0LmNv\n" +
-            "bS9jcHMwCgYIKoZIzj0EAwIDSAAwRQIgURdcqJVr4PWNIkmWcSKmzgZ1i94hQpGe\n" +
-            "mWbE9osk4m0CIQDhxIguihwvDa5RsBwdM0aRDgGKLNHigGqJoKqgH0d2qg==\n" +
+            "Q0EgM0ExDzANBgNVBAMTBkFtYXpvbjAeFw0yMTEyMTcyMDIzMDBaFw0yMzAxMTcy\n" +
+            "MDIzMDBaMCUxIzAhBgNVBAMTGmdvb2Quc2NhM2EuYW1hem9udHJ1c3QuY29tMFkw\n" +
+            "EwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE275wkVMovF+U/fRduMcuthD8AYpYTUgc\n" +
+            "qoEHEccF6eZYzoGlufHJCwtLHXk9qXeXtjZV8N90ksYahFV+oGFcpaOCASYwggEi\n" +
+            "MA4GA1UdDwEB/wQEAwIHgDAdBgNVHQ4EFgQUS8gTB11XA49gH4IGAD6p3UilrIMw\n" +
+            "HwYDVR0jBBgwFoAUBNzgleXouWuUoe+MWzEeE35Vl9owHQYDVR0lBBYwFAYIKwYB\n" +
+            "BQUHAwEGCCsGAQUFBwMCMHUGCCsGAQUFBwEBBGkwZzAtBggrBgEFBQcwAYYhaHR0\n" +
+            "cDovL29jc3Auc2NhM2EuYW1hem9udHJ1c3QuY29tMDYGCCsGAQUFBzAChipodHRw\n" +
+            "Oi8vY3J0LnNjYTNhLmFtYXpvbnRydXN0LmNvbS9zY2EzYS5jZXIwJQYDVR0RBB4w\n" +
+            "HIIaZ29vZC5zY2EzYS5hbWF6b250cnVzdC5jb20wEwYDVR0gBAwwCjAIBgZngQwB\n" +
+            "AgEwCgYIKoZIzj0EAwIDSAAwRQIgRRteTEwQoqw95mKff0ydDMD1+YQbcN6QLw/a\n" +
+            "NwDti9ICIQDYMNw6u0d5gaZZo/zizl1JRVAuSxoO5lNOrleaEOkImA==\n" +
             "-----END CERTIFICATE-----";
 
-    // Owner: CN=revoked.sca3a.amazontrust.com, O=Amazon Trust Services, L=Seattle, ST=Washington, C=US, \
-    // SERIALNUMBER=5846743, OID.2.5.4.15=PrivateOrganization, OID.1.3.6.1.4.1.311.60.2.1.2=Delaware, \
-    // OID.1.3.6.1.4.1.311.60.2.1.3=US
+    // Owner: CN=revoked.sca3a.amazontrust.com
     // Issuer: CN=Amazon, OU=Server CA 3A, O=Amazon, C=US
-    // Serial number: 6f1d78cf0ca64ce7f551a6f2a0715cc0e8b50
-    // Valid from: Mon Jan 28 15:40:01 PST 2019 until: Thu Apr 28 16:40:01 PDT 2022
+    // Serial number: 75a5df9c88c0613777baba663000de147a26b
+    // Valid from: Fri Dec 17 12:30:04 PST 2021 until: Tue Jan 17 12:30:04 PST 2023
     private static final String REVOKED = "-----BEGIN CERTIFICATE-----\n" +
-            "MIIDTzCCAvWgAwIBAgITBvHXjPDKZM5/VRpvKgcVzA6LUDAKBggqhkjOPQQDAjBG\n" +
+            "MIICmzCCAkCgAwIBAgITB1pd+ciMBhN3e6umYwAN4UeiazAKBggqhkjOPQQDAjBG\n" +
             "MQswCQYDVQQGEwJVUzEPMA0GA1UEChMGQW1hem9uMRUwEwYDVQQLEwxTZXJ2ZXIg\n" +
-            "Q0EgM0ExDzANBgNVBAMTBkFtYXpvbjAeFw0xOTAxMjgyMzQwMDFaFw0yMjA0Mjgy\n" +
-            "MzQwMDFaMIHcMRMwEQYLKwYBBAGCNzwCAQMTAlVTMRkwFwYLKwYBBAGCNzwCAQIT\n" +
-            "CERlbGF3YXJlMRwwGgYDVQQPExNQcml2YXRlT3JnYW5pemF0aW9uMRAwDgYDVQQF\n" +
-            "Ewc1ODQ2NzQzMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4G\n" +
-            "A1UEBxMHU2VhdHRsZTEeMBwGA1UEChMVQW1hem9uIFRydXN0IFNlcnZpY2VzMSYw\n" +
-            "JAYDVQQDEx1yZXZva2VkLnNjYTNhLmFtYXpvbnRydXN0LmNvbTBZMBMGByqGSM49\n" +
-            "AgEGCCqGSM49AwEHA0IABJNl90Jq0wddpFj+JbLtmvGR/1geL5t1tvV406jGpYn2\n" +
-            "C5lAFjwASFy7pAnazZbfSkIDUU2i2XU0+7Cs+j1S/EOjggEpMIIBJTAOBgNVHQ8B\n" +
-            "Af8EBAMCB4AwHQYDVR0OBBYEFPhX3dYays5Sps0xTgouLkZzYLg4MB8GA1UdIwQY\n" +
-            "MBaAFATc4JXl6LlrlKHvjFsxHhN+VZfaMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggr\n" +
-            "BgEFBQcDAjB1BggrBgEFBQcBAQRpMGcwLQYIKwYBBQUHMAGGIWh0dHA6Ly9vY3Nw\n" +
-            "LnNjYTNhLmFtYXpvbnRydXN0LmNvbTA2BggrBgEFBQcwAoYqaHR0cDovL2NydC5z\n" +
-            "Y2EzYS5hbWF6b250cnVzdC5jb20vc2NhM2EuY2VyMCgGA1UdEQQhMB+CHXJldm9r\n" +
-            "ZWQuc2NhM2EuYW1hem9udHJ1c3QuY29tMBMGA1UdIAQMMAowCAYGZ4EMAQIBMAoG\n" +
-            "CCqGSM49BAMCA0gAMEUCICLb16/50S4fOAFafi5lagdx7q6EDPPm596g19eQDMXk\n" +
-            "AiEAksCMLypRB4t30FABlsEjhVCBIxay0iIer2OcCIrhfEI=\n" +
+            "Q0EgM0ExDzANBgNVBAMTBkFtYXpvbjAeFw0yMTEyMTcyMDMwMDRaFw0yMzAxMTcy\n" +
+            "MDMwMDRaMCgxJjAkBgNVBAMTHXJldm9rZWQuc2NhM2EuYW1hem9udHJ1c3QuY29t\n" +
+            "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEbppBP3Dj0qoRHMB9VMTXhw2Fg8ef\n" +
+            "o32r/Mu3IzT8T6kWCk3UqVDL3UIn3qVZLCW1nJfVc1d1EeSDvyjCL3u3f6OCASkw\n" +
+            "ggElMA4GA1UdDwEB/wQEAwIHgDAdBgNVHQ4EFgQUv8lJ3W7O74zVj+0zhD4+rrqZ\n" +
+            "yvMwHwYDVR0jBBgwFoAUBNzgleXouWuUoe+MWzEeE35Vl9owHQYDVR0lBBYwFAYI\n" +
+            "KwYBBQUHAwEGCCsGAQUFBwMCMHUGCCsGAQUFBwEBBGkwZzAtBggrBgEFBQcwAYYh\n" +
+            "aHR0cDovL29jc3Auc2NhM2EuYW1hem9udHJ1c3QuY29tMDYGCCsGAQUFBzAChipo\n" +
+            "dHRwOi8vY3J0LnNjYTNhLmFtYXpvbnRydXN0LmNvbS9zY2EzYS5jZXIwKAYDVR0R\n" +
+            "BCEwH4IdcmV2b2tlZC5zY2EzYS5hbWF6b250cnVzdC5jb20wEwYDVR0gBAwwCjAI\n" +
+            "BgZngQwBAgEwCgYIKoZIzj0EAwIDSQAwRgIhAKrA0fOK4NKDKHTY8ESeVW3D/7NH\n" +
+            "tbNdfcIXolAoFfmFAiEAylAsKdND8c4w69jlFTId0X8F/mrXzKfLFCQ+b/7jTto=\n" +
             "-----END CERTIFICATE-----";
 
     public void runTest(ValidatePathWithParams pathValidator, boolean ocspEnabled) throws Exception {
@@ -443,7 +405,7 @@ class AmazonCA_3 {
         // Validate Revoked
         pathValidator.validate(new String[]{REVOKED, INT},
                 ValidatePathWithParams.Status.REVOKED,
-                "Mon Jan 28 15:40:35 PST 2019", System.out);
+                "Fri Dec 17 12:30:37 PST 2021", System.out);
     }
 }
 
@@ -472,63 +434,50 @@ class AmazonCA_4 {
             "1HrQq+WXHBM5sIuViJI/Zh7MOjsc159Q+dn36PBqLRq03AXqE/lRjnv8C5nj\n" +
             "-----END CERTIFICATE-----";
 
-    // Owner: CN=good.sca4a.amazontrust.com, O=Amazon Trust Services, L=Seattle, ST=Washington, C=US, \
-    // SERIALNUMBER=5846743, OID.2.5.4.15=Private Organization, OID.1.3.6.1.4.1.311.60.2.1.2=Delaware, \
-    // OID.1.3.6.1.4.1.311.60.2.1.3=US
+    // Owner: CN=good.sca4a.amazontrust.com
     // Issuer: CN=Amazon, OU=Server CA 4A, O=Amazon, C=US
-    // Serial number: 703e4ec57c72d5669efbc98875c3f6bc3f934
-    // Valid from: Mon Jul 29 16:55:17 PDT 2019 until: Sat Aug 29 16:55:17 PDT 2020
+    // Serial number: 75a5ddc1a4ea5a18110454883269df9409bf5
+    // Valid from: Fri Dec 17 12:23:29 PST 2021 until: Tue Jan 17 12:23:29 PST 2023
     private static final String VALID = "-----BEGIN CERTIFICATE-----\n" +
-            "MIIDxTCCA0qgAwIBAgITBwPk7FfHLVZp77yYh1w/a8P5NDAKBggqhkjOPQQDAzBG\n" +
+            "MIIC0TCCAlegAwIBAgITB1pd3BpOpaGBEEVIgyad+UCb9TAKBggqhkjOPQQDAzBG\n" +
             "MQswCQYDVQQGEwJVUzEPMA0GA1UEChMGQW1hem9uMRUwEwYDVQQLEwxTZXJ2ZXIg\n" +
-            "Q0EgNEExDzANBgNVBAMTBkFtYXpvbjAeFw0xOTA3MjkyMzU1MTdaFw0yMDA4Mjky\n" +
-            "MzU1MTdaMIHaMRMwEQYLKwYBBAGCNzwCAQMTAlVTMRkwFwYLKwYBBAGCNzwCAQIT\n" +
-            "CERlbGF3YXJlMR0wGwYDVQQPExRQcml2YXRlIE9yZ2FuaXphdGlvbjEQMA4GA1UE\n" +
-            "BRMHNTg0Njc0MzELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAO\n" +
-            "BgNVBAcTB1NlYXR0bGUxHjAcBgNVBAoTFUFtYXpvbiBUcnVzdCBTZXJ2aWNlczEj\n" +
-            "MCEGA1UEAxMaZ29vZC5zY2E0YS5hbWF6b250cnVzdC5jb20wdjAQBgcqhkjOPQIB\n" +
-            "BgUrgQQAIgNiAAS9fqMYfOBsdXMSsPjqOlTgIGOlOQWA7Wg6XwVvHTr0+UN+XTeC\n" +
-            "yZN+XjLbEDQ0CF5eryRZ535sDpwh3qNe0lYFO1n1+2iDtDI1jhhLNYNxBpVnR2BU\n" +
-            "2l9EuRmgRbQpDCajggFjMIIBXzAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0OBBYEFMd0\n" +
-            "itH5IcE6DpM1uTSBV/6DLmK7MB8GA1UdIwQYMBaAFKUhzdvrUyGZqsrZZ0KUJbJ7\n" +
-            "9MLjMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjB1BggrBgEFBQcBAQRp\n" +
-            "MGcwLQYIKwYBBQUHMAGGIWh0dHA6Ly9vY3NwLnNjYTRhLmFtYXpvbnRydXN0LmNv\n" +
-            "bTA2BggrBgEFBQcwAoYqaHR0cDovL2NydC5zY2E0YS5hbWF6b250cnVzdC5jb20v\n" +
-            "c2NhNGEuY2VyMCUGA1UdEQQeMByCGmdvb2Quc2NhNGEuYW1hem9udHJ1c3QuY29t\n" +
-            "MFAGA1UdIARJMEcwDQYLYIZIAYb9bgEHGAMwNgYFZ4EMAQEwLTArBggrBgEFBQcC\n" +
-            "ARYfaHR0cHM6Ly93d3cuYW1hem9udHJ1c3QuY29tL2NwczAKBggqhkjOPQQDAwNp\n" +
-            "ADBmAjEA2RBD1F+rnm394VkqA3ncysM3deoyfWqaoAO5923MNisswPnHfVqnfeXf\n" +
-            "ZwTAvVTBAjEAiiaPx9GRjEk8IBKvCSbTp9rPogVTN7zDDQGrwA83O0pRP7A0dxtT\n" +
-            "pn/0K5Sj8otp\n" +
+            "Q0EgNEExDzANBgNVBAMTBkFtYXpvbjAeFw0yMTEyMTcyMDIzMjlaFw0yMzAxMTcy\n" +
+            "MDIzMjlaMCUxIzAhBgNVBAMTGmdvb2Quc2NhNGEuYW1hem9udHJ1c3QuY29tMHYw\n" +
+            "EAYHKoZIzj0CAQYFK4EEACIDYgAE7VpccYyJsD19xB1owlNs9PGkXkjptJZK6eFY\n" +
+            "q9Tc+CZLaOAhi47uuWsPwyIYB3vEIUXoWWKTvgycHhsmVQDQ2hLYMS+h9tQgnqVN\n" +
+            "TDYpEnnBa6AUbTKXtJDLG+z+7Kd7o4IBJjCCASIwDgYDVR0PAQH/BAQDAgeAMB0G\n" +
+            "A1UdDgQWBBRHzxN3jV4vU1PEmHmTqB8YXXoMYDAfBgNVHSMEGDAWgBSlIc3b61Mh\n" +
+            "marK2WdClCWye/TC4zAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwdQYI\n" +
+            "KwYBBQUHAQEEaTBnMC0GCCsGAQUFBzABhiFodHRwOi8vb2NzcC5zY2E0YS5hbWF6\n" +
+            "b250cnVzdC5jb20wNgYIKwYBBQUHMAKGKmh0dHA6Ly9jcnQuc2NhNGEuYW1hem9u\n" +
+            "dHJ1c3QuY29tL3NjYTRhLmNlcjAlBgNVHREEHjAcghpnb29kLnNjYTRhLmFtYXpv\n" +
+            "bnRydXN0LmNvbTATBgNVHSAEDDAKMAgGBmeBDAECATAKBggqhkjOPQQDAwNoADBl\n" +
+            "AjEAyHMRGLsUVEufoih22dPfO5LrLpO4/2VzeNBbUvP/mOcwvMrrq1yQjot3CTdm\n" +
+            "ZwnRAjAj2zmAM5asBZwuEN1pbEFgHdojio0O4oYvUsdMooLOKJsBD7hmgAdhpObO\n" +
+            "Xv0oNIE=\n" +
             "-----END CERTIFICATE-----";
 
-    // Owner: CN=revoked.sca4a.amazontrust.com, O=Amazon Trust Services, L=Seattle, ST=Washington, C=US, \
-    // SERIALNUMBER=5846743, OID.2.5.4.15=PrivateOrganization, OID.1.3.6.1.4.1.311.60.2.1.2=Delaware, \
-    // OID.1.3.6.1.4.1.311.60.2.1.3=US
+    // Owner: CN=revoked.sca4a.amazontrust.com
     // Issuer: CN=Amazon, OU=Server CA 4A, O=Amazon, C=US
-    // Serial number: 6f1d79295c384a699d51c2d756bd46213b5b3
-    // Valid from: Mon Jan 28 15:41:16 PST 2019 until: Thu Apr 28 16:41:16 PDT 2022
+    // Serial number: 75a5e0442d0fed2b11850ed6746a2200bb4af
+    // Valid from: Fri Dec 17 12:32:23 PST 2021 until: Tue Jan 17 12:32:23 PST 2023
     private static final String REVOKED = "-----BEGIN CERTIFICATE-----\n" +
-            "MIIDjTCCAxKgAwIBAgITBvHXkpXDhKaZ1RwtdWvUYhO1szAKBggqhkjOPQQDAzBG\n" +
+            "MIIC1zCCAl2gAwIBAgITB1peBELQ/tKxGFDtZ0aiIAu0rzAKBggqhkjOPQQDAzBG\n" +
             "MQswCQYDVQQGEwJVUzEPMA0GA1UEChMGQW1hem9uMRUwEwYDVQQLEwxTZXJ2ZXIg\n" +
-            "Q0EgNEExDzANBgNVBAMTBkFtYXpvbjAeFw0xOTAxMjgyMzQxMTZaFw0yMjA0Mjgy\n" +
-            "MzQxMTZaMIHcMRMwEQYLKwYBBAGCNzwCAQMTAlVTMRkwFwYLKwYBBAGCNzwCAQIT\n" +
-            "CERlbGF3YXJlMRwwGgYDVQQPExNQcml2YXRlT3JnYW5pemF0aW9uMRAwDgYDVQQF\n" +
-            "Ewc1ODQ2NzQzMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4G\n" +
-            "A1UEBxMHU2VhdHRsZTEeMBwGA1UEChMVQW1hem9uIFRydXN0IFNlcnZpY2VzMSYw\n" +
-            "JAYDVQQDEx1yZXZva2VkLnNjYTRhLmFtYXpvbnRydXN0LmNvbTB2MBAGByqGSM49\n" +
-            "AgEGBSuBBAAiA2IABLuNpZTcNU3FElNP3Y/OeXIZcIMXkFTBi/n92fNwHfqUbEhH\n" +
-            "H+PovJ26eAGvb5a8bGc275MBFcVnWL0rCVgM+j9KAtBDCRJX3f7mo0D2VKcmtZKu\n" +
-            "jPxwGPy2kuqM505dGqOCASkwggElMA4GA1UdDwEB/wQEAwIHgDAdBgNVHQ4EFgQU\n" +
-            "zUFIhn+hphzCKA2qgAdLztSBzJgwHwYDVR0jBBgwFoAUpSHN2+tTIZmqytlnQpQl\n" +
-            "snv0wuMwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMHUGCCsGAQUFBwEB\n" +
-            "BGkwZzAtBggrBgEFBQcwAYYhaHR0cDovL29jc3Auc2NhNGEuYW1hem9udHJ1c3Qu\n" +
-            "Y29tMDYGCCsGAQUFBzAChipodHRwOi8vY3J0LnNjYTRhLmFtYXpvbnRydXN0LmNv\n" +
-            "bS9zY2E0YS5jZXIwKAYDVR0RBCEwH4IdcmV2b2tlZC5zY2E0YS5hbWF6b250cnVz\n" +
-            "dC5jb20wEwYDVR0gBAwwCjAIBgZngQwBAgEwCgYIKoZIzj0EAwMDaQAwZgIxALDA\n" +
-            "klY3iKwyzwpwVtLfLxzQEl45xvE2VjBJvfJJ60KhJt7Ud0gt0zxkogh29+mpEQIx\n" +
-            "ANTG1mk8OJB41DU7ru1Pwc6ju8STw1FdwDp/Eliqhvnm2i0k4/F1bBHLta2mlC2V\n" +
-            "hg==\n" +
+            "Q0EgNEExDzANBgNVBAMTBkFtYXpvbjAeFw0yMTEyMTcyMDMyMjNaFw0yMzAxMTcy\n" +
+            "MDMyMjNaMCgxJjAkBgNVBAMTHXJldm9rZWQuc2NhNGEuYW1hem9udHJ1c3QuY29t\n" +
+            "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEqxQKCDKJYXzA0uR3jyfk/ZRyPAJolRNI\n" +
+            "xI3+vlQW7SqVs+MziCLFPuU68kf74a5/YFWK/bRdXrVue4IMbM8TKO2FwXIHn/Iw\n" +
+            "udkJIG+CdqnL4IlH+tFf+l47vRzMS0TQo4IBKTCCASUwDgYDVR0PAQH/BAQDAgeA\n" +
+            "MB0GA1UdDgQWBBR04rEvUxTzLh0OGHyMgrYanP7lqzAfBgNVHSMEGDAWgBSlIc3b\n" +
+            "61MhmarK2WdClCWye/TC4zAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIw\n" +
+            "dQYIKwYBBQUHAQEEaTBnMC0GCCsGAQUFBzABhiFodHRwOi8vb2NzcC5zY2E0YS5h\n" +
+            "bWF6b250cnVzdC5jb20wNgYIKwYBBQUHMAKGKmh0dHA6Ly9jcnQuc2NhNGEuYW1h\n" +
+            "em9udHJ1c3QuY29tL3NjYTRhLmNlcjAoBgNVHREEITAfgh1yZXZva2VkLnNjYTRh\n" +
+            "LmFtYXpvbnRydXN0LmNvbTATBgNVHSAEDDAKMAgGBmeBDAECATAKBggqhkjOPQQD\n" +
+            "AwNoADBlAjEAgOyeHMBYmO9rfMgCnV4oOQ5PcjSAgotYwEGqFHA5+TuIPBTcdFar\n" +
+            "J1j1JY+EirQ3AjAuGMJdyiQfAVi1n5wT1/2nIOIEGtV2/9CrNmhmjIzKrfu+HUUk\n" +
+            "bduxD7hNhott7NE=\n" +
             "-----END CERTIFICATE-----";
 
     public void runTest(ValidatePathWithParams pathValidator, boolean ocspEnabled) throws Exception {
@@ -547,6 +496,6 @@ class AmazonCA_4 {
         // Validate Revoked
         pathValidator.validate(new String[]{REVOKED, INT},
                 ValidatePathWithParams.Status.REVOKED,
-                "Mon Jan 28 15:41:53 PST 2019", System.out);
+                "Fri Dec 17 12:32:59 PST 2021", System.out);
     }
 }


### PR DESCRIPTION
Backport of JDK-8271838 which applies clean modulo path differences and copyright. Test only change, thus, very low risk. It's a dependency to get JDK-8309088 in (which makes `AmazonCA.java` test pass again; fails currently).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8271838](https://bugs.openjdk.org/browse/JDK-8271838): AmazonCA.java interop test fails (**Bug** - P4)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/364/head:pull/364` \
`$ git checkout pull/364`

Update a local copy of the PR: \
`$ git checkout pull/364` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/364/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 364`

View PR using the GUI difftool: \
`$ git pr show -t 364`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/364.diff">https://git.openjdk.org/jdk8u-dev/pull/364.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/364#issuecomment-1706295138)