### PR TITLE
8285696: AlgorithmConstraints:permits not throwing IllegalArgumentException when 'alg'  is null

### DIFF
--- a/jdk/src/share/classes/sun/security/util/DisabledAlgorithmConstraints.java
+++ b/jdk/src/share/classes/sun/security/util/DisabledAlgorithmConstraints.java
@@ -158,6 +158,9 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
     @Override
     public final boolean permits(Set<CryptoPrimitive> primitives,
             String algorithm, AlgorithmParameters parameters) {
+        if (algorithm == null || algorithm.isEmpty()) {
+            throw new IllegalArgumentException("No algorithm name specified");
+        }
         if (!checkAlgorithm(disabledAlgorithms, algorithm, decomposer)) {
             return false;
         }


### PR DESCRIPTION
This is a follow-up fix for the JDK-8285398: Cache the results of constraint checks
Simple fix to prevent JCK failure

This fix should be applied after JDK-8285398

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8285696](https://bugs.openjdk.org/browse/JDK-8285696) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285696](https://bugs.openjdk.org/browse/JDK-8285696): AlgorithmConstraints:permits not throwing IllegalArgumentException when 'alg'  is null (**Bug** - P2 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**) ⚠️ Review applies to [f826982e](https://git.openjdk.org/jdk8u-dev/pull/382/files/f826982e8ce1ac3b46d1de14894080b315339766)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/382/head:pull/382` \
`$ git checkout pull/382`

Update a local copy of the PR: \
`$ git checkout pull/382` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/382/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 382`

View PR using the GUI difftool: \
`$ git pr show -t 382`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/382.diff">https://git.openjdk.org/jdk8u-dev/pull/382.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/382#issuecomment-1758375946)