### PR TITLE
8312489: Increase jdk.jar.maxSignatureFileSize default which is too low for JARs such as WhiteSource/Mend unified agent jar

### DIFF
--- a/jdk/src/share/classes/java/util/jar/JarFile.java
+++ b/jdk/src/share/classes/java/util/jar/JarFile.java
@@ -436,7 +436,9 @@ class JarFile extends ZipFile {
                 throw new IOException("Unsupported size: " + uncompressedSize +
                         " for JarEntry " + ze.getName() +
                         ". Allowed max size: " +
-                        SignatureFileVerifier.MAX_SIG_FILE_SIZE + " bytes");
+                        SignatureFileVerifier.MAX_SIG_FILE_SIZE + " bytes. " +
+                        "You can use the jdk.jar.maxSignatureFileSize " +
+                        "system property to increase the default value.");
             }
             int len = (int)uncompressedSize;
             byte[] b = IOUtils.readAllBytes(is);

--- a/jdk/src/share/classes/sun/security/util/SignatureFileVerifier.java
+++ b/jdk/src/share/classes/sun/security/util/SignatureFileVerifier.java
@@ -855,16 +855,16 @@ public class SignatureFileVerifier {
          * the maximum allowed number of bytes for the signature-related files
          * in a JAR file.
          */
-        Integer tmp = AccessController.doPrivileged(new GetIntegerAction(
-                "jdk.jar.maxSignatureFileSize", 8000000));
+        int tmp = AccessController.doPrivileged(new GetIntegerAction(
+                "jdk.jar.maxSignatureFileSize", 16000000));
         if (tmp < 0 || tmp > MAX_ARRAY_SIZE) {
             if (debug != null) {
-                debug.println("Default signature file size 8000000 bytes " +
-                        "is used as the specified size for the " +
-                        "jdk.jar.maxSignatureFileSize system property " +
+                debug.println("The default signature file size of 16000000 bytes " +
+                        "will be used for the jdk.jar.maxSignatureFileSize " +
+                        "system property since the specified value " +
                         "is out of range: " + tmp);
             }
-            tmp = 8000000;
+            tmp = 16000000;
         }
         return tmp;
     }


### PR DESCRIPTION
The security fix, JDK-8300596, introduced a maximum size for signature-related files in JAR files, via the `jdk.jar.maxSignatureFileSize` property. The default value of 8MB has since proven to be too low for some JARs in general use. This change doubles it to 16MB, while still being much lower than the previous `MAX_ARRAY_SIZE` value of `Integer.MAX_VALUE - 8`

This pull request contains a backport of commit [e47a84f2](https://github.com/openjdk/jdk/commit/e47a84f23dd2608c6f5748093eefe301fb5bf750) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.  After path shuffling, the `SignatureFileVerifier.java` changes had to be applied manually due to the lack of `GetIntegerAction.privilegedGetProperty` in 8u. The actual changes are the same as for 11u+. Comparing the two patches:

~~~
+@@ -855,16 +855,16 @@ public class SignatureFileVerifier {
           * the maximum allowed number of bytes for the signature-related files
           * in a JAR file.
           */
--        Integer tmp = GetIntegerAction.privilegedGetProperty(
--                "jdk.jar.maxSignatureFileSize", 8000000);
-+        int tmp = GetIntegerAction.privilegedGetProperty(
-+                "jdk.jar.maxSignatureFileSize", 16000000);
+-        Integer tmp = AccessController.doPrivileged(new GetIntegerAction(
+-                "jdk.jar.maxSignatureFileSize", 8000000));
++        int tmp = AccessController.doPrivileged(new GetIntegerAction(
++                "jdk.jar.maxSignatureFileSize", 16000000));
          if (tmp < 0 || tmp > MAX_ARRAY_SIZE) {
              if (debug != null) {
 -                debug.println("Default signature file size 8000000 bytes " +
~~~

The commit being backported was authored by Hai-May Chao on 31 Jul 2023 and was reviewed by Sean Mullan and Matthias Baesken.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8312489](https://bugs.openjdk.org/browse/JDK-8312489) needs maintainer approval

### Issue
 * [JDK-8312489](https://bugs.openjdk.org/browse/JDK-8312489): Increase jdk.jar.maxSignatureFileSize default which is too low for JARs such as WhiteSource/Mend unified agent jar (**Bug** - P3 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/381/head:pull/381` \
`$ git checkout pull/381`

Update a local copy of the PR: \
`$ git checkout pull/381` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/381/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 381`

View PR using the GUI difftool: \
`$ git pr show -t 381`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/381.diff">https://git.openjdk.org/jdk8u-dev/pull/381.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/381#issuecomment-1756561840)