### PR TITLE
8317291: Missing null check for nmethod::is_native_method()

### DIFF
--- a/hotspot/src/share/vm/code/nmethod.hpp
+++ b/hotspot/src/share/vm/code/nmethod.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -363,8 +363,8 @@ class nmethod : public CodeBlob {
 
   // type info
   bool is_nmethod() const                         { return true; }
-  bool is_java_method() const                     { return !method()->is_native(); }
-  bool is_native_method() const                   { return method()->is_native(); }
+  bool is_java_method() const                     { return _method != NULL && !method()->is_native(); }
+  bool is_native_method() const                   { return _method != NULL && method()->is_native(); }
   bool is_osr_method() const                      { return _entry_bci != InvocationEntryBci; }
 
   bool is_compiled_by_c1() const;


### PR DESCRIPTION
I added null check to nmethod::is_native_method() and is_java_method().
I verified that the JVM crash problem no longer occurs by this fix.
I don't attach the test for this fix beause I could reproduce this problem only with debug build.

Would anyone review this fix, pelase?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8317291](https://bugs.openjdk.org/browse/JDK-8317291) needs maintainer approval

### Issue
 * [JDK-8317291](https://bugs.openjdk.org/browse/JDK-8317291): Missing null check for nmethod::is_native_method() (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/379/head:pull/379` \
`$ git checkout pull/379`

Update a local copy of the PR: \
`$ git checkout pull/379` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/379/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 379`

View PR using the GUI difftool: \
`$ git pr show -t 379`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/379.diff">https://git.openjdk.org/jdk8u-dev/pull/379.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/379#issuecomment-1740285705)