### PR TITLE
8198321: javax/swing/JEditorPane/5076514/bug5076514.java fails

### DIFF
--- a/jdk/test/javax/swing/JEditorPane/5076514/bug5076514.java
+++ b/jdk/test/javax/swing/JEditorPane/5076514/bug5076514.java
@@ -22,13 +22,15 @@
  */
 
 /* @test
-   @bug 5076514 8025430
+   @bug 5076514 8025430 8198321
    @summary Tests if SecurityManager.checkPermission()
                   used for clipboard access with permission 'accessClipboard'
    @run main bug5076514
+   @run main/othervm -Djava.awt.headless=true bug5076514
 */
-
+import java.awt.GraphicsEnvironment;
 import java.security.Permission;
+
 import javax.swing.JEditorPane;
 
 public class bug5076514 {
@@ -37,9 +39,13 @@ public class bug5076514 {
 
     public static void main(String[] args) {
         System.setSecurityManager(new MySecurityManager());
+
+        // no system clipboard in the headless mode
+        boolean expected  = !GraphicsEnvironment.isHeadless();
+
         JEditorPane editor = new JEditorPane();
         editor.copy();
-        if (!isCheckPermissionCalled) {
+        if (isCheckPermissionCalled != expected) {
             throw new RuntimeException("JEditorPane's clipboard operations "
                     + "didn't call SecurityManager.checkPermission() with "
                     + "permission 'accessClipboard' when there is a security"

--- a/jdk/test/javax/swing/JEditorPane/5076514/bug5076514.java
+++ b/jdk/test/javax/swing/JEditorPane/5076514/bug5076514.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@
    @run main bug5076514
    @run main/othervm -Djava.awt.headless=true bug5076514
 */
+
 import java.awt.GraphicsEnvironment;
 import java.security.Permission;
 


### PR DESCRIPTION
I backport this for parity with 8u271.
Low risk, only test changes. Apply clean except for test path and Problemlist.txt. And test have been locally verified to pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8198321](https://bugs.openjdk.org/browse/JDK-8198321) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8198321](https://bugs.openjdk.org/browse/JDK-8198321): javax/swing/JEditorPane/5076514/bug5076514.java fails (**Bug** - P4 - Approved)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/386/head:pull/386` \
`$ git checkout pull/386`

Update a local copy of the PR: \
`$ git checkout pull/386` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/386/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 386`

View PR using the GUI difftool: \
`$ git pr show -t 386`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/386.diff">https://git.openjdk.org/jdk8u-dev/pull/386.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/386#issuecomment-1805327386)