### PR TITLE
JDK-8319405: [s390] [jdk8] Increase javac default stack size for s390x zero

### DIFF
--- a/jdk/make/CompileLaunchers.gmk
+++ b/jdk/make/CompileLaunchers.gmk
@@ -281,10 +281,17 @@ $(eval $(call SetupLauncher,jar, \
 $(eval $(call SetupLauncher,jarsigner, \
     -DJAVA_ARGS='{ "-J-ms8m"$(COMMA) "sun.security.tools.jarsigner.Main"$(COMMA) }'))
 
+# On s390 zero, run javac with larger stack
+ifeq ($(OPENJDK_TARGET_CPU), s390x)
+JAVAC_ARGS := '{ "-J-ms8m"$(COMMA) "-J-Xss3m"$(COMMA) "com.sun.tools.javac.Main"$(COMMA) }'
+else
+JAVAC_ARGS := '{ "-J-ms8m"$(COMMA) "com.sun.tools.javac.Main"$(COMMA) }'
+endif
+
 $(eval $(call SetupLauncher,javac, \
     -DEXPAND_CLASSPATH_WILDCARDS \
     -DNEVER_ACT_AS_SERVER_CLASS_MACHINE \
-    -DJAVA_ARGS='{ "-J-ms8m"$(COMMA) "com.sun.tools.javac.Main"$(COMMA) }'))
+    -DJAVA_ARGS=$(JAVAC_ARGS)))
 
 ifeq ($(ENABLE_SJAVAC), yes)
   $(eval $(call SetupLauncher,sjavac, \


### PR DESCRIPTION
This is a JDK8 - only patch to fix failing TCK tests for javac on s390.

s390x, by default, needs a lot of stack space for C++ frames since the s390x ABI requires a 160-byte register save area per frame. That affects JDK 8 in particular since we run Zero, and the C++ interpreter builds up C-frames for Java frames; furthermore, it affects javac since it recurses a lot.

This causes several javac TCK tests to fail with SOE (stmt33002mxxx).

To pass TCK, the default stack size of javac should be increased for s390 on JDK 8.

Testing:

- manually tested on s390 to see if the issue was resolved, which it was.
- manually tested on x64 to check that nothing changed
- GHAs

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8319405](https://bugs.openjdk.org/browse/JDK-8319405) needs maintainer approval

### Issue
 * [JDK-8319405](https://bugs.openjdk.org/browse/JDK-8319405): [s390] [jdk8] Increase javac default stack size for s390x zero (**Bug** - P3 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/385/head:pull/385` \
`$ git checkout pull/385`

Update a local copy of the PR: \
`$ git checkout pull/385` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/385/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 385`

View PR using the GUI difftool: \
`$ git pr show -t 385`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/385.diff">https://git.openjdk.org/jdk8u-dev/pull/385.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/385#issuecomment-1793359984)