### PR TITLE
8029995: accept yes/no for boolean krb5.conf settings

### DIFF
--- a/jdk/src/share/classes/javax/security/auth/kerberos/package-info.java
+++ b/jdk/src/share/classes/javax/security/auth/kerberos/package-info.java
@@ -48,6 +48,12 @@
  * {@code <java-home>/lib/security} and failing that, in an OS-specific
  * location.<p>
  *
+ * The {@code krb5.conf} file is formatted in the Windows INI file style,
+ * which contains a series of relations grouped into different sections.
+ * Each relation contains a key and a value, the value can be an arbitrary
+ * string or a boolean value. A boolean value can be one of "true", "false",
+ * "yes", or "no", case-insensitive.<p>
+ *
  * @since JDK1.4
  */
 package javax.security.auth.kerberos;

--- a/jdk/src/share/classes/sun/security/krb5/Config.java
+++ b/jdk/src/share/classes/sun/security/krb5/Config.java
@@ -450,23 +450,6 @@ public class Config {
     }
 
     /**
-     * Gets the boolean value for the specified keys.
-     * @param keys the keys
-     * @return the boolean value, false is returned if it cannot be
-     * found or the value is not "true" (case insensitive).
-     * @throw IllegalArgumentException if any of the keys is illegal
-     * @see #get(java.lang.String[])
-     */
-    public boolean getBooleanValue(String... keys) {
-        String val = get(keys);
-        if (val != null && val.equalsIgnoreCase("true")) {
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-    /**
      * Parses a string to an integer. The convertible strings include the
      * string representations of positive integers, negative integers, and
      * hex decimal integers.  Valid inputs are, e.g., -1234, +1234,
@@ -474,7 +457,7 @@ public class Config {
      *
      * @param input the String to be converted to an Integer.
      * @return an numeric value represented by the string
-     * @exception NumberFormationException if the String does not contain a
+     * @exception NumberFormatException if the String does not contain a
      * parsable integer.
      */
     private int parseIntValue(String input) throws NumberFormatException {
@@ -1060,20 +1043,13 @@ public class Config {
      * use addresses if "no_addresses" or "noaddresses" is set to false
      */
     public boolean useAddresses() {
-        boolean useAddr = false;
-        // use addresses if "no_addresses" is set to false
-        String value = get("libdefaults", "no_addresses");
-        useAddr = (value != null && value.equalsIgnoreCase("false"));
-        if (useAddr == false) {
-            // use addresses if "noaddresses" is set to false
-            value = get("libdefaults", "noaddresses");
-            useAddr = (value != null && value.equalsIgnoreCase("false"));
-        }
-        return useAddr;
+        return getBooleanObject("libdefaults", "no_addresses") == Boolean.FALSE ||
+                getBooleanObject("libdefaults", "noaddresses") == Boolean.FALSE;
     }
 
     /**
-     * Check if need to use DNS to locate Kerberos services
+     * Check if need to use DNS to locate Kerberos services for name. If not
+     * defined, check dns_fallback, whose default value is true.
      */
     private boolean useDNS(String name, boolean defaultValue) {
         Boolean value = getBooleanObject("libdefaults", name);

--- a/jdk/src/share/classes/sun/security/krb5/internal/KDCOptions.java
+++ b/jdk/src/share/classes/sun/security/krb5/internal/KDCOptions.java
@@ -301,14 +301,14 @@ public class KDCOptions extends KerberosFlags {
             if ((options & KDC_OPT_RENEWABLE_OK) == KDC_OPT_RENEWABLE_OK) {
                 set(RENEWABLE_OK, true);
             } else {
-                if (config.getBooleanValue("libdefaults", "renewable")) {
+                if (config.getBooleanObject("libdefaults", "renewable") == Boolean.TRUE) {
                     set(RENEWABLE_OK, true);
                 }
             }
             if ((options & KDC_OPT_PROXIABLE) == KDC_OPT_PROXIABLE) {
                 set(PROXIABLE, true);
             } else {
-                if (config.getBooleanValue("libdefaults", "proxiable")) {
+                if (config.getBooleanObject("libdefaults", "proxiable") == Boolean.TRUE) {
                     set(PROXIABLE, true);
                 }
             }
@@ -316,7 +316,7 @@ public class KDCOptions extends KerberosFlags {
             if ((options & KDC_OPT_FORWARDABLE) == KDC_OPT_FORWARDABLE) {
                 set(FORWARDABLE, true);
             } else {
-                if (config.getBooleanValue("libdefaults", "forwardable")) {
+                if (config.getBooleanObject("libdefaults", "forwardable") == Boolean.TRUE) {
                     set(FORWARDABLE, true);
                 }
             }

--- a/jdk/src/share/classes/sun/security/krb5/internal/crypto/EType.java
+++ b/jdk/src/share/classes/sun/security/krb5/internal/crypto/EType.java
@@ -58,8 +58,8 @@ public abstract class EType {
         boolean allowed = false;
         try {
             Config cfg = Config.getInstance();
-            String temp = cfg.get("libdefaults", "allow_weak_crypto");
-            if (temp != null && temp.equals("true")) allowed = true;
+            allowed = cfg.getBooleanObject("libdefaults", "allow_weak_crypto")
+                    == Boolean.TRUE;
         } catch (Exception exc) {
             if (DEBUG) {
                 System.out.println ("Exception in getting allow_weak_crypto, " +

--- a/jdk/test/sun/security/krb5/config/YesNo.java
+++ b/jdk/test/sun/security/krb5/config/YesNo.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8029995
+ * @summary accept yes/no for boolean krb5.conf settings
+ * @compile -XDignore.symbol.file YesNo.java
+ * @run main/othervm YesNo
+ */
+import sun.security.krb5.Config;
+import sun.security.krb5.internal.crypto.EType;
+
+import java.util.Arrays;
+
+public class YesNo {
+    static Config config = null;
+    public static void main(String[] args) throws Exception {
+        System.setProperty("java.security.krb5.conf",
+                System.getProperty("test.src", ".") +"/yesno.conf");
+        config = Config.getInstance();
+        check("a", Boolean.TRUE);
+        check("b", Boolean.FALSE);
+        check("c", Boolean.TRUE);
+        check("d", Boolean.FALSE);
+        check("e", null);
+        check("f", null);
+
+        if (!Arrays.stream(EType.getBuiltInDefaults())
+                .anyMatch(n -> n < 4)) {
+            throw new Exception();
+        }
+    }
+
+    static void check(String k, Boolean expected) throws Exception {
+        Boolean result = config.getBooleanObject("libdefaults", k);
+        if (expected != result) {
+            throw new Exception("value for " + k + " is " + result);
+        }
+    }
+}

--- a/jdk/test/sun/security/krb5/config/yesno.conf
+++ b/jdk/test/sun/security/krb5/config/yesno.conf
@@ -1,0 +1,7 @@
+[libdefaults]
+a = true
+b = FALSE
+c = YES
+d = no
+e = nothing
+allow_weak_crypto = yes


### PR DESCRIPTION
This fix solves regression caused by JDK-8139348 and found by the test suite of 3rd party library.
The fix allows to use "yes" and "no" values in the krb5.conf file. It is important because sometimes krb5.conf is autogenerated and uses "yes"/"no" values inside.
The backport is almost clean except of the Config.java file. Config.java already has some changes applied as part of JDK-8077102
sun/security/krb5 jtreg tests passed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8029995](https://bugs.openjdk.org/browse/JDK-8029995): accept yes/no for boolean krb5.conf settings (**Enhancement** - P3)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/367/head:pull/367` \
`$ git checkout pull/367`

Update a local copy of the PR: \
`$ git checkout pull/367` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/367/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 367`

View PR using the GUI difftool: \
`$ git pr show -t 367`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/367.diff">https://git.openjdk.org/jdk8u-dev/pull/367.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/367#issuecomment-1707452204)