### PR TITLE
8295685: Update Libpng to 1.6.38

### DIFF
--- a/THIRD_PARTY_README
+++ b/THIRD_PARTY_README
@@ -1639,8 +1639,8 @@ Glenn Randers-Pehrson
 glennrp at users.sourceforge.net
 July 15, 2018
 
-### AUTHORS File Information
-```
+AUTHORS File Information:
+
 PNG REFERENCE LIBRARY AUTHORS
 =============================
 
@@ -1690,7 +1690,6 @@ other copyright owners, but are released under the libpng license.
 Some files in the "contrib" directory, and some tools-generated files
 that are distributed with libpng, have other copyright owners, and are
 released under other open source licenses.
-```
 
 --- end of LICENSE ---
 

--- a/THIRD_PARTY_README
+++ b/THIRD_PARTY_README
@@ -1472,7 +1472,7 @@ included with JDK 8 and OpenJDK 8 source distributions.
 
 -------------------------------------------------------------------------------
 
-%% This notice is provided with respect to libpng 1.6.37, which may be
+%% This notice is provided with respect to libpng 1.6.38, which may be
 included with JRE 8, JDK 8, and OpenJDK 8.
 
 --- begin of LICENSE ---
@@ -1483,11 +1483,11 @@ COPYRIGHT NOTICE, DISCLAIMER, and LICENSE
 PNG Reference Library License version 2
 ---------------------------------------
 
- * Copyright (c) 1995-2019 The PNG Reference Library Authors.
- * Copyright (c) 2018-2019 Cosmin Truta.
- * Copyright (c) 2000-2002, 2004, 2006-2018 Glenn Randers-Pehrson.
- * Copyright (c) 1996-1997 Andreas Dilger.
- * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
+Copyright (c) 1995-2022 The PNG Reference Library Authors.
+Copyright (c) 2018-2022 Cosmin Truta
+Copyright (c) 1998-2018 Glenn Randers-Pehrson
+Copyright (c) 1996-1997 Andreas Dilger
+Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
 
 The software is supplied "as is", without warranty of any kind,
 express or implied, including, without limitation, the warranties
@@ -1614,10 +1614,10 @@ be appreciated.
 
 TRADEMARK:
 
-The name "libpng" has not been registered by the Copyright owner
+The name "libpng" has not been registered by the Copyright owners
 as a trademark in any jurisdiction.  However, because libpng has
 been distributed and maintained world-wide, continually since 1995,
-the Copyright owner claims "common-law trademark protection" in any
+the Copyright owners claim "common-law trademark protection" in any
 jurisdiction where common-law trademark is recognized.
 
 OSI CERTIFICATION:
@@ -1638,6 +1638,59 @@ any encryption software.  See the EAR, paragraphs 734.3(b)(3) and
 Glenn Randers-Pehrson
 glennrp at users.sourceforge.net
 July 15, 2018
+
+### AUTHORS File Information
+```
+PNG REFERENCE LIBRARY AUTHORS
+=============================
+
+This is the list of PNG Reference Library ("libpng") Contributing
+Authors, for copyright and licensing purposes.
+
+ * Andreas Dilger
+ * Cosmin Truta
+ * Dave Martindale
+ * Eric S. Raymond
+ * Gilles Vollant
+ * Glenn Randers-Pehrson
+ * Greg Roelofs
+ * Guy Eric Schalnat
+ * James Yu
+ * John Bowler
+ * Kevin Bracey
+ * Magnus Holmgren
+ * Mandar Sahastrabuddhe
+ * Mans Rullgard
+ * Matt Sarett
+ * Mike Klein
+ * Pascal Massimino
+ * Paul Schmidt
+ * Qiang Zhou
+ * Sam Bushell
+ * Samuel Williams
+ * Simon-Pierre Cadieux
+ * Tim Wegner
+ * Tom Lane
+ * Tom Tanner
+ * Vadim Barkov
+ * Willem van Schaik
+ * Zhijie Liang
+ * Arm Holdings
+   - Richard Townsend
+ * Google Inc.
+   - Matt Sarett
+   - Mike Klein
+   - Dan Field
+   - Sami Boukortt
+
+The build projects, the build scripts, the test scripts, and other
+files in the "ci", "projects", "scripts" and "tests" directories, have
+other copyright owners, but are released under the libpng license.
+
+Some files in the "contrib" directory, and some tools-generated files
+that are distributed with libpng, have other copyright owners, and are
+released under other open source licenses.
+```
 
 --- end of LICENSE ---
 

--- a/corba/THIRD_PARTY_README
+++ b/corba/THIRD_PARTY_README
@@ -1639,8 +1639,8 @@ Glenn Randers-Pehrson
 glennrp at users.sourceforge.net
 July 15, 2018
 
-### AUTHORS File Information
-```
+AUTHORS File Information:
+
 PNG REFERENCE LIBRARY AUTHORS
 =============================
 
@@ -1690,7 +1690,6 @@ other copyright owners, but are released under the libpng license.
 Some files in the "contrib" directory, and some tools-generated files
 that are distributed with libpng, have other copyright owners, and are
 released under other open source licenses.
-```
 
 --- end of LICENSE ---
 

--- a/corba/THIRD_PARTY_README
+++ b/corba/THIRD_PARTY_README
@@ -1472,7 +1472,7 @@ included with JDK 8 and OpenJDK 8 source distributions.
 
 -------------------------------------------------------------------------------
 
-%% This notice is provided with respect to libpng 1.6.37, which may be
+%% This notice is provided with respect to libpng 1.6.38, which may be
 included with JRE 8, JDK 8, and OpenJDK 8.
 
 --- begin of LICENSE ---
@@ -1483,11 +1483,11 @@ COPYRIGHT NOTICE, DISCLAIMER, and LICENSE
 PNG Reference Library License version 2
 ---------------------------------------
 
- * Copyright (c) 1995-2019 The PNG Reference Library Authors.
- * Copyright (c) 2018-2019 Cosmin Truta.
- * Copyright (c) 2000-2002, 2004, 2006-2018 Glenn Randers-Pehrson.
- * Copyright (c) 1996-1997 Andreas Dilger.
- * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
+Copyright (c) 1995-2022 The PNG Reference Library Authors.
+Copyright (c) 2018-2022 Cosmin Truta
+Copyright (c) 1998-2018 Glenn Randers-Pehrson
+Copyright (c) 1996-1997 Andreas Dilger
+Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
 
 The software is supplied "as is", without warranty of any kind,
 express or implied, including, without limitation, the warranties
@@ -1614,10 +1614,10 @@ be appreciated.
 
 TRADEMARK:
 
-The name "libpng" has not been registered by the Copyright owner
+The name "libpng" has not been registered by the Copyright owners
 as a trademark in any jurisdiction.  However, because libpng has
 been distributed and maintained world-wide, continually since 1995,
-the Copyright owner claims "common-law trademark protection" in any
+the Copyright owners claim "common-law trademark protection" in any
 jurisdiction where common-law trademark is recognized.
 
 OSI CERTIFICATION:
@@ -1638,6 +1638,59 @@ any encryption software.  See the EAR, paragraphs 734.3(b)(3) and
 Glenn Randers-Pehrson
 glennrp at users.sourceforge.net
 July 15, 2018
+
+### AUTHORS File Information
+```
+PNG REFERENCE LIBRARY AUTHORS
+=============================
+
+This is the list of PNG Reference Library ("libpng") Contributing
+Authors, for copyright and licensing purposes.
+
+ * Andreas Dilger
+ * Cosmin Truta
+ * Dave Martindale
+ * Eric S. Raymond
+ * Gilles Vollant
+ * Glenn Randers-Pehrson
+ * Greg Roelofs
+ * Guy Eric Schalnat
+ * James Yu
+ * John Bowler
+ * Kevin Bracey
+ * Magnus Holmgren
+ * Mandar Sahastrabuddhe
+ * Mans Rullgard
+ * Matt Sarett
+ * Mike Klein
+ * Pascal Massimino
+ * Paul Schmidt
+ * Qiang Zhou
+ * Sam Bushell
+ * Samuel Williams
+ * Simon-Pierre Cadieux
+ * Tim Wegner
+ * Tom Lane
+ * Tom Tanner
+ * Vadim Barkov
+ * Willem van Schaik
+ * Zhijie Liang
+ * Arm Holdings
+   - Richard Townsend
+ * Google Inc.
+   - Matt Sarett
+   - Mike Klein
+   - Dan Field
+   - Sami Boukortt
+
+The build projects, the build scripts, the test scripts, and other
+files in the "ci", "projects", "scripts" and "tests" directories, have
+other copyright owners, but are released under the libpng license.
+
+Some files in the "contrib" directory, and some tools-generated files
+that are distributed with libpng, have other copyright owners, and are
+released under other open source licenses.
+```
 
 --- end of LICENSE ---
 

