### PR TITLE
8311813: C1: Uninitialized PhiResolver::_loop field

### DIFF
--- a/hotspot/src/share/vm/c1/c1_LIRGenerator.cpp
+++ b/hotspot/src/share/vm/c1/c1_LIRGenerator.cpp
@@ -79,6 +79,7 @@ void PhiResolverState::reset(int max_vregs) {
 PhiResolver::PhiResolver(LIRGenerator* gen, int max_vregs)
  : _gen(gen)
  , _state(gen->resolver_state())
+ , _loop(nullptr)
  , _temp(LIR_OprFact::illegalOpr)
 {
   // reinitialize the shared state arrays

--- a/hotspot/src/share/vm/c1/c1_LIRGenerator.cpp
+++ b/hotspot/src/share/vm/c1/c1_LIRGenerator.cpp
@@ -79,7 +79,7 @@ void PhiResolverState::reset(int max_vregs) {
 PhiResolver::PhiResolver(LIRGenerator* gen, int max_vregs)
  : _gen(gen)
  , _state(gen->resolver_state())
- , _loop(nullptr)
+ , _loop(NULL)
  , _temp(LIR_OprFact::illegalOpr)
 {
   // reinitialize the shared state arrays


### PR DESCRIPTION
[JDK-8311813](https://bugs.openjdk.org/browse/JDK-8311813)

Initialize `PhiResolver::_loop` field to `nullptr`

Clean backport

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8311813](https://bugs.openjdk.org/browse/JDK-8311813) needs maintainer approval

### Issue
 * [JDK-8311813](https://bugs.openjdk.org/browse/JDK-8311813): C1: Uninitialized PhiResolver::_loop field (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/369/head:pull/369` \
`$ git checkout pull/369`

Update a local copy of the PR: \
`$ git checkout pull/369` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/369/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 369`

View PR using the GUI difftool: \
`$ git pr show -t 369`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/369.diff">https://git.openjdk.org/jdk8u-dev/pull/369.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/369#issuecomment-1709183610)