### PR TITLE
8209115: adjust libsplashscreen linux ppc64le builds for easier libpng update

### DIFF
--- a/jdk/make/lib/Awt2dLibraries.gmk
+++ b/jdk/make/lib/Awt2dLibraries.gmk
@@ -1159,6 +1159,12 @@ ifndef BUILD_HEADLESS_ONLY
       -DPNG_ARM_NEON_OPT=0 -DPNG_ARM_NEON_IMPLEMENTATION=0 \
       $(foreach dir, $(LIBSPLASHSCREEN_DIRS), -I$(dir))
 
+  ifeq ($(OPENJDK_TARGET_OS), linux)
+    ifeq ($(OPENJDK_TARGET_CPU_ARCH), ppc)
+      LIBSPLASHSCREEN_CFLAGS += -DPNG_POWERPC_VSX_OPT=0
+    endif
+  endif
+
   ifeq ($(OPENJDK_TARGET_OS), macosx)
     LIBSPLASHSCREEN_CFLAGS := -I$(JDK_TOPDIR)/src/macosx/native/sun/awt/splashscreen \
         $(LIBSPLASHSCREEN_CFLAGS)

--- a/jdk/src/share/native/sun/awt/libpng/pngpriv.h
+++ b/jdk/src/share/native/sun/awt/libpng/pngpriv.h
@@ -293,13 +293,10 @@
 #  endif
 #endif /* PNG_MIPS_MSA_OPT > 0 */
 
-#ifdef PNG_POWERPC_VSX_API_SUPPORTED
 #if PNG_POWERPC_VSX_OPT > 0
 #  define PNG_FILTER_OPTIMIZATIONS png_init_filter_functions_vsx
 #  define PNG_POWERPC_VSX_IMPLEMENTATION 1
 #endif
-#endif
-
 
 
 /* Is this a build of a DLL where compilation of the object modules requires


### PR DESCRIPTION
The 11u patch does not apply cleanly because of the file paths and because the context for the change in jdk/make/lib/Awt2dLibraries.gmk is slightly different.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8209115](https://bugs.openjdk.org/browse/JDK-8209115): adjust libsplashscreen linux ppc64le builds for easier libpng update (**Bug** - P4)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/371/head:pull/371` \
`$ git checkout pull/371`

Update a local copy of the PR: \
`$ git checkout pull/371` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/371/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 371`

View PR using the GUI difftool: \
`$ git pr show -t 371`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/371.diff">https://git.openjdk.org/jdk8u-dev/pull/371.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/371#issuecomment-1719956163)