--- a/hotspot/THIRD_PARTY_README
+++ b/hotspot/THIRD_PARTY_README
@@ -1639,8 +1639,8 @@ Glenn Randers-Pehrson
 glennrp at users.sourceforge.net
 July 15, 2018
 
-### AUTHORS File Information
-```
+AUTHORS File Information:
+
 PNG REFERENCE LIBRARY AUTHORS
 =============================
 
@@ -1690,7 +1690,6 @@ other copyright owners, but are released under the libpng license.
 Some files in the "contrib" directory, and some tools-generated files
 that are distributed with libpng, have other copyright owners, and are
 released under other open source licenses.
-```
 
 --- end of LICENSE ---
 

--- a/hotspot/THIRD_PARTY_README
+++ b/hotspot/THIRD_PARTY_README
@@ -1472,7 +1472,7 @@ included with JDK 8 and OpenJDK 8 source distributions.
 
 -------------------------------------------------------------------------------
 
-%% This notice is provided with respect to libpng 1.6.37, which may be
+%% This notice is provided with respect to libpng 1.6.38, which may be
 included with JRE 8, JDK 8, and OpenJDK 8.
 
 --- begin of LICENSE ---
@@ -1483,11 +1483,11 @@ COPYRIGHT NOTICE, DISCLAIMER, and LICENSE
 PNG Reference Library License version 2
 ---------------------------------------
 
- * Copyright (c) 1995-2019 The PNG Reference Library Authors.
- * Copyright (c) 2018-2019 Cosmin Truta.
- * Copyright (c) 2000-2002, 2004, 2006-2018 Glenn Randers-Pehrson.
- * Copyright (c) 1996-1997 Andreas Dilger.
- * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
+Copyright (c) 1995-2022 The PNG Reference Library Authors.
+Copyright (c) 2018-2022 Cosmin Truta
+Copyright (c) 1998-2018 Glenn Randers-Pehrson
+Copyright (c) 1996-1997 Andreas Dilger
+Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
 
 The software is supplied "as is", without warranty of any kind,
 express or implied, including, without limitation, the warranties
@@ -1614,10 +1614,10 @@ be appreciated.
 
 TRADEMARK:
 
-The name "libpng" has not been registered by the Copyright owner
+The name "libpng" has not been registered by the Copyright owners
 as a trademark in any jurisdiction.  However, because libpng has
 been distributed and maintained world-wide, continually since 1995,
-the Copyright owner claims "common-law trademark protection" in any
+the Copyright owners claim "common-law trademark protection" in any
 jurisdiction where common-law trademark is recognized.
 
 OSI CERTIFICATION:
@@ -1638,6 +1638,59 @@ any encryption software.  See the EAR, paragraphs 734.3(b)(3) and
 Glenn Randers-Pehrson
 glennrp at users.sourceforge.net
 July 15, 2018
+
+### AUTHORS File Information
+```
+PNG REFERENCE LIBRARY AUTHORS
+=============================
+
+This is the list of PNG Reference Library ("libpng") Contributing
+Authors, for copyright and licensing purposes.
+
+ * Andreas Dilger
+ * Cosmin Truta
+ * Dave Martindale
+ * Eric S. Raymond
+ * Gilles Vollant
+ * Glenn Randers-Pehrson
+ * Greg Roelofs
+ * Guy Eric Schalnat
+ * James Yu
+ * John Bowler
+ * Kevin Bracey
+ * Magnus Holmgren
+ * Mandar Sahastrabuddhe
+ * Mans Rullgard
+ * Matt Sarett
+ * Mike Klein
+ * Pascal Massimino
+ * Paul Schmidt
+ * Qiang Zhou
+ * Sam Bushell
+ * Samuel Williams
+ * Simon-Pierre Cadieux
+ * Tim Wegner
+ * Tom Lane
+ * Tom Tanner
+ * Vadim Barkov
+ * Willem van Schaik
+ * Zhijie Liang
+ * Arm Holdings
+   - Richard Townsend
+ * Google Inc.
+   - Matt Sarett
+   - Mike Klein
+   - Dan Field
+   - Sami Boukortt
+
+The build projects, the build scripts, the test scripts, and other
+files in the "ci", "projects", "scripts" and "tests" directories, have
+other copyright owners, but are released under the libpng license.
+
+Some files in the "contrib" directory, and some tools-generated files
+that are distributed with libpng, have other copyright owners, and are
+released under other open source licenses.
+```
 
 --- end of LICENSE ---
 

--- a/jaxp/THIRD_PARTY_README
+++ b/jaxp/THIRD_PARTY_README
@@ -1639,8 +1639,8 @@ Glenn Randers-Pehrson
 glennrp at users.sourceforge.net
 July 15, 2018
 
-### AUTHORS File Information
-```
+AUTHORS File Information:
+
 PNG REFERENCE LIBRARY AUTHORS
 =============================
 
@@ -1690,7 +1690,6 @@ other copyright owners, but are released under the libpng license.
 Some files in the "contrib" directory, and some tools-generated files
 that are distributed with libpng, have other copyright owners, and are
 released under other open source licenses.
-```
 
 --- end of LICENSE ---
 

--- a/jaxp/THIRD_PARTY_README
+++ b/jaxp/THIRD_PARTY_README
@@ -1472,7 +1472,7 @@ included with JDK 8 and OpenJDK 8 source distributions.
 
 -------------------------------------------------------------------------------
 
-%% This notice is provided with respect to libpng 1.6.37, which may be
+%% This notice is provided with respect to libpng 1.6.38, which may be
 included with JRE 8, JDK 8, and OpenJDK 8.
 
 --- begin of LICENSE ---
@@ -1483,11 +1483,11 @@ COPYRIGHT NOTICE, DISCLAIMER, and LICENSE
 PNG Reference Library License version 2
 ---------------------------------------
 
- * Copyright (c) 1995-2019 The PNG Reference Library Authors.
- * Copyright (c) 2018-2019 Cosmin Truta.
- * Copyright (c) 2000-2002, 2004, 2006-2018 Glenn Randers-Pehrson.
- * Copyright (c) 1996-1997 Andreas Dilger.
- * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
+Copyright (c) 1995-2022 The PNG Reference Library Authors.
+Copyright (c) 2018-2022 Cosmin Truta
+Copyright (c) 1998-2018 Glenn Randers-Pehrson
+Copyright (c) 1996-1997 Andreas Dilger
+Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
 
 The software is supplied "as is", without warranty of any kind,
 express or implied, including, without limitation, the warranties
@@ -1614,10 +1614,10 @@ be appreciated.
 
 TRADEMARK:
 
-The name "libpng" has not been registered by the Copyright owner
+The name "libpng" has not been registered by the Copyright owners
 as a trademark in any jurisdiction.  However, because libpng has
 been distributed and maintained world-wide, continually since 1995,
-the Copyright owner claims "common-law trademark protection" in any
+the Copyright owners claim "common-law trademark protection" in any
 jurisdiction where common-law trademark is recognized.
 
 OSI CERTIFICATION:
@@ -1638,6 +1638,59 @@ any encryption software.  See the EAR, paragraphs 734.3(b)(3) and
 Glenn Randers-Pehrson
 glennrp at users.sourceforge.net
 July 15, 2018
+
+### AUTHORS File Information
+```
+PNG REFERENCE LIBRARY AUTHORS
+=============================
+
+This is the list of PNG Reference Library ("libpng") Contributing
+Authors, for copyright and licensing purposes.
+
+ * Andreas Dilger
+ * Cosmin Truta
+ * Dave Martindale
+ * Eric S. Raymond
+ * Gilles Vollant
+ * Glenn Randers-Pehrson
+ * Greg Roelofs
+ * Guy Eric Schalnat
+ * James Yu
+ * John Bowler
+ * Kevin Bracey
+ * Magnus Holmgren
+ * Mandar Sahastrabuddhe
+ * Mans Rullgard
+ * Matt Sarett
+ * Mike Klein
+ * Pascal Massimino
+ * Paul Schmidt
+ * Qiang Zhou
+ * Sam Bushell
+ * Samuel Williams
+ * Simon-Pierre Cadieux
+ * Tim Wegner
+ * Tom Lane
+ * Tom Tanner
+ * Vadim Barkov
+ * Willem van Schaik
+ * Zhijie Liang
+ * Arm Holdings
+   - Richard Townsend
+ * Google Inc.
+   - Matt Sarett
+   - Mike Klein
+   - Dan Field
+   - Sami Boukortt
+
+The build projects, the build scripts, the test scripts, and other
+files in the "ci", "projects", "scripts" and "tests" directories, have
+other copyright owners, but are released under the libpng license.
+
+Some files in the "contrib" directory, and some tools-generated files
+that are distributed with libpng, have other copyright owners, and are
+released under other open source licenses.
+```
 
 --- end of LICENSE ---
 

--- a/jaxws/THIRD_PARTY_README
+++ b/jaxws/THIRD_PARTY_README
@@ -1639,8 +1639,8 @@ Glenn Randers-Pehrson
 glennrp at users.sourceforge.net
 July 15, 2018
 
-### AUTHORS File Information
-```
+AUTHORS File Information:
+
 PNG REFERENCE LIBRARY AUTHORS
 =============================
 
@@ -1690,7 +1690,6 @@ other copyright owners, but are released under the libpng license.
 Some files in the "contrib" directory, and some tools-generated files
 that are distributed with libpng, have other copyright owners, and are
 released under other open source licenses.
-```
 
 --- end of LICENSE ---
 

--- a/jaxws/THIRD_PARTY_README
+++ b/jaxws/THIRD_PARTY_README
@@ -1472,7 +1472,7 @@ included with JDK 8 and OpenJDK 8 source distributions.
 
 -------------------------------------------------------------------------------
 
-%% This notice is provided with respect to libpng 1.6.37, which may be
+%% This notice is provided with respect to libpng 1.6.38, which may be
 included with JRE 8, JDK 8, and OpenJDK 8.
 
 --- begin of LICENSE ---
@@ -1483,11 +1483,11 @@ COPYRIGHT NOTICE, DISCLAIMER, and LICENSE
 PNG Reference Library License version 2
 ---------------------------------------
 
- * Copyright (c) 1995-2019 The PNG Reference Library Authors.
- * Copyright (c) 2018-2019 Cosmin Truta.
- * Copyright (c) 2000-2002, 2004, 2006-2018 Glenn Randers-Pehrson.
- * Copyright (c) 1996-1997 Andreas Dilger.
- * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
+Copyright (c) 1995-2022 The PNG Reference Library Authors.
+Copyright (c) 2018-2022 Cosmin Truta
+Copyright (c) 1998-2018 Glenn Randers-Pehrson
+Copyright (c) 1996-1997 Andreas Dilger
+Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
 
 The software is supplied "as is", without warranty of any kind,
 express or implied, including, without limitation, the warranties
@@ -1614,10 +1614,10 @@ be appreciated.
 
 TRADEMARK:
 
-The name "libpng" has not been registered by the Copyright owner
+The name "libpng" has not been registered by the Copyright owners
 as a trademark in any jurisdiction.  However, because libpng has
 been distributed and maintained world-wide, continually since 1995,
-the Copyright owner claims "common-law trademark protection" in any
+the Copyright owners claim "common-law trademark protection" in any
 jurisdiction where common-law trademark is recognized.
 
 OSI CERTIFICATION:
@@ -1638,6 +1638,59 @@ any encryption software.  See the EAR, paragraphs 734.3(b)(3) and
 Glenn Randers-Pehrson
 glennrp at users.sourceforge.net
 July 15, 2018
+
+### AUTHORS File Information
+```
+PNG REFERENCE LIBRARY AUTHORS
+=============================
+
+This is the list of PNG Reference Library ("libpng") Contributing
+Authors, for copyright and licensing purposes.
+
+ * Andreas Dilger
+ * Cosmin Truta
+ * Dave Martindale
+ * Eric S. Raymond
+ * Gilles Vollant
+ * Glenn Randers-Pehrson
+ * Greg Roelofs
+ * Guy Eric Schalnat
+ * James Yu
+ * John Bowler
+ * Kevin Bracey
+ * Magnus Holmgren
+ * Mandar Sahastrabuddhe
+ * Mans Rullgard
+ * Matt Sarett
+ * Mike Klein
+ * Pascal Massimino
+ * Paul Schmidt
+ * Qiang Zhou
+ * Sam Bushell
+ * Samuel Williams
+ * Simon-Pierre Cadieux
+ * Tim Wegner
+ * Tom Lane
+ * Tom Tanner
+ * Vadim Barkov
+ * Willem van Schaik
+ * Zhijie Liang
+ * Arm Holdings
+   - Richard Townsend
+ * Google Inc.
+   - Matt Sarett
+   - Mike Klein
+   - Dan Field
+   - Sami Boukortt
+
+The build projects, the build scripts, the test scripts, and other
+files in the "ci", "projects", "scripts" and "tests" directories, have
+other copyright owners, but are released under the libpng license.
+
+Some files in the "contrib" directory, and some tools-generated files
+that are distributed with libpng, have other copyright owners, and are
+released under other open source licenses.
+```
 
 --- end of LICENSE ---
 

--- a/jdk/THIRD_PARTY_README
+++ b/jdk/THIRD_PARTY_README
@@ -1639,8 +1639,8 @@ Glenn Randers-Pehrson
 glennrp at users.sourceforge.net
 July 15, 2018
 
-### AUTHORS File Information
-```
+AUTHORS File Information:
+
 PNG REFERENCE LIBRARY AUTHORS
 =============================
 
@@ -1690,7 +1690,6 @@ other copyright owners, but are released under the libpng license.
 Some files in the "contrib" directory, and some tools-generated files
 that are distributed with libpng, have other copyright owners, and are
 released under other open source licenses.
-```
 
 --- end of LICENSE ---
 

--- a/jdk/THIRD_PARTY_README
+++ b/jdk/THIRD_PARTY_README
@@ -1472,7 +1472,7 @@ included with JDK 8 and OpenJDK 8 source distributions.
 
 -------------------------------------------------------------------------------
 
-%% This notice is provided with respect to libpng 1.6.37, which may be
+%% This notice is provided with respect to libpng 1.6.38, which may be
 included with JRE 8, JDK 8, and OpenJDK 8.
 
 --- begin of LICENSE ---
@@ -1483,11 +1483,11 @@ COPYRIGHT NOTICE, DISCLAIMER, and LICENSE
 PNG Reference Library License version 2
 ---------------------------------------
 
- * Copyright (c) 1995-2019 The PNG Reference Library Authors.
- * Copyright (c) 2018-2019 Cosmin Truta.
- * Copyright (c) 2000-2002, 2004, 2006-2018 Glenn Randers-Pehrson.
- * Copyright (c) 1996-1997 Andreas Dilger.
- * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
+Copyright (c) 1995-2022 The PNG Reference Library Authors.
+Copyright (c) 2018-2022 Cosmin Truta
+Copyright (c) 1998-2018 Glenn Randers-Pehrson
+Copyright (c) 1996-1997 Andreas Dilger
+Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
 
 The software is supplied "as is", without warranty of any kind,
 express or implied, including, without limitation, the warranties
@@ -1614,10 +1614,10 @@ be appreciated.
 
 TRADEMARK:
 
-The name "libpng" has not been registered by the Copyright owner
+The name "libpng" has not been registered by the Copyright owners
 as a trademark in any jurisdiction.  However, because libpng has
 been distributed and maintained world-wide, continually since 1995,
-the Copyright owner claims "common-law trademark protection" in any
+the Copyright owners claim "common-law trademark protection" in any
 jurisdiction where common-law trademark is recognized.
 
 OSI CERTIFICATION:
@@ -1638,6 +1638,59 @@ any encryption software.  See the EAR, paragraphs 734.3(b)(3) and
 Glenn Randers-Pehrson
 glennrp at users.sourceforge.net
 July 15, 2018
+
+### AUTHORS File Information
+```
+PNG REFERENCE LIBRARY AUTHORS
+=============================
+
+This is the list of PNG Reference Library ("libpng") Contributing
+Authors, for copyright and licensing purposes.
+
+ * Andreas Dilger
+ * Cosmin Truta
+ * Dave Martindale
+ * Eric S. Raymond
+ * Gilles Vollant
+ * Glenn Randers-Pehrson
+ * Greg Roelofs
+ * Guy Eric Schalnat
+ * James Yu
+ * John Bowler
+ * Kevin Bracey
+ * Magnus Holmgren
+ * Mandar Sahastrabuddhe
+ * Mans Rullgard
+ * Matt Sarett
+ * Mike Klein
+ * Pascal Massimino
+ * Paul Schmidt
+ * Qiang Zhou
+ * Sam Bushell
+ * Samuel Williams
+ * Simon-Pierre Cadieux
+ * Tim Wegner
+ * Tom Lane
+ * Tom Tanner
+ * Vadim Barkov
+ * Willem van Schaik
+ * Zhijie Liang
+ * Arm Holdings
+   - Richard Townsend
+ * Google Inc.
+   - Matt Sarett
+   - Mike Klein
+   - Dan Field
+   - Sami Boukortt
+
+The build projects, the build scripts, the test scripts, and other
+files in the "ci", "projects", "scripts" and "tests" directories, have
+other copyright owners, but are released under the libpng license.
+
+Some files in the "contrib" directory, and some tools-generated files
+that are distributed with libpng, have other copyright owners, and are
+released under other open source licenses.
+```
 
 --- end of LICENSE ---
 

--- a/jdk/src/share/native/sun/awt/libpng/CHANGES
+++ b/jdk/src/share/native/sun/awt/libpng/CHANGES
@@ -2295,7 +2295,7 @@ Version 1.4.0beta58 [May 14, 2009]
   Clarified usage of sig_bit versus sig_bit_p in example.c (Vincent Torri)
 
 Version 1.4.0beta59 [May 15, 2009]
-  Reformated sources in libpng style (3-space intentation, comment format)
+  Reformated sources in libpng style (3-space indentation, comment format)
   Fixed typo in libpng docs (PNG_FILTER_AVE should be PNG_FILTER_AVG)
   Added sections about the git repository and our coding style to the
     documentation
@@ -3886,7 +3886,7 @@ Version 1.6.0beta06 [January 24, 2012]
 Version 1.6.0beta07 [January 28, 2012]
   Eliminated Intel icc/icl compiler warnings. The Intel (GCC derived)
     compiler issues slightly different warnings from those issued by the
-    current vesions of GCC. This eliminates those warnings by
+    current versions of GCC. This eliminates those warnings by
     adding/removing casts and small code rewrites.
   Updated configure.ac from autoupdate: added --enable-werror option.
     Also some layout regularization and removal of introduced tab characters
@@ -6102,6 +6102,12 @@ Version 1.6.37 [April 14, 2019]
     (Contributed by Miguel Ojeda)
   Added makefiles for AddressSanitizer-enabled builds.
   Cleaned up various makefiles.
+
+Version 1.6.38 [September 14, 2022]
+  Added configurations and scripts for continuous integration.
+  Fixed various errors in the handling of tRNS, hIST and eXIf.
+  Implemented many stability improvements across all platforms.
+  Updated the internal documentation.
 
 Send comments/corrections/commendations to png-mng-implement at lists.sf.net.
 Subscription is required; visit

--- a/jdk/src/share/native/sun/awt/libpng/LICENSE
+++ b/jdk/src/share/native/sun/awt/libpng/LICENSE
@@ -4,8 +4,8 @@ COPYRIGHT NOTICE, DISCLAIMER, and LICENSE
 PNG Reference Library License version 2
 ---------------------------------------
 
- * Copyright (c) 1995-2019 The PNG Reference Library Authors.
- * Copyright (c) 2018-2019 Cosmin Truta.
+ * Copyright (c) 1995-2022 The PNG Reference Library Authors.
+ * Copyright (c) 2018-2022 Cosmin Truta.
  * Copyright (c) 2000-2002, 2004, 2006-2018 Glenn Randers-Pehrson.
  * Copyright (c) 1996-1997 Andreas Dilger.
  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.

--- a/jdk/src/share/native/sun/awt/libpng/README
+++ b/jdk/src/share/native/sun/awt/libpng/README
@@ -1,12 +1,12 @@
-README for libpng version 1.6.37 - April 14, 2019
-=================================================
+README for libpng version 1.6.38
+================================
 
 See the note about version numbers near the top of png.h.
 See INSTALL for instructions on how to install libpng.
 
 Libpng comes in several distribution formats.  Get libpng-*.tar.gz or
-libpng-*.tar.xz or if you want UNIX-style line endings in the text
-files, or lpng*.7z or lpng*.zip if you want DOS-style line endings.
+libpng-*.tar.xz if you want UNIX-style line endings in the text files,
+or lpng*.7z or lpng*.zip if you want DOS-style line endings.
 
 Version 0.89 was the first official release of libpng.  Don't let the
 fact that it's the first release fool you.  The libpng library has been

--- a/jdk/src/share/native/sun/awt/libpng/png.c
+++ b/jdk/src/share/native/sun/awt/libpng/png.c
@@ -29,7 +29,7 @@
  * However, the following notice accompanied the original version of this
  * file and, per its terms, should not be removed:
  *
- * Copyright (c) 2018-2019 Cosmin Truta
+ * Copyright (c) 2018-2022 Cosmin Truta
  * Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson
  * Copyright (c) 1996-1997 Andreas Dilger
  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
@@ -42,7 +42,7 @@
 #include "pngpriv.h"
 
 /* Generate a compiler error if there is an old png.h in the search path. */
-typedef png_libpng_version_1_6_37 Your_png_h_is_not_version_1_6_37;
+typedef png_libpng_version_1_6_38 Your_png_h_is_not_version_1_6_38;
 
 #ifdef __GNUC__
 /* The version tests may need to be added to, but the problem warning has
@@ -748,7 +748,7 @@ png_init_io(png_structrp png_ptr, png_FILE_p fp)
  *
  * Where UNSIGNED_MAX is the appropriate maximum unsigned value, so when the
  * negative integral value is added the result will be an unsigned value
- * correspnding to the 2's complement representation.
+ * corresponding to the 2's complement representation.
  */
 void PNGAPI
 png_save_int_32(png_bytep buf, png_int_32 i)
@@ -843,8 +843,8 @@ png_get_copyright(png_const_structrp png_ptr)
    return PNG_STRING_COPYRIGHT
 #else
    return PNG_STRING_NEWLINE \
-      "libpng version 1.6.37" PNG_STRING_NEWLINE \
-      "Copyright (c) 2018-2019 Cosmin Truta" PNG_STRING_NEWLINE \
+      "libpng version 1.6.38" PNG_STRING_NEWLINE \
+      "Copyright (c) 2018-2022 Cosmin Truta" PNG_STRING_NEWLINE \
       "Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson" \
       PNG_STRING_NEWLINE \
       "Copyright (c) 1996-1997 Andreas Dilger" PNG_STRING_NEWLINE \
@@ -1871,12 +1871,12 @@ png_icc_profile_error(png_const_structrp png_ptr, png_colorspacerp colorspace,
 #  ifdef PNG_WARNINGS_SUPPORTED
    else
       {
-         char number[PNG_NUMBER_BUFFER_SIZE]; /* +24 = 114*/
+         char number[PNG_NUMBER_BUFFER_SIZE]; /* +24 = 114 */
 
          pos = png_safecat(message, (sizeof message), pos,
              png_format_number(number, number+(sizeof number),
              PNG_NUMBER_FORMAT_x, value));
-         pos = png_safecat(message, (sizeof message), pos, "h: "); /*+2 = 116*/
+         pos = png_safecat(message, (sizeof message), pos, "h: "); /* +2 = 116 */
       }
 #  endif
    /* The 'reason' is an arbitrary message, allow +79 maximum 195 */

--- a/jdk/src/share/native/sun/awt/libpng/png.h
+++ b/jdk/src/share/native/sun/awt/libpng/png.h
@@ -29,9 +29,9 @@
  * However, the following notice accompanied the original version of this
  * file and, per its terms, should not be removed:
  *
- * libpng version 1.6.37 - April 14, 2019
+ * libpng version 1.6.38 - September 14, 2022
  *
- * Copyright (c) 2018-2019 Cosmin Truta
+ * Copyright (c) 2018-2022 Cosmin Truta
  * Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson
  * Copyright (c) 1996-1997 Andreas Dilger
  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
@@ -43,7 +43,7 @@
  *   libpng versions 0.89, June 1996, through 0.96, May 1997: Andreas Dilger
  *   libpng versions 0.97, January 1998, through 1.6.35, July 2018:
  *     Glenn Randers-Pehrson
- *   libpng versions 1.6.36, December 2018, through 1.6.37, April 2019:
+ *   libpng versions 1.6.36, December 2018, through 1.6.38, September 2022:
  *     Cosmin Truta
  *   See also "Contributing Authors", below.
  */
@@ -55,8 +55,8 @@
  * PNG Reference Library License version 2
  * ---------------------------------------
  *
- *  * Copyright (c) 1995-2019 The PNG Reference Library Authors.
- *  * Copyright (c) 2018-2019 Cosmin Truta.
+ *  * Copyright (c) 1995-2022 The PNG Reference Library Authors.
+ *  * Copyright (c) 2018-2022 Cosmin Truta.
  *  * Copyright (c) 2000-2002, 2004, 2006-2018 Glenn Randers-Pehrson.
  *  * Copyright (c) 1996-1997 Andreas Dilger.
  *  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
@@ -267,7 +267,7 @@
  *    ...
  *    1.5.30                  15    10530  15.so.15.30[.0]
  *    ...
- *    1.6.37                  16    10637  16.so.16.37[.0]
+ *    1.6.38                  16    10638  16.so.16.38[.0]
  *
  *    Henceforth the source version will match the shared-library major and
  *    minor numbers; the shared-library major version number will be used for
@@ -306,8 +306,8 @@
  */
 
 /* Version information for png.h - this should match the version in png.c */
-#define PNG_LIBPNG_VER_STRING "1.6.37"
-#define PNG_HEADER_VERSION_STRING " libpng version 1.6.37 - April 14, 2019\n"
+#define PNG_LIBPNG_VER_STRING "1.6.38"
+#define PNG_HEADER_VERSION_STRING " libpng version 1.6.38 - September 14, 2022\n"
 
 #define PNG_LIBPNG_VER_SONUM   16
 #define PNG_LIBPNG_VER_DLLNUM  16
@@ -315,7 +315,7 @@
 /* These should match the first 3 components of PNG_LIBPNG_VER_STRING: */
 #define PNG_LIBPNG_VER_MAJOR   1
 #define PNG_LIBPNG_VER_MINOR   6
-#define PNG_LIBPNG_VER_RELEASE 37
+#define PNG_LIBPNG_VER_RELEASE 38
 
 /* This should be zero for a public release, or non-zero for a
  * development version.  [Deprecated]
@@ -346,7 +346,7 @@
  * From version 1.0.1 it is:
  * XXYYZZ, where XX=major, YY=minor, ZZ=release
  */
-#define PNG_LIBPNG_VER 10637 /* 1.6.37 */
+#define PNG_LIBPNG_VER 10638 /* 1.6.38 */
 
 /* Library configuration: these options cannot be changed after
  * the library has been built.
@@ -456,7 +456,7 @@ extern "C" {
 /* This triggers a compiler error in png.c, if png.c and png.h
  * do not agree upon the version number.
  */
-typedef char* png_libpng_version_1_6_37;
+typedef char* png_libpng_version_1_6_38;
 
 /* Basic control structions.  Read libpng-manual.txt or libpng.3 for more info.
  *
@@ -1474,7 +1474,7 @@ PNG_EXPORT(66, void, png_set_crc_action, (png_structrp png_ptr, int crit_action,
  * mainly useful for testing, as the defaults should work with most users.
  * Those users who are tight on memory or want faster performance at the
  * expense of compression can modify them.  See the compression library
- * header file (zlib.h) for an explination of the compression functions.
+ * header file (zlib.h) for an explanation of the compression functions.
  */
 
 /* Set the filtering method(s) used by libpng.  Currently, the only valid
@@ -1529,7 +1529,7 @@ PNG_FIXED_EXPORT(209, void, png_set_filter_heuristics_fixed,
  * 0 - 9, corresponding directly to the zlib compression levels 0 - 9
  * (0 - no compression, 9 - "maximal" compression).  Note that tests have
  * shown that zlib compression levels 3-6 usually perform as well as level 9
- * for PNG images, and do considerably fewer caclulations.  In the future,
+ * for PNG images, and do considerably fewer calculations.  In the future,
  * these values may not correspond directly to the zlib compression levels.
  */
 #ifdef PNG_WRITE_CUSTOMIZE_COMPRESSION_SUPPORTED

--- a/jdk/src/share/native/sun/awt/libpng/pngconf.h
+++ b/jdk/src/share/native/sun/awt/libpng/pngconf.h
@@ -29,9 +29,9 @@
  * However, the following notice accompanied the original version of this
  * file and, per its terms, should not be removed:
  *
- * libpng version 1.6.37
+ * libpng version 1.6.38
  *
- * Copyright (c) 2018-2019 Cosmin Truta
+ * Copyright (c) 2018-2022 Cosmin Truta
  * Copyright (c) 1998-2002,2004,2006-2016,2018 Glenn Randers-Pehrson
  * Copyright (c) 1996-1997 Andreas Dilger
  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
@@ -208,8 +208,8 @@
  * compiler-specific macros to the values required to change the calling
  * conventions of the various functions.
  */
-#if defined(_Windows) || defined(_WINDOWS) || defined(WIN32) ||\
-    defined(_WIN32) || defined(__WIN32__) || defined(__CYGWIN__)
+#if defined(_WIN32) || defined(__WIN32__) || defined(__NT__) || \
+    defined(__CYGWIN__)
   /* Windows system (DOS doesn't support DLLs).  Includes builds under Cygwin or
    * MinGW on any architecture currently supported by Windows.  Also includes
    * Watcom builds but these need special treatment because they are not

--- a/jdk/src/share/native/sun/awt/libpng/pngget.c
+++ b/jdk/src/share/native/sun/awt/libpng/pngget.c
@@ -1179,7 +1179,7 @@ png_get_unknown_chunks(png_const_structrp png_ptr, png_inforp info_ptr,
 
 #ifdef PNG_READ_RGB_TO_GRAY_SUPPORTED
 png_byte PNGAPI
-png_get_rgb_to_gray_status (png_const_structrp png_ptr)
+png_get_rgb_to_gray_status(png_const_structrp png_ptr)
 {
    return (png_byte)(png_ptr ? png_ptr->rgb_to_gray_status : 0);
 }
@@ -1220,27 +1220,27 @@ png_get_compression_buffer_size(png_const_structrp png_ptr)
 /* These functions were added to libpng 1.2.6 and were enabled
  * by default in libpng-1.4.0 */
 png_uint_32 PNGAPI
-png_get_user_width_max (png_const_structrp png_ptr)
+png_get_user_width_max(png_const_structrp png_ptr)
 {
    return (png_ptr ? png_ptr->user_width_max : 0);
 }
 
 png_uint_32 PNGAPI
-png_get_user_height_max (png_const_structrp png_ptr)
+png_get_user_height_max(png_const_structrp png_ptr)
 {
    return (png_ptr ? png_ptr->user_height_max : 0);
 }
 
 /* This function was added to libpng 1.4.0 */
 png_uint_32 PNGAPI
-png_get_chunk_cache_max (png_const_structrp png_ptr)
+png_get_chunk_cache_max(png_const_structrp png_ptr)
 {
    return (png_ptr ? png_ptr->user_chunk_cache_max : 0);
 }
 
 /* This function was added to libpng 1.4.1 */
 png_alloc_size_t PNGAPI
-png_get_chunk_malloc_max (png_const_structrp png_ptr)
+png_get_chunk_malloc_max(png_const_structrp png_ptr)
 {
    return (png_ptr ? png_ptr->user_chunk_malloc_max : 0);
 }
@@ -1249,13 +1249,13 @@ png_get_chunk_malloc_max (png_const_structrp png_ptr)
 /* These functions were added to libpng 1.4.0 */
 #ifdef PNG_IO_STATE_SUPPORTED
 png_uint_32 PNGAPI
-png_get_io_state (png_const_structrp png_ptr)
+png_get_io_state(png_const_structrp png_ptr)
 {
    return png_ptr->io_state;
 }
 
 png_uint_32 PNGAPI
-png_get_io_chunk_type (png_const_structrp png_ptr)
+png_get_io_chunk_type(png_const_structrp png_ptr)
 {
    return png_ptr->chunk_name;
 }

--- a/jdk/src/share/native/sun/awt/libpng/pnglibconf.h
+++ b/jdk/src/share/native/sun/awt/libpng/pnglibconf.h
@@ -31,9 +31,9 @@
  * However, the following notice accompanied the original version of this
  * file and, per its terms, should not be removed:
  */
-/* libpng version 1.6.37 */
+/* libpng version 1.6.38 */
 
-/* Copyright (c) 2018-2019 Cosmin Truta */
+/* Copyright (c) 2018-2022 Cosmin Truta */
 /* Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson */
 
 /* This code is released under the libpng license. */

--- a/jdk/src/share/native/sun/awt/libpng/pngpriv.h
+++ b/jdk/src/share/native/sun/awt/libpng/pngpriv.h
@@ -29,7 +29,7 @@
  * However, the following notice accompanied the original version of this
  * file and, per its terms, should not be removed:
  *
- * Copyright (c) 2018-2019 Cosmin Truta
+ * Copyright (c) 2018-2022 Cosmin Truta
  * Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson
  * Copyright (c) 1996-1997 Andreas Dilger
  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
@@ -202,7 +202,7 @@
 #     else /* !defined __ARM_NEON__ */
          /* The 'intrinsics' code simply won't compile without this -mfpu=neon:
           */
-#        if !defined(__aarch64__)
+#        if !defined(__aarch64__) && !defined(_M_ARM64)
             /* The assembler code currently does not work on ARM64 */
 #          define PNG_ARM_NEON_IMPLEMENTATION 2
 #        endif /* __aarch64__ */
@@ -213,6 +213,8 @@
       /* Use the intrinsics code by default. */
 #     define PNG_ARM_NEON_IMPLEMENTATION 1
 #  endif
+#else /* PNG_ARM_NEON_OPT == 0 */
+#     define PNG_ARM_NEON_IMPLEMENTATION 0
 #endif /* PNG_ARM_NEON_OPT > 0 */
 
 #ifndef PNG_MIPS_MSA_OPT
@@ -291,11 +293,15 @@
 #  ifndef PNG_MIPS_MSA_IMPLEMENTATION
 #     define PNG_MIPS_MSA_IMPLEMENTATION 1
 #  endif
+#else
+#  define PNG_MIPS_MSA_IMPLEMENTATION 0
 #endif /* PNG_MIPS_MSA_OPT > 0 */
 
 #if PNG_POWERPC_VSX_OPT > 0
 #  define PNG_FILTER_OPTIMIZATIONS png_init_filter_functions_vsx
 #  define PNG_POWERPC_VSX_IMPLEMENTATION 1
+#else
+#  define PNG_POWERPC_VSX_IMPLEMENTATION 0
 #endif
 
 
@@ -520,16 +526,7 @@
    static_cast<type>(static_cast<const void*>(value))
 #else
 #  define png_voidcast(type, value) (value)
-#  ifdef _WIN64
-#     ifdef __GNUC__
-         typedef unsigned long long png_ptruint;
-#     else
-         typedef unsigned __int64 png_ptruint;
-#     endif
-#  else
-      typedef unsigned long png_ptruint;
-#  endif
-#  define png_constcast(type, value) ((type)(png_ptruint)(const void*)(value))
+#  define png_constcast(type, value) ((type)(void*)(const void*)(value))
 #  define png_aligncast(type, value) ((void*)(value))
 #  define png_aligncastconst(type, value) ((const void*)(value))
 #endif /* __cplusplus */
@@ -571,9 +568,8 @@
 #  include <alloc.h>
 #endif
 
-#if defined(WIN32) || defined(_Windows) || defined(_WINDOWS) || \
-    defined(_WIN32) || defined(__WIN32__)
-#  include <windows.h>  /* defines _WINDOWS_ macro */
+#if defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
+#  include <windows.h>
 #endif
 #endif /* PNG_VERSION_INFO_ONLY */
 
@@ -582,24 +578,20 @@
  * functions that are passed far data must be model-independent.
  */
 
-/* Memory model/platform independent fns */
+/* Platform-independent functions */
 #ifndef PNG_ABORT
-#  ifdef _WINDOWS_
-#    define PNG_ABORT() ExitProcess(0)
-#  else
-#    define PNG_ABORT() abort()
-#  endif
+#  define PNG_ABORT() abort()
 #endif
 
 /* These macros may need to be architecture dependent. */
-#define PNG_ALIGN_NONE   0 /* do not use data alignment */
-#define PNG_ALIGN_ALWAYS 1 /* assume unaligned accesses are OK */
+#define PNG_ALIGN_NONE      0 /* do not use data alignment */
+#define PNG_ALIGN_ALWAYS    1 /* assume unaligned accesses are OK */
 #ifdef offsetof
-#  define PNG_ALIGN_OFFSET 2 /* use offsetof to determine alignment */
+#  define PNG_ALIGN_OFFSET  2 /* use offsetof to determine alignment */
 #else
 #  define PNG_ALIGN_OFFSET -1 /* prevent the use of this */
 #endif
-#define PNG_ALIGN_SIZE   3 /* use sizeof to determine alignment */
+#define PNG_ALIGN_SIZE      3 /* use sizeof to determine alignment */
 
 #ifndef PNG_ALIGN_TYPE
    /* Default to using aligned access optimizations and requiring alignment to a
@@ -613,26 +605,25 @@
    /* This is used because in some compiler implementations non-aligned
     * structure members are supported, so the offsetof approach below fails.
     * Set PNG_ALIGN_SIZE=0 for compiler combinations where unaligned access
-    * is good for performance.  Do not do this unless you have tested the result
-    * and understand it.
+    * is good for performance.  Do not do this unless you have tested the
+    * result and understand it.
     */
-#  define png_alignof(type) (sizeof (type))
+#  define png_alignof(type) (sizeof(type))
 #else
 #  if PNG_ALIGN_TYPE == PNG_ALIGN_OFFSET
-#     define png_alignof(type) offsetof(struct{char c; type t;}, t)
+#    define png_alignof(type) offsetof(struct{char c; type t;}, t)
 #  else
-#     if PNG_ALIGN_TYPE == PNG_ALIGN_ALWAYS
-#        define png_alignof(type) (1)
-#     endif
-      /* Else leave png_alignof undefined to prevent use thereof */
+#    if PNG_ALIGN_TYPE == PNG_ALIGN_ALWAYS
+#      define png_alignof(type) 1
+#    endif
+     /* Else leave png_alignof undefined to prevent use thereof */
 #  endif
 #endif
 
-/* This implicitly assumes alignment is always to a power of 2. */
+/* This implicitly assumes alignment is always a multiple of 2. */
 #ifdef png_alignof
-#  define png_isaligned(ptr, type)\
-   (((type)((const char*)ptr-(const char*)0) & \
-   (type)(png_alignof(type)-1)) == 0)
+#  define png_isaligned(ptr, type) \
+   (((type)(size_t)((const void*)(ptr)) & (type)(png_alignof(type)-1)) == 0)
 #else
 #  define png_isaligned(ptr, type) 0
 #endif

--- a/jdk/src/share/native/sun/awt/libpng/pngread.c
+++ b/jdk/src/share/native/sun/awt/libpng/pngread.c
@@ -3480,7 +3480,6 @@ png_image_read_background(png_voidp argument)
 
             for (pass = 0; pass < passes; ++pass)
             {
-               png_bytep row = png_voidcast(png_bytep, display->first_row);
                unsigned int     startx, stepx, stepy;
                png_uint_32      y;
 
@@ -3585,8 +3584,6 @@ png_image_read_background(png_voidp argument)
 
                         inrow += 2; /* gray and alpha channel */
                      }
-
-                     row += display->row_bytes;
                   }
                }
             }

--- a/jdk/src/share/native/sun/awt/libpng/pngrtran.c
+++ b/jdk/src/share/native/sun/awt/libpng/pngrtran.c
@@ -49,7 +49,7 @@
 #ifdef PNG_ARM_NEON_IMPLEMENTATION
 #  if PNG_ARM_NEON_IMPLEMENTATION == 1
 #    define PNG_ARM_NEON_INTRINSICS_AVAILABLE
-#    if defined(_MSC_VER) && defined(_M_ARM64)
+#    if defined(_MSC_VER) && !defined(__clang__) && defined(_M_ARM64)
 #      include <arm64_neon.h>
 #    else
 #      include <arm_neon.h>

--- a/jdk/src/share/native/sun/awt/libpng/pngrutil.c
+++ b/jdk/src/share/native/sun/awt/libpng/pngrutil.c
@@ -29,7 +29,7 @@
  * However, the following notice accompanied the original version of this
  * file and, per its terms, should not be removed:
  *
- * Copyright (c) 2018 Cosmin Truta
+ * Copyright (c) 2018-2022 Cosmin Truta
  * Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson
  * Copyright (c) 1996-1997 Andreas Dilger
  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
@@ -329,7 +329,6 @@ png_read_buffer(png_structrp png_ptr, png_alloc_size_t new_size, int warn)
 
    if (buffer != NULL && new_size > png_ptr->read_buffer_size)
    {
-      png_ptr->read_buffer = NULL;
       png_ptr->read_buffer = NULL;
       png_ptr->read_buffer_size = 0;
       png_free(png_ptr, buffer);
@@ -2104,21 +2103,22 @@ png_handle_eXIf(png_structrp png_ptr, png_inforp info_ptr, png_uint_32 length)
       png_byte buf[1];
       png_crc_read(png_ptr, buf, 1);
       info_ptr->eXIf_buf[i] = buf[0];
-      if (i == 1 && buf[0] != 'M' && buf[0] != 'I'
-                 && info_ptr->eXIf_buf[0] != buf[0])
+      if (i == 1)
       {
-         png_crc_finish(png_ptr, length);
-         png_chunk_benign_error(png_ptr, "incorrect byte-order specifier");
-         png_free(png_ptr, info_ptr->eXIf_buf);
-         info_ptr->eXIf_buf = NULL;
-         return;
+         if ((buf[0] != 'M' && buf[0] != 'I') ||
+             (info_ptr->eXIf_buf[0] != buf[0]))
+         {
+            png_crc_finish(png_ptr, length - 2);
+            png_chunk_benign_error(png_ptr, "incorrect byte-order specifier");
+            png_free(png_ptr, info_ptr->eXIf_buf);
+            info_ptr->eXIf_buf = NULL;
+            return;
+         }
       }
    }
 
-   if (png_crc_finish(png_ptr, 0) != 0)
-      return;
-
-   png_set_eXIf_1(png_ptr, info_ptr, length, info_ptr->eXIf_buf);
+   if (png_crc_finish(png_ptr, 0) == 0)
+      png_set_eXIf_1(png_ptr, info_ptr, length, info_ptr->eXIf_buf);
 
    png_free(png_ptr, info_ptr->eXIf_buf);
    info_ptr->eXIf_buf = NULL;
@@ -2154,8 +2154,9 @@ png_handle_hIST(png_structrp png_ptr, png_inforp info_ptr, png_uint_32 length)
 
    num = length / 2 ;
 
-   if (num != (unsigned int) png_ptr->num_palette ||
-       num > (unsigned int) PNG_MAX_PALETTE_LENGTH)
+   if (length != num * 2 ||
+       num != (unsigned int)png_ptr->num_palette ||
+       num > (unsigned int)PNG_MAX_PALETTE_LENGTH)
    {
       png_crc_finish(png_ptr, length);
       png_chunk_benign_error(png_ptr, "invalid");
@@ -4649,14 +4650,13 @@ defined(PNG_USER_TRANSFORM_PTR_SUPPORTED)
        */
       {
          png_bytep temp = png_ptr->big_row_buf + 32;
-         int extra = (int)((temp - (png_bytep)0) & 0x0f);
+         size_t extra = (size_t)temp & 0x0f;
          png_ptr->row_buf = temp - extra - 1/*filter byte*/;
 
          temp = png_ptr->big_prev_row + 32;
-         extra = (int)((temp - (png_bytep)0) & 0x0f);
+         extra = (size_t)temp & 0x0f;
          png_ptr->prev_row = temp - extra - 1/*filter byte*/;
       }
-
 #else
       /* Use 31 bytes of padding before and 17 bytes after row_buf. */
       png_ptr->row_buf = png_ptr->big_row_buf + 31;

--- a/jdk/src/share/native/sun/awt/libpng/pngset.c
+++ b/jdk/src/share/native/sun/awt/libpng/pngset.c
@@ -29,7 +29,7 @@
  * However, the following notice accompanied the original version of this
  * file and, per its terms, should not be removed:
  *
- * Copyright (c) 2018 Cosmin Truta
+ * Copyright (c) 2018-2022 Cosmin Truta
  * Copyright (c) 1998-2018 Glenn Randers-Pehrson
  * Copyright (c) 1996-1997 Andreas Dilger
  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
@@ -1047,6 +1047,9 @@ png_set_tRNS(png_structrp png_ptr, png_inforp info_ptr,
           info_ptr->trans_alpha = png_voidcast(png_bytep,
               png_malloc(png_ptr, PNG_MAX_PALETTE_LENGTH));
           memcpy(info_ptr->trans_alpha, trans_alpha, (size_t)num_trans);
+
+          info_ptr->valid |= PNG_INFO_tRNS;
+          info_ptr->free_me |= PNG_FREE_TRNS;
        }
        png_ptr->trans_alpha = info_ptr->trans_alpha;
    }
@@ -1354,7 +1357,7 @@ png_set_unknown_chunk_location(png_const_structrp png_ptr, png_inforp info_ptr,
 
 #ifdef PNG_MNG_FEATURES_SUPPORTED
 png_uint_32 PNGAPI
-png_permit_mng_features (png_structrp png_ptr, png_uint_32 mng_features)
+png_permit_mng_features(png_structrp png_ptr, png_uint_32 mng_features)
 {
    png_debug(1, "in png_permit_mng_features");
 
@@ -1661,7 +1664,7 @@ png_set_invalid(png_const_structrp png_ptr, png_inforp info_ptr, int mask)
 #ifdef PNG_SET_USER_LIMITS_SUPPORTED
 /* This function was added to libpng 1.2.6 */
 void PNGAPI
-png_set_user_limits (png_structrp png_ptr, png_uint_32 user_width_max,
+png_set_user_limits(png_structrp png_ptr, png_uint_32 user_width_max,
     png_uint_32 user_height_max)
 {
    /* Images with dimensions larger than these limits will be
@@ -1677,7 +1680,7 @@ png_set_user_limits (png_structrp png_ptr, png_uint_32 user_width_max,
 
 /* This function was added to libpng 1.4.0 */
 void PNGAPI
-png_set_chunk_cache_max (png_structrp png_ptr, png_uint_32 user_chunk_cache_max)
+png_set_chunk_cache_max(png_structrp png_ptr, png_uint_32 user_chunk_cache_max)
 {
    if (png_ptr != NULL)
       png_ptr->user_chunk_cache_max = user_chunk_cache_max;
@@ -1685,7 +1688,7 @@ png_set_chunk_cache_max (png_structrp png_ptr, png_uint_32 user_chunk_cache_max)
 
 /* This function was added to libpng 1.4.1 */
 void PNGAPI
-png_set_chunk_malloc_max (png_structrp png_ptr,
+png_set_chunk_malloc_max(png_structrp png_ptr,
     png_alloc_size_t user_chunk_malloc_max)
 {
    if (png_ptr != NULL)

--- a/jdk/src/share/native/sun/awt/libpng/pngstruct.h
+++ b/jdk/src/share/native/sun/awt/libpng/pngstruct.h
@@ -29,7 +29,7 @@
  * However, the following notice accompanied the original version of this
  * file and, per its terms, should not be removed:
  *
- * Copyright (c) 2018-2019 Cosmin Truta
+ * Copyright (c) 2018-2022 Cosmin Truta
  * Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson
  * Copyright (c) 1996-1997 Andreas Dilger
  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
@@ -362,17 +362,7 @@ struct png_struct_def
    size_t current_buffer_size;       /* amount of data now in current_buffer */
    int process_mode;                 /* what push library is currently doing */
    int cur_palette;                  /* current push library palette index */
-
 #endif /* PROGRESSIVE_READ */
-
-#if defined(__TURBOC__) && !defined(_Windows) && !defined(__FLAT__)
-/* For the Borland special 64K segment handler */
-   png_bytepp offset_table_ptr;
-   png_bytep offset_table;
-   png_uint_16 offset_table_number;
-   png_uint_16 offset_table_count;
-   png_uint_16 offset_table_count_free;
-#endif
 
 #ifdef PNG_READ_QUANTIZE_SUPPORTED
    png_bytep palette_lookup; /* lookup table for quantizing */

--- a/langtools/THIRD_PARTY_README
+++ b/langtools/THIRD_PARTY_README
@@ -1639,8 +1639,8 @@ Glenn Randers-Pehrson
 glennrp at users.sourceforge.net
 July 15, 2018
 
-### AUTHORS File Information
-```
+AUTHORS File Information:
+
 PNG REFERENCE LIBRARY AUTHORS
 =============================
 
@@ -1690,7 +1690,6 @@ other copyright owners, but are released under the libpng license.
 Some files in the "contrib" directory, and some tools-generated files
 that are distributed with libpng, have other copyright owners, and are
 released under other open source licenses.
-```
 
 --- end of LICENSE ---
 

--- a/langtools/THIRD_PARTY_README
+++ b/langtools/THIRD_PARTY_README
@@ -1472,7 +1472,7 @@ included with JDK 8 and OpenJDK 8 source distributions.
 
 -------------------------------------------------------------------------------
 
-%% This notice is provided with respect to libpng 1.6.37, which may be
+%% This notice is provided with respect to libpng 1.6.38, which may be
 included with JRE 8, JDK 8, and OpenJDK 8.
 
 --- begin of LICENSE ---
@@ -1483,11 +1483,11 @@ COPYRIGHT NOTICE, DISCLAIMER, and LICENSE
 PNG Reference Library License version 2
 ---------------------------------------
 
- * Copyright (c) 1995-2019 The PNG Reference Library Authors.
- * Copyright (c) 2018-2019 Cosmin Truta.
- * Copyright (c) 2000-2002, 2004, 2006-2018 Glenn Randers-Pehrson.
- * Copyright (c) 1996-1997 Andreas Dilger.
- * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
+Copyright (c) 1995-2022 The PNG Reference Library Authors.
+Copyright (c) 2018-2022 Cosmin Truta
+Copyright (c) 1998-2018 Glenn Randers-Pehrson
+Copyright (c) 1996-1997 Andreas Dilger
+Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
 
 The software is supplied "as is", without warranty of any kind,
 express or implied, including, without limitation, the warranties
@@ -1614,10 +1614,10 @@ be appreciated.
 
 TRADEMARK:
 
-The name "libpng" has not been registered by the Copyright owner
+The name "libpng" has not been registered by the Copyright owners
 as a trademark in any jurisdiction.  However, because libpng has
 been distributed and maintained world-wide, continually since 1995,
-the Copyright owner claims "common-law trademark protection" in any
+the Copyright owners claim "common-law trademark protection" in any
 jurisdiction where common-law trademark is recognized.
 
 OSI CERTIFICATION:
@@ -1638,6 +1638,59 @@ any encryption software.  See the EAR, paragraphs 734.3(b)(3) and
 Glenn Randers-Pehrson
 glennrp at users.sourceforge.net
 July 15, 2018
+
+### AUTHORS File Information
+```
+PNG REFERENCE LIBRARY AUTHORS
+=============================
+
+This is the list of PNG Reference Library ("libpng") Contributing
+Authors, for copyright and licensing purposes.
+
+ * Andreas Dilger
+ * Cosmin Truta
+ * Dave Martindale
+ * Eric S. Raymond
+ * Gilles Vollant
+ * Glenn Randers-Pehrson
+ * Greg Roelofs
+ * Guy Eric Schalnat
+ * James Yu
+ * John Bowler
+ * Kevin Bracey
+ * Magnus Holmgren
+ * Mandar Sahastrabuddhe
+ * Mans Rullgard
+ * Matt Sarett
+ * Mike Klein
+ * Pascal Massimino
+ * Paul Schmidt
+ * Qiang Zhou
+ * Sam Bushell
+ * Samuel Williams
+ * Simon-Pierre Cadieux
+ * Tim Wegner
+ * Tom Lane
+ * Tom Tanner
+ * Vadim Barkov
+ * Willem van Schaik
+ * Zhijie Liang
+ * Arm Holdings
+   - Richard Townsend
+ * Google Inc.
+   - Matt Sarett
+   - Mike Klein
+   - Dan Field
+   - Sami Boukortt
+
+The build projects, the build scripts, the test scripts, and other
+files in the "ci", "projects", "scripts" and "tests" directories, have
+other copyright owners, but are released under the libpng license.
+
+Some files in the "contrib" directory, and some tools-generated files
+that are distributed with libpng, have other copyright owners, and are
+released under other open source licenses.
+```
 
 --- end of LICENSE ---
 

--- a/nashorn/THIRD_PARTY_README
+++ b/nashorn/THIRD_PARTY_README
@@ -1639,8 +1639,8 @@ Glenn Randers-Pehrson
 glennrp at users.sourceforge.net
 July 15, 2018
 
-### AUTHORS File Information
-```
+AUTHORS File Information:
+
 PNG REFERENCE LIBRARY AUTHORS
 =============================
 
@@ -1690,7 +1690,6 @@ other copyright owners, but are released under the libpng license.
 Some files in the "contrib" directory, and some tools-generated files
 that are distributed with libpng, have other copyright owners, and are
 released under other open source licenses.
-```
 
 --- end of LICENSE ---
 

--- a/nashorn/THIRD_PARTY_README
+++ b/nashorn/THIRD_PARTY_README
@@ -1472,7 +1472,7 @@ included with JDK 8 and OpenJDK 8 source distributions.
 
 -------------------------------------------------------------------------------
 
-%% This notice is provided with respect to libpng 1.6.37, which may be
+%% This notice is provided with respect to libpng 1.6.38, which may be
 included with JRE 8, JDK 8, and OpenJDK 8.
 
 --- begin of LICENSE ---
@@ -1483,11 +1483,11 @@ COPYRIGHT NOTICE, DISCLAIMER, and LICENSE
 PNG Reference Library License version 2
 ---------------------------------------
 
- * Copyright (c) 1995-2019 The PNG Reference Library Authors.
- * Copyright (c) 2018-2019 Cosmin Truta.
- * Copyright (c) 2000-2002, 2004, 2006-2018 Glenn Randers-Pehrson.
- * Copyright (c) 1996-1997 Andreas Dilger.
- * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
+Copyright (c) 1995-2022 The PNG Reference Library Authors.
+Copyright (c) 2018-2022 Cosmin Truta
+Copyright (c) 1998-2018 Glenn Randers-Pehrson
+Copyright (c) 1996-1997 Andreas Dilger
+Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
 
 The software is supplied "as is", without warranty of any kind,
 express or implied, including, without limitation, the warranties
@@ -1614,10 +1614,10 @@ be appreciated.
 
 TRADEMARK:
 
-The name "libpng" has not been registered by the Copyright owner
+The name "libpng" has not been registered by the Copyright owners
 as a trademark in any jurisdiction.  However, because libpng has
 been distributed and maintained world-wide, continually since 1995,
-the Copyright owner claims "common-law trademark protection" in any
+the Copyright owners claim "common-law trademark protection" in any
 jurisdiction where common-law trademark is recognized.
 
 OSI CERTIFICATION:
@@ -1638,6 +1638,59 @@ any encryption software.  See the EAR, paragraphs 734.3(b)(3) and
 Glenn Randers-Pehrson
 glennrp at users.sourceforge.net
 July 15, 2018
+
+### AUTHORS File Information
+```
+PNG REFERENCE LIBRARY AUTHORS
+=============================
+
+This is the list of PNG Reference Library ("libpng") Contributing
+Authors, for copyright and licensing purposes.
+
+ * Andreas Dilger
+ * Cosmin Truta
+ * Dave Martindale
+ * Eric S. Raymond
+ * Gilles Vollant
+ * Glenn Randers-Pehrson
+ * Greg Roelofs
+ * Guy Eric Schalnat
+ * James Yu
+ * John Bowler
+ * Kevin Bracey
+ * Magnus Holmgren
+ * Mandar Sahastrabuddhe
+ * Mans Rullgard
+ * Matt Sarett
+ * Mike Klein
+ * Pascal Massimino
+ * Paul Schmidt
+ * Qiang Zhou
+ * Sam Bushell
+ * Samuel Williams
+ * Simon-Pierre Cadieux
+ * Tim Wegner
+ * Tom Lane
+ * Tom Tanner
+ * Vadim Barkov
+ * Willem van Schaik
+ * Zhijie Liang
+ * Arm Holdings
+   - Richard Townsend
+ * Google Inc.
+   - Matt Sarett
+   - Mike Klein
+   - Dan Field
+   - Sami Boukortt
+
+The build projects, the build scripts, the test scripts, and other
+files in the "ci", "projects", "scripts" and "tests" directories, have
+other copyright owners, but are released under the libpng license.
+
+Some files in the "contrib" directory, and some tools-generated files
+that are distributed with libpng, have other copyright owners, and are
+released under other open source licenses.
+```
 
 --- end of LICENSE ---
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [d183dc25f7360c3012726acf8c03874df6fc41a4](https://github.com/openjdk/jdk11u-dev/commit/d183dc25f7360c3012726acf8c03874df6fc41a4) from the [openjdk/jdk11u-dev](https://github.com/openjdk/jdk11u-dev) repository.

This backport is a follow up fix of [JDK-8209115](https://bugs.openjdk.org/browse/JDK-8209115), and a dependency of [JDK-8305815](https://bugs.openjdk.org/browse/JDK-8305815).

This backport applied cleanly, except for the changes to the THIRD_PARTY_README files that are specific to 8u.

Note: Changes to src/java.desktop/share/native/libsplashscreen/libpng/UPDATING.txt were skipped because this file was not introduced by the 8u backport of 8208353. That's okay, as for 8u we will backport libpng from 11u or newer JDK releases, and not directly from the library.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295685](https://bugs.openjdk.org/browse/JDK-8295685): Update Libpng to 1.6.38 (**Bug** - P2)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/372/head:pull/372` \
`$ git checkout pull/372`

Update a local copy of the PR: \
`$ git checkout pull/372` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/372/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 372`

View PR using the GUI difftool: \
`$ git pr show -t 372`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/372.diff">https://git.openjdk.org/jdk8u-dev/pull/372.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/372#issuecomment-1720111629)