### PR TITLE
8208655: use JTreg skipped status in hotspot tests

### DIFF
--- a/hotspot/test/ProblemList.txt
+++ b/hotspot/test/ProblemList.txt
@@ -43,7 +43,6 @@
 runtime/SharedArchiveFile/SharedBaseAddress.java 8044600 solaris-sparc
 runtime/6929067/Test6929067.sh 8028740 generic-all
 runtime/CDSCompressedKPtrs/XShareAuto.java 8026154 generic-all
-runtime/XCheckJniJsig/XCheckJSig.java 8023735 generic-all
 runtime/6626217/Test6626217.sh 8028733 generic-all
 runtime/jsig/Test8017498.sh 8028806 generic-all
 runtime/LoadClass/LoadClassNegative.java 8028095 generic-all

--- a/hotspot/test/TEST.ROOT
+++ b/hotspot/test/TEST.ROOT
@@ -38,6 +38,9 @@ requires.properties=sun.arch.data.model \
     vm.flavor \
     vm.bits
 
+# Minimum jtreg version
+requiredVersion=4.2 b13
+
 # Path to libraries in the topmost test directory. This is needed so @library
 # does not need ../../ notation to reach them
 external.lib.roots = ../../

--- a/hotspot/test/TEST.ROOT
+++ b/hotspot/test/TEST.ROOT
@@ -36,7 +36,8 @@ groups=TEST.groups [closed/TEST.groups]
 requires.extraPropDefns = ../../test/jtreg-ext/requires/VMProps.java
 requires.properties=sun.arch.data.model \
     vm.flavor \
-    vm.bits
+    vm.bits \
+    vm.debug
 
 # Minimum jtreg version
 requiredVersion=4.2 b13

--- a/hotspot/test/compiler/classUnloading/anonymousClass/TestAnonymousClassUnloading.java
+++ b/hotspot/test/compiler/classUnloading/anonymousClass/TestAnonymousClassUnloading.java
@@ -107,7 +107,8 @@ public class TestAnonymousClassUnloading {
      */
     static public void main(String[] args) throws Exception {
         // (1) Load an anonymous version of this class using the corresponding Unsafe method
-        URL classUrl = TestAnonymousClassUnloading.class.getResource("TestAnonymousClassUnloading.class");
+        String rn = TestAnonymousClassUnloading.class.getSimpleName() + ".class";
+        URL classUrl = TestAnonymousClassUnloading.class.getResource(rn);
         URLConnection connection = classUrl.openConnection();
 
         int length = connection.getContentLength();

--- a/hotspot/test/compiler/tiered/ConstantGettersTransitionsTest.java
+++ b/hotspot/test/compiler/tiered/ConstantGettersTransitionsTest.java
@@ -21,6 +21,8 @@
  * questions.
  */
 
+import jtreg.SkippedException;
+
 import java.lang.reflect.Executable;
 import java.util.concurrent.Callable;
 

--- a/hotspot/test/compiler/tiered/ConstantGettersTransitionsTest.java
+++ b/hotspot/test/compiler/tiered/ConstantGettersTransitionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@ import java.util.concurrent.Callable;
 
 /**
  * @test ConstantGettersTransitionsTest
- * @library /testlibrary /testlibrary/whitebox /compiler/whitebox
+ * @library /testlibrary /testlibrary/whitebox /compiler/whitebox /test/lib
  * @build TransitionsTestExecutor ConstantGettersTransitionsTest
  * @run main ClassFileInstaller sun.hotspot.WhiteBox sun.hotspot.WhiteBox$WhiteBoxPermission
  * @run main/othervm/timeout=240 -Xmixed -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
@@ -37,7 +37,9 @@ import java.util.concurrent.Callable;
  */
 public class ConstantGettersTransitionsTest extends LevelTransitionTest {
     public static void main(String[] args) {
-        assert (!CompilerWhiteBoxTest.skipOnTieredCompilation(false));
+        if (CompilerWhiteBoxTest.skipOnTieredCompilation(false)) {
+            throw new SkippedException("Test isn't applicable for non-tiered mode");
+        }
 
         // run test cases
         for (TestCase testCase : ConstantGettersTestCase.values()) {

--- a/hotspot/test/compiler/tiered/LevelTransitionTest.java
+++ b/hotspot/test/compiler/tiered/LevelTransitionTest.java
@@ -21,6 +21,8 @@
  * questions.
  */
 
+import jtreg.SkippedException;
+
 import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
 import java.util.Objects;
@@ -28,7 +30,7 @@ import java.util.concurrent.Callable;
 
 /**
  * @test LevelTransitionTest
- * @library /testlibrary /testlibrary/whitebox /compiler/whitebox
+ * @library /testlibrary /testlibrary/whitebox /compiler/whitebox /test/lib
  * @build TransitionsTestExecutor LevelTransitionTest
  * @run main ClassFileInstaller sun.hotspot.WhiteBox sun.hotspot.WhiteBox$WhiteBoxPermission
  * @run main/othervm/timeout=240 -Xmixed -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
@@ -44,7 +46,9 @@ public class LevelTransitionTest extends TieredLevelsTest {
     private int transitionCount;
 
     public static void main(String[] args) throws Throwable {
-        assert (!CompilerWhiteBoxTest.skipOnTieredCompilation(false));
+        if (CompilerWhiteBoxTest.skipOnTieredCompilation(false)) {
+            throw new SkippedException("Test isn't applicable for non-tiered mode");
+        }
 
         CompilerWhiteBoxTest.main(LevelTransitionTest::new, args);
         // run extended test cases

--- a/hotspot/test/compiler/tiered/NonTieredLevelsTest.java
+++ b/hotspot/test/compiler/tiered/NonTieredLevelsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,10 +22,11 @@
  */
 
 import java.util.function.IntPredicate;
+import jtreg.SkippedException;
 
 /**
  * @test NonTieredLevelsTest
- * @library /testlibrary /testlibrary/whitebox /compiler/whitebox
+ * @library /testlibrary /testlibrary/whitebox /compiler/whitebox /test/lib
  * @build NonTieredLevelsTest
  * @run main ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -XX:-TieredCompilation
@@ -54,7 +55,7 @@ public class NonTieredLevelsTest extends CompLevelsTest {
     }
     public static void main(String[] args) throws Exception {
         if (CompilerWhiteBoxTest.skipOnTieredCompilation(true)) {
-            return;
+            throw new SkippedException("Test isn't applicable for tiered mode");
         }
         CompilerWhiteBoxTest.main(NonTieredLevelsTest::new, args);
     }

--- a/hotspot/test/compiler/tiered/TieredLevelsTest.java
+++ b/hotspot/test/compiler/tiered/TieredLevelsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /**
  * @test TieredLevelsTest
- * @library /testlibrary /testlibrary/whitebox /compiler/whitebox
+ * @library /testlibrary /testlibrary/whitebox /compiler/whitebox /test/lib
  * @build TieredLevelsTest
  * @run main ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -XX:+TieredCompilation
@@ -33,10 +33,13 @@
  * @summary Verify that all levels &lt; 'TieredStopAtLevel' can be used
  * @author igor.ignatyev@oracle.com
  */
+
+import jtreg.SkippedException;
+
 public class TieredLevelsTest extends CompLevelsTest {
     public static void main(String[] args) throws Exception, Throwable {
         if (CompilerWhiteBoxTest.skipOnTieredCompilation(false)) {
-            return;
+            throw new SkippedException("Test isn't applicable for non-tiered mode");
         }
         CompilerWhiteBoxTest.main(TieredLevelsTest::new, args);
     }

--- a/hotspot/test/gc/arguments/TestAggressiveHeap.java
+++ b/hotspot/test/gc/arguments/TestAggressiveHeap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @key gc
  * @bug 8179084
  * @summary Test argument processing for -XX:+AggressiveHeap.
- * @library /testlibrary
+ * @library /testlibrary /test/lib
  * @run driver TestAggressiveHeap
  */
 
@@ -36,6 +36,7 @@ import javax.management.ObjectName;
 
 import com.oracle.java.testlibrary.OutputAnalyzer;
 import com.oracle.java.testlibrary.ProcessTools;
+import jtreg.SkippedException;
 
 public class TestAggressiveHeap {
 
@@ -86,9 +87,7 @@ public class TestAggressiveHeap {
 
     private static boolean canUseAggressiveHeapOption() throws Exception {
         if (!haveRequiredMemory()) {
-            System.out.println(
-                "Skipping test of " + option + " : insufficient memory");
-            return false;
+            throw new SkippedException("Skipping test of " + option + " : insufficient memory");
         }
         return true;
     }

--- a/hotspot/test/gc/g1/TestHumongousShrinkHeap.java
+++ b/hotspot/test/gc/g1/TestHumongousShrinkHeap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @requires vm.gc=="G1" | vm.gc=="null"
  * @summary Verify that heap shrinks after GC in the presence of fragmentation
  * due to humongous objects
- * @library /testlibrary
+ * @library /testlibrary /test/lib
  * @run main/othervm -XX:-ExplicitGCInvokesConcurrent -XX:MinHeapFreeRatio=10
  * -XX:MaxHeapFreeRatio=12 -XX:+UseG1GC -XX:G1HeapRegionSize=1M -verbose:gc
  * TestHumongousShrinkHeap
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.List;
 import sun.management.ManagementFactoryHelper;
 import static com.oracle.java.testlibrary.Asserts.*;
+import jtreg.SkippedException;
 
 public class TestHumongousShrinkHeap {
 
@@ -57,13 +58,11 @@ public class TestHumongousShrinkHeap {
 
     public static void main(String[] args) {
         if (HUMON_COUNT == 0) {
-            System.out.println("Skipped. Heap is too small");
-            return;
+            throw new SkippedException("Heap is too small");
         }
 
         if (TOTAL_MEMORY + REGION_SIZE * HUMON_COUNT > MAX_MEMORY) {
-            System.out.println("Skipped. Initial heap size is to close to max heap size.");
-            return;
+            throw new SkippedException("Initial heap size is to close to max heap size.");
         }
 
         System.out.format("Running with %s initial heap size of %s maximum heap size. "

--- a/hotspot/test/gc/g1/TestLargePageUseForAuxMemory.java
+++ b/hotspot/test/gc/g1/TestLargePageUseForAuxMemory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,8 @@
  * @test TestLargePageUseForAuxMemory.java
  * @bug 8058354
  * @key gc
- * @library /testlibrary /testlibrary/whitebox
- * @requires (vm.gc=="G1" | vm.gc=="null")
+ * @library /testlibrary /testlibrary/whitebox /test/lib
+ * @requires (vm.gc=="G1" | vm.gc=="null") & vm.debug
  * @build TestLargePageUseForAuxMemory
  * @run main ClassFileInstaller sun.hotspot.WhiteBox
  *                              sun.hotspot.WhiteBox$WhiteBoxPermission
@@ -35,6 +35,7 @@
  */
 
 import com.oracle.java.testlibrary.*;
+import jtreg.SkippedException;
 import sun.hotspot.WhiteBox;
 
 public class TestLargePageUseForAuxMemory {
@@ -88,18 +89,12 @@ public class TestLargePageUseForAuxMemory {
     }
 
     public static void main(String[] args) throws Exception {
-        if (!Platform.isDebugBuild()) {
-            System.out.println("Skip tests on non-debug builds because the required option TracePageSizes is a debug-only option.");
-            return;
-        }
-
         WhiteBox wb = WhiteBox.getWhiteBox();
         smallPageSize = wb.getVMPageSize();
         largePageSize = wb.getVMLargePageSize();
 
         if (largePageSize == 0) {
-            System.out.println("Skip tests because large page support does not seem to be available on this platform.");
-            return;
+            throw new SkippedException("Large page support does not seem to be available on this platform.");
         }
 
         // To get large pages for the card table etc. we need at least a 1G heap (with 4k page size).

--- a/hotspot/test/gc/g1/TestShrinkAuxiliaryData.java
+++ b/hotspot/test/gc/g1/TestShrinkAuxiliaryData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,8 @@ import com.oracle.java.testlibrary.OutputAnalyzer;
 import com.oracle.java.testlibrary.Platform;
 import com.oracle.java.testlibrary.ProcessTools;
 import com.oracle.java.testlibrary.Utils;
+import jtreg.SkippedException;
+
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryUsage;
@@ -67,10 +69,9 @@ public class TestShrinkAuxiliaryData {
 
         int maxCacheSize = Math.max(0, Math.min(31, getMaxCacheSize()));
         if (maxCacheSize < hotCardTableSize) {
-            System.out.format("Skiping test for %d cache size due max cache size %d",
-                    hotCardTableSize, maxCacheSize
-            );
-            return;
+            throw new SkippedException(String.format(
+                    "Skiping test for %d cache size due max cache size %d",
+                    hotCardTableSize, maxCacheSize));
         }
 
         printTestInfo(maxCacheSize);

--- a/hotspot/test/gc/g1/TestShrinkAuxiliaryData00.java
+++ b/hotspot/test/gc/g1/TestShrinkAuxiliaryData00.java
@@ -27,7 +27,7 @@
  * @summary Checks that decommitment occurs for JVM with different
  * G1ConcRSLogCacheSize and ObjectAlignmentInBytes options values
  * @requires vm.gc=="G1" | vm.gc=="null"
- * @library /testlibrary /testlibrary/whitebox
+ * @library /testlibrary /testlibrary/whitebox /test/lib
  * @build com.oracle.java.testlibrary.* sun.hotspot.WhiteBox
  *        TestShrinkAuxiliaryData TestShrinkAuxiliaryData00
  * @run main ClassFileInstaller sun.hotspot.WhiteBox

--- a/hotspot/test/gc/g1/TestShrinkAuxiliaryData05.java
+++ b/hotspot/test/gc/g1/TestShrinkAuxiliaryData05.java
@@ -27,7 +27,7 @@
  * @summary Checks that decommitment occurs for JVM with different
  * G1ConcRSLogCacheSize and ObjectAlignmentInBytes options values
  * @requires vm.gc=="G1" | vm.gc=="null"
- * @library /testlibrary /testlibrary/whitebox
+ * @library /testlibrary /testlibrary/whitebox /test/lib
  * @build com.oracle.java.testlibrary.* sun.hotspot.WhiteBox
  *        TestShrinkAuxiliaryData TestShrinkAuxiliaryData05
  * @run main ClassFileInstaller sun.hotspot.WhiteBox

--- a/hotspot/test/gc/g1/TestShrinkAuxiliaryData10.java
+++ b/hotspot/test/gc/g1/TestShrinkAuxiliaryData10.java
@@ -27,7 +27,7 @@
  * @summary Checks that decommitment occurs for JVM with different
  * G1ConcRSLogCacheSize and ObjectAlignmentInBytes options values
  * @requires vm.gc=="G1" | vm.gc=="null"
- * @library /testlibrary /testlibrary/whitebox
+ * @library /testlibrary /testlibrary/whitebox /test/lib
  * @build com.oracle.java.testlibrary.* sun.hotspot.WhiteBox
  * @build TestShrinkAuxiliaryData TestShrinkAuxiliaryData10
  * @run main ClassFileInstaller sun.hotspot.WhiteBox

--- a/hotspot/test/gc/g1/TestShrinkAuxiliaryData15.java
+++ b/hotspot/test/gc/g1/TestShrinkAuxiliaryData15.java
@@ -27,7 +27,7 @@
  * @summary Checks that decommitment occurs for JVM with different
  * G1ConcRSLogCacheSize and ObjectAlignmentInBytes options values
  * @requires vm.gc=="G1" | vm.gc=="null"
- * @library /testlibrary /testlibrary/whitebox
+ * @library /testlibrary /testlibrary/whitebox /test/lib
  * @build com.oracle.java.testlibrary.* sun.hotspot.WhiteBox
  * @build TestShrinkAuxiliaryData TestShrinkAuxiliaryData15
  * @run main ClassFileInstaller sun.hotspot.WhiteBox

--- a/hotspot/test/gc/g1/TestShrinkAuxiliaryData25.java
+++ b/hotspot/test/gc/g1/TestShrinkAuxiliaryData25.java
@@ -27,7 +27,7 @@
  * @summary Checks that decommitment occurs for JVM with different
  * G1ConcRSLogCacheSize and ObjectAlignmentInBytes options values
  * @requires vm.gc=="G1" | vm.gc=="null"
- * @library /testlibrary /testlibrary/whitebox
+ * @library /testlibrary /testlibrary/whitebox /test/lib
  * @build com.oracle.java.testlibrary.* sun.hotspot.WhiteBox
  * @build TestShrinkAuxiliaryData TestShrinkAuxiliaryData25
  * @run main ClassFileInstaller sun.hotspot.WhiteBox

--- a/hotspot/test/gc/g1/TestShrinkAuxiliaryData30.java
+++ b/hotspot/test/gc/g1/TestShrinkAuxiliaryData30.java
@@ -27,7 +27,7 @@
  * @summary Checks that decommitment occurs for JVM with different
  * G1ConcRSLogCacheSize and ObjectAlignmentInBytes options values
  * @requires vm.gc=="G1" | vm.gc=="null"
- * @library /testlibrary /testlibrary/whitebox
+ * @library /testlibrary /testlibrary/whitebox /test/lib
  * @build com.oracle.java.testlibrary.* sun.hotspot.WhiteBox
  * @build TestShrinkAuxiliaryData TestShrinkAuxiliaryData30
  * @run main ClassFileInstaller sun.hotspot.WhiteBox

--- a/hotspot/test/gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java
+++ b/hotspot/test/gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java
@@ -25,6 +25,7 @@
  * @test CompressedClassSpaceSizeInJmapHeap
  * @bug 8004924
  * @summary Checks that jmap -heap contains the flag CompressedClassSpaceSize
+ * @requires vm.bits == 64
  * @library /testlibrary
  * @run main/othervm -XX:CompressedClassSpaceSize=50m CompressedClassSpaceSizeInJmapHeap
  */

--- a/hotspot/test/gc/metaspace/TestMetaspaceMemoryPool.java
+++ b/hotspot/test/gc/metaspace/TestMetaspaceMemoryPool.java
@@ -30,6 +30,7 @@ import static com.oracle.java.testlibrary.Asserts.*;
  * @bug 8000754
  * @summary Tests that a MemoryPoolMXBeans is created for metaspace and that a
  *          MemoryManagerMXBean is created.
+ * @requires vm.bits == 64
  * @library /testlibrary
  * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-UseCompressedOops TestMetaspaceMemoryPool
  * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-UseCompressedOops -XX:MaxMetaspaceSize=60m TestMetaspaceMemoryPool

--- a/hotspot/test/runtime/6819213/TestBootNativeLibraryPath.java
+++ b/hotspot/test/runtime/6819213/TestBootNativeLibraryPath.java
@@ -27,7 +27,7 @@
  * @summary verify sun.boot.native.library.path is expandable on 32 bit systems
  * @author ksrini
  * @library /test/lib
- * @requiers vm.bits == 32
+ * @requires vm.bits == 32
  * @compile -XDignore.symbol.file TestBootNativeLibraryPath.java
  * @run main TestBootNativeLibraryPath
  */

--- a/hotspot/test/runtime/6819213/TestBootNativeLibraryPath.java
+++ b/hotspot/test/runtime/6819213/TestBootNativeLibraryPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,11 +24,13 @@
 /*
  * @test TestBootNativeLibraryPath.java
  * @bug 6819213
- * @compile -XDignore.symbol.file TestBootNativeLibraryPath.java
  * @summary verify sun.boot.native.library.path is expandable on 32 bit systems
- * @run main TestBootNativeLibraryPath
  * @author ksrini
-*/
+ * @library /test/lib
+ * @requiers vm.bits == 32
+ * @compile -XDignore.symbol.file TestBootNativeLibraryPath.java
+ * @run main TestBootNativeLibraryPath
+ */
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -107,10 +109,6 @@ public class TestBootNativeLibraryPath {
 
     public static void main(String[] args) {
         try {
-            if (!System.getProperty("sun.arch.data.model").equals("32")) {
-                System.out.println("Warning: test skipped for 64-bit systems\n");
-                return;
-            }
             String osname = System.getProperty("os.name");
             if (osname.startsWith("Windows")) {
                 osname = "Windows";

--- a/hotspot/test/runtime/CompressedOops/CompressedClassPointers.java
+++ b/hotspot/test/runtime/CompressedOops/CompressedClassPointers.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8024927
  * @summary Testing address of compressed class pointer space as best as possible.
+ * @requires vm.bits == 64
  * @library /testlibrary /test/lib
  * @run main CompressedClassPointers
  */

--- a/hotspot/test/runtime/CompressedOops/CompressedClassPointers.java
+++ b/hotspot/test/runtime/CompressedOops/CompressedClassPointers.java
@@ -25,10 +25,12 @@
  * @test
  * @bug 8024927
  * @summary Testing address of compressed class pointer space as best as possible.
- * @library /testlibrary
+ * @library /testlibrary /test/lib
+ * @run main CompressedClassPointers
  */
 
 import com.oracle.java.testlibrary.*;
+import jtreg.SkippedException;
 
 public class CompressedClassPointers {
 
@@ -114,17 +116,10 @@ public class CompressedClassPointers {
     }
 
   public static void main(String[] args) throws Exception {
-      if (!Platform.is64bit()) {
-          // Can't test this on 32 bit, just pass
-          System.out.println("Skipping test on 32bit");
-          return;
-      }
-      // Solaris 10 can't mmap compressed oops space without a base
       if (Platform.isSolaris()) {
            String name = System.getProperty("os.version");
            if (name.equals("5.10")) {
-               System.out.println("Skipping test on Solaris 10");
-               return;
+                throw new SkippedException("Solaris 10 can't mmap compressed oops space without a base");
            }
       }
       smallHeapTest();

--- a/hotspot/test/runtime/CompressedOops/CompressedKlassPointerAndOops.java
+++ b/hotspot/test/runtime/CompressedOops/CompressedKlassPointerAndOops.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,8 @@
  * @key regression
  * @summary NPG: UseCompressedClassPointers asserts with ObjectAlignmentInBytes=32
  * @library /testlibrary
+ * @requiers vm.bits == 64
+ * @run main CompressedKlassPointerAndOops
  */
 
 import com.oracle.java.testlibrary.*;
@@ -34,13 +36,6 @@ import com.oracle.java.testlibrary.*;
 public class CompressedKlassPointerAndOops {
 
     public static void main(String[] args) throws Exception {
-
-        if (!Platform.is64bit()) {
-            // Can't test this on 32 bit, just pass
-            System.out.println("Skipping test on 32bit");
-            return;
-        }
-
         runWithAlignment(16);
         runWithAlignment(32);
         runWithAlignment(64);

--- a/hotspot/test/runtime/CompressedOops/CompressedKlassPointerAndOops.java
+++ b/hotspot/test/runtime/CompressedOops/CompressedKlassPointerAndOops.java
@@ -27,7 +27,7 @@
  * @key regression
  * @summary NPG: UseCompressedClassPointers asserts with ObjectAlignmentInBytes=32
  * @library /testlibrary
- * @requiers vm.bits == 64
+ * @requires vm.bits == 64
  * @run main CompressedKlassPointerAndOops
  */
 

--- a/hotspot/test/runtime/ErrorHandling/TestOnError.java
+++ b/hotspot/test/runtime/ErrorHandling/TestOnError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,11 +23,12 @@
 
 /*
  * @test TestOnError
+ * @bug 8078470
  * @summary Test using -XX:OnError=<cmd>
  * @library /testlibrary
+ * @requires vm.debug
  * @build TestOnError com.oracle.java.testlibrary.*
  * @run main TestOnError
- * @bug 8078470
  */
 
 import com.oracle.java.testlibrary.*;
@@ -35,11 +36,6 @@ import com.oracle.java.testlibrary.*;
 public class TestOnError {
 
     public static void main(String[] args) throws Exception {
-        if (!Platform.isDebugBuild()) {
-            System.out.println("Test requires a non-product build - skipping");
-            return;
-        }
-
         String msg = "Test Succeeded";
 
         // Execute the VM so that a

--- a/hotspot/test/runtime/Metaspace/FragmentMetaspaceSimple.java
+++ b/hotspot/test/runtime/Metaspace/FragmentMetaspaceSimple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,10 +21,12 @@
  * questions.
  */
 
+// ClassFileInstaller is needed to place test.Empty into well-known place
 /**
  * @test
- * @library classes
+ * @library /test/lib classes
  * @build test.Empty
+ * @run driver ClassFileInstaller test.Empty
  * @run main/othervm/timeout=200 FragmentMetaspaceSimple
  */
 
@@ -51,8 +53,8 @@ public class FragmentMetaspaceSimple {
         long startTime = System.currentTimeMillis();
         ArrayList<ClassLoader> cls = new ArrayList<>();
         char sep = File.separatorChar;
-        String fileName = "classes" + sep + "test" + sep + "Empty.class";
-        File file = new File(System.getProperty("test.classes",".") + sep + fileName);
+        String fileName = "test" + sep + "Empty.class";
+        File file = new File(fileName);
         byte buff[] = read(file);
 
         int i = 0;

--- a/hotspot/test/runtime/Metaspace/FragmentMetaspaceSimple.java
+++ b/hotspot/test/runtime/Metaspace/FragmentMetaspaceSimple.java
@@ -23,12 +23,15 @@
 
 /**
  * @test
- * @library /runtime/testlibrary
  * @library classes
- * @build test.Empty ClassUnloadCommon
+ * @build test.Empty
  * @run main/othervm/timeout=200 FragmentMetaspaceSimple
  */
 
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.util.ArrayList;
 
 /**
@@ -47,8 +50,14 @@ public class FragmentMetaspaceSimple {
     private static void runSimple(long time) {
         long startTime = System.currentTimeMillis();
         ArrayList<ClassLoader> cls = new ArrayList<>();
-        for (int i = 0; System.currentTimeMillis() < startTime + time; ++i) {
-            ClassLoader ldr = ClassUnloadCommon.newClassLoader();
+        char sep = File.separatorChar;
+        String fileName = "classes" + sep + "test" + sep + "Empty.class";
+        File file = new File(System.getProperty("test.classes",".") + sep + fileName);
+        byte buff[] = read(file);
+
+        int i = 0;
+        for (i = 0; System.currentTimeMillis() < startTime + time; ++i) {
+            ClassLoader ldr = new MyClassLoader(buff);
             if (i % 1000 == 0) {
                 cls.clear();
             }
@@ -59,11 +68,43 @@ public class FragmentMetaspaceSimple {
             Class<?> c = null;
             try {
                 c = ldr.loadClass("test.Empty");
+                c.getClass().getClassLoader(); // make sure we have a valid class.
             } catch (ClassNotFoundException ex) {
+                System.out.println("i=" + i + ", len" + buff.length);
                 throw new RuntimeException(ex);
             }
             c = null;
         }
         cls = null;
+        System.out.println("Finished " + i + " iterations in " +
+                           (System.currentTimeMillis() - startTime) + " ms");
+    }
+
+    private static byte[] read(File file) {
+        byte buff[] = new byte[(int)(file.length())];
+        try {
+            DataInputStream din = new DataInputStream(new FileInputStream(file));
+            din.readFully(buff);
+            din.close();
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+        return buff;
+    }
+
+    static class MyClassLoader extends ClassLoader {
+        byte buff[];
+        MyClassLoader(byte buff[]) {
+            this.buff = buff;
+        }
+
+        public Class<?> loadClass() throws ClassNotFoundException {
+            String name = "test.Empty";
+            try {
+                return defineClass(name, buff, 0, buff.length);
+            } catch (Throwable e) {
+                throw new ClassNotFoundException(name, e);
+            }
+        }
     }
 }

--- a/hotspot/test/runtime/Metaspace/MaxMetaspaceSizeTest.java
+++ b/hotspot/test/runtime/Metaspace/MaxMetaspaceSizeTest.java
@@ -26,7 +26,7 @@ import com.oracle.java.testlibrary.OutputAnalyzer;
 
 /*
  * @test MaxMetaspaceSizeTest
- * @requires vm.bits == "64"
+ * @requires vm.bits == 64
  * @bug 8087291
  * @library /testlibrary
  * @run main/othervm MaxMetaspaceSizeTest

--- a/hotspot/test/runtime/SharedArchiveFile/CdsDifferentObjectAlignment.java
+++ b/hotspot/test/runtime/SharedArchiveFile/CdsDifferentObjectAlignment.java
@@ -28,26 +28,20 @@
  *          This is a negative test; using  object alignment for loading that
  *          is different from object alignment for creating a CDS file
  *          should fail when loading.
+ * @requires vm.bits == 64
  * @library /testlibrary
  * @bug 8025642
+ * @run main CdsDifferentObjectAlignment
  */
 
 import com.oracle.java.testlibrary.*;
 
 public class CdsDifferentObjectAlignment {
-    public static void main(String[] args) throws Exception {
-        String nativeWordSize = System.getProperty("sun.arch.data.model");
-        if (!Platform.is64bit()) {
-            System.out.println("ObjectAlignmentInBytes for CDS is only " +
-                "supported on 64bit platforms; this plaform is " +
-                nativeWordSize);
-            System.out.println("Skipping the test");
-        } else {
-            createAndLoadSharedArchive(16, 64);
-            createAndLoadSharedArchive(64, 32);
-        }
-    }
 
+    public static void main(String[] args) throws Exception {
+        createAndLoadSharedArchive(16, 64);
+        createAndLoadSharedArchive(64, 32);
+    }
 
     // Parameters are object alignment expressed in bytes
     private static void

--- a/hotspot/test/runtime/SharedArchiveFile/CdsSameObjectAlignment.java
+++ b/hotspot/test/runtime/SharedArchiveFile/CdsSameObjectAlignment.java
@@ -25,25 +25,19 @@
  * @test CdsSameObjectAlignment
  * @summary Testing CDS (class data sharing) using varying object alignment.
  *          Using same object alignment for each dump/load pair
+ * @requires vm.bits == 64
  * @library /testlibrary
+ * @run main CdsSameObjectAlignment
  */
 
 import com.oracle.java.testlibrary.*;
 
 public class CdsSameObjectAlignment {
     public static void main(String[] args) throws Exception {
-        String nativeWordSize = System.getProperty("sun.arch.data.model");
-        if (!Platform.is64bit()) {
-            System.out.println("ObjectAlignmentInBytes for CDS is only " +
-                "supported on 64bit platforms; this plaform is " +
-                nativeWordSize);
-            System.out.println("Skipping the test");
-        } else {
-            dumpAndLoadSharedArchive(8);
-            dumpAndLoadSharedArchive(16);
-            dumpAndLoadSharedArchive(32);
-            dumpAndLoadSharedArchive(64);
-        }
+        dumpAndLoadSharedArchive(8);
+        dumpAndLoadSharedArchive(16);
+        dumpAndLoadSharedArchive(32);
+        dumpAndLoadSharedArchive(64);
     }
 
     private static void

--- a/hotspot/test/runtime/XCheckJniJsig/XCheckJSig.java
+++ b/hotspot/test/runtime/XCheckJniJsig/XCheckJSig.java
@@ -26,7 +26,7 @@
  * @bug 7051189 8023393
  * @summary Need to suppress info message if -Xcheck:jni is used with libjsig.so
  * @library /testlibrary /test/lib
- * @requires vm.family == "solaris" | vm.family == "linux" | vm.family == "mac"
+ * @requires os.family == "solaris" | os.family == "linux" | os.family == "mac"
  * @run main XCheckJSig
  */
 

--- a/hotspot/test/runtime/XCheckJniJsig/XCheckJSig.java
+++ b/hotspot/test/runtime/XCheckJniJsig/XCheckJSig.java
@@ -25,12 +25,13 @@
  * @test
  * @bug 7051189 8023393
  * @summary Need to suppress info message if -Xcheck:jni is used with libjsig.so
- * @library /testlibrary
+ * @library /testlibrary /test/lib
  * @requires vm.family == "solaris" | vm.family == "linux" | vm.family == "mac"
  * @run main XCheckJSig
  */
 
-import java.util.*;
+import java.io.File;
+import java.util.Map;
 import com.oracle.java.testlibrary.*;
 import jtreg.SkippedException;
 
@@ -44,33 +45,35 @@ public class XCheckJSig {
         String libjsig;
         String env_var;
         if (Platform.isOSX()) {
-            libjsig = jdk_path + "/jre/lib/server/libjsig.dylib";
             env_var = "DYLD_INSERT_LIBRARIES";
+            libjsig = jdk_path + "/jre/lib/libjsig.dylib"; // jdk location
+            if (!(new File(libjsig).exists())) {
+                libjsig = jdk_path + "/lib/libjsig.dylib"; // jre location
+            }
         } else {
-            libjsig = jdk_path + "/jre/lib/" + os_arch + "/libjsig.so";
             env_var = "LD_PRELOAD";
-        }
-        String java_program;
-        if (Platform.isSolaris()) {
-            // On Solaris, need to call the 64-bit Java directly in order for
-            // LD_PRELOAD to work because libjsig.so is 64-bit.
-            java_program = jdk_path + "/jre/bin/" + os_arch + "/java";
-        } else {
-            java_program = JDKToolFinder.getJDKTool("java");
+            libjsig = jdk_path + "/jre/lib/" + os_arch + "/libjsig.so"; // jdk location
+            if (!(new File(libjsig).exists())) {
+                libjsig = jdk_path + "/lib/" + os_arch + "/libjsig.so"; // jre location
+            }
         }
         // If this test fails, these might be useful to know.
         System.out.println("libjsig: " + libjsig);
         System.out.println("osArch: " + os_arch);
-        System.out.println("java_program: " + java_program);
 
-        ProcessBuilder pb = new ProcessBuilder(java_program, "-Xcheck:jni", "-version");
+        // Make sure the libjsig file exists.
+        if (!(new File(libjsig).exists())) {
+            throw new jtreg.SkippedException("File " + libjsig + " not found");
+        }
+
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-Xcheck:jni", "-version");
         Map<String, String> env = pb.environment();
         env.put(env_var, libjsig);
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldNotContain("libjsig is activated");
         output.shouldHaveExitValue(0);
 
-        pb = new ProcessBuilder(java_program, "-Xcheck:jni", "-verbose:jni", "-version");
+        pb = ProcessTools.createJavaProcessBuilder("-Xcheck:jni", "-verbose:jni", "-version");
         env = pb.environment();
         env.put(env_var, libjsig);
         output = new OutputAnalyzer(pb.start());

--- a/hotspot/test/runtime/XCheckJniJsig/XCheckJSig.java
+++ b/hotspot/test/runtime/XCheckJniJsig/XCheckJSig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,20 +26,18 @@
  * @bug 7051189 8023393
  * @summary Need to suppress info message if -Xcheck:jni is used with libjsig.so
  * @library /testlibrary
+ * @requires vm.family == "solaris" | vm.family == "linux" | vm.family == "mac"
  * @run main XCheckJSig
  */
 
 import java.util.*;
 import com.oracle.java.testlibrary.*;
+import jtreg.SkippedException;
 
 public class XCheckJSig {
     public static void main(String args[]) throws Throwable {
 
         System.out.println("Regression test for bugs 7051189 and 8023393");
-        if (!Platform.isSolaris() && !Platform.isLinux() && !Platform.isOSX()) {
-            System.out.println("Test only applicable on Solaris, Linux, and Mac OSX, skipping");
-            return;
-        }
 
         String jdk_path = System.getProperty("test.jdk");
         String os_arch = Platform.getOsArch();

--- a/hotspot/test/runtime/memory/LargePages/TestLargePagesFlags.java
+++ b/hotspot/test/runtime/memory/LargePages/TestLargePagesFlags.java
@@ -23,7 +23,7 @@
 
 /* @test TestLargePagesFlags
  * @summary Tests how large pages are choosen depending on the given large pages flag combinations.
- * @requires vm.family == "linux"
+ * @requires os.family == "linux"
  * @library /testlibrary
  * @run main TestLargePagesFlags
  */

--- a/hotspot/test/runtime/memory/LargePages/TestLargePagesFlags.java
+++ b/hotspot/test/runtime/memory/LargePages/TestLargePagesFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /* @test TestLargePagesFlags
  * @summary Tests how large pages are choosen depending on the given large pages flag combinations.
+ * @requires vm.family == "linux"
  * @library /testlibrary
  * @run main TestLargePagesFlags
  */
@@ -30,16 +31,12 @@
 import com.oracle.java.testlibrary.OutputAnalyzer;
 import com.oracle.java.testlibrary.Platform;
 import com.oracle.java.testlibrary.ProcessTools;
+
 import java.util.ArrayList;
 
 public class TestLargePagesFlags {
 
   public static void main(String [] args) throws Exception {
-    if (!Platform.isLinux()) {
-      System.out.println("Skipping. TestLargePagesFlags has only been implemented for Linux.");
-      return;
-    }
-
     testUseTransparentHugePages();
     testUseHugeTLBFS();
     testUseSHM();

--- a/hotspot/test/runtime/os/AvailableProcessors.java
+++ b/hotspot/test/runtime/os/AvailableProcessors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,20 +20,24 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-import java.io.File;
-import com.oracle.java.testlibrary.ProcessTools;
-import com.oracle.java.testlibrary.OutputAnalyzer;
-import java.util.ArrayList;
 
 /*
  * @test
  * @bug 6515172
  * @summary Check that availableProcessors reports the correct value when running in a cpuset on linux
  * @requires os.family == "linux"
- * @library /testlibrary
+ * @library /testlibrary /test/lib
  * @build com.oracle.java.testlibrary.*
  * @run driver AvailableProcessors
  */
+
+import com.oracle.java.testlibrary.ProcessTools;
+import com.oracle.java.testlibrary.OutputAnalyzer;
+import jtreg.SkippedException;
+
+import java.util.ArrayList;
+import java.io.File;
+
 public class AvailableProcessors {
 
     static final String SUCCESS_STRING = "Found expected processors: ";
@@ -47,20 +51,18 @@ public class AvailableProcessors {
             String taskset;
             final String taskset1 = "/bin/taskset";
             final String taskset2 = "/usr/bin/taskset";
-            if (new File(taskset1).exists())
+            if (new File(taskset1).exists()) {
                 taskset = taskset1;
-            else if (new File(taskset2).exists())
+            } else if (new File(taskset2).exists()) {
                 taskset = taskset2;
-            else {
-                System.out.println("Skipping test: could not find taskset command");
-                return;
+            } else {
+                throw new SkippedException("Could not find taskset command");
             }
 
             int available = Runtime.getRuntime().availableProcessors();
 
             if (available == 1) {
-                System.out.println("Skipping test: only one processor available");
-                return;
+                throw new SkippedException("only one processor available");
             }
 
             // Get the java command we want to execute

--- a/hotspot/test/runtime/testlibrary/ClassUnloadCommon.java
+++ b/hotspot/test/runtime/testlibrary/ClassUnloadCommon.java
@@ -25,8 +25,10 @@ import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.stream.Stream;
 
 public class ClassUnloadCommon {
     public static class TestFailure extends RuntimeException {
@@ -55,14 +57,45 @@ public class ClassUnloadCommon {
         System.gc();
     }
 
+    /**
+     * Creates a class loader that loads classes from {@code ${test.class.path}}
+     * before delegating to the system class loader.
+     */
     public static ClassLoader newClassLoader() {
-        try {
-            return new URLClassLoader(new URL[] {
-                Paths.get(System.getProperty("test.classes",".") + File.separatorChar + "classes").toUri().toURL(),
-            }, null);
-        } catch (MalformedURLException e){
-            throw new RuntimeException("Unexpected URL conversion failure", e);
-        }
+        String cp = System.getProperty("test.class.path", ".");
+        URL[] urls = Stream.of(cp.split(File.pathSeparator))
+                .map(Paths::get)
+                .map(ClassUnloadCommon::toURL)
+                .toArray(URL[]::new);
+        return new URLClassLoader(urls) {
+            @Override
+            public Class<?> loadClass(String cn, boolean resolve)
+                throws ClassNotFoundException
+            {
+                synchronized (getClassLoadingLock(cn)) {
+                    Class<?> c = findLoadedClass(cn);
+                    if (c == null) {
+                        try {
+                            c = findClass(cn);
+                        } catch (ClassNotFoundException e) {
+                            c = getParent().loadClass(cn);
+                        }
+
+                    }
+                    if (resolve) {
+                        resolveClass(c);
+                    }
+                    return c;
+                }
+            }
+        };
     }
 
+    static URL toURL(Path path) {
+        try {
+            return path.toUri().toURL();
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/hotspot/test/serviceability/jvmti/GetObjectSizeOverflow.java
+++ b/hotspot/test/serviceability/jvmti/GetObjectSizeOverflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,26 +20,26 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-import java.io.PrintWriter;
-import com.oracle.java.testlibrary.*;
 
 /*
  * Test to verify GetObjectSize does not overflow on a 600M element int[]
  *
  * @test
  * @bug 8027230
- * @library /testlibrary
+ * @library /testlibrary /test/lib
+ * @requires vm.bits == 64
  * @build ClassFileInstaller com.oracle.java.testlibrary.* GetObjectSizeOverflowAgent
  * @run main ClassFileInstaller GetObjectSizeOverflowAgent
  * @run main GetObjectSizeOverflow
  */
+
+import java.io.PrintWriter;
+
+import com.oracle.java.testlibrary.*;
+import jtreg.SkippedException;
+
 public class GetObjectSizeOverflow {
     public static void main(String[] args) throws Exception  {
-
-        if (!Platform.is64bit()) {
-            System.out.println("Test needs a 4GB heap and can only be run as a 64bit process, skipping.");
-            return;
-        }
 
         PrintWriter pw = new PrintWriter("MANIFEST.MF");
         pw.println("Premain-Class: GetObjectSizeOverflowAgent");
@@ -55,8 +55,7 @@ public class GetObjectSizeOverflow {
         if (output.getStdout().contains("Could not reserve enough space") || output.getStderr().contains("java.lang.OutOfMemoryError")) {
             System.out.println("stdout: " + output.getStdout());
             System.out.println("stderr: " + output.getStderr());
-            System.out.println("Test could not reserve or allocate enough space, skipping");
-            return;
+            throw new SkippedException("Test could not reserve or allocate enough space");
         }
 
         output.stdoutShouldContain("GetObjectSizeOverflow passed");

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -52,6 +52,7 @@ public class VMProps implements Callable<Map<String, String>> {
         map.put("vm.flavor", vmFlavor());
         map.put("vm.compMode", vmCompMode());
         map.put("vm.bits", vmBits());
+        map.put("vm.debug", vmDebug());
         dump(map);
         return map;
     }
@@ -101,6 +102,13 @@ public class VMProps implements Callable<Map<String, String>> {
      */
     protected String vmBits() {
         return System.getProperty("sun.arch.data.model");
+    }
+
+    /**
+     * @return debug level value extracted from the "java.vm.version" property.
+     */
+    protected String vmDebug() {
+        return "" + System.getProperty("java.vm.version").toLowerCase().contains("debug");
     }
 
     /**

--- a/test/lib/jtreg/SkippedException.java
+++ b/test/lib/jtreg/SkippedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,22 +21,18 @@
  * questions.
  */
 
-/**
- * @test TestShrinkAuxiliaryData20
- * @bug 8038423 8061715
- * @summary Checks that decommitment occurs for JVM with different
- * G1ConcRSLogCacheSize and ObjectAlignmentInBytes options values
- * @requires vm.gc=="G1" | vm.gc=="null"
- * @library /testlibrary /testlibrary/whitebox /test/lib
- * @build com.oracle.java.testlibrary.* sun.hotspot.WhiteBox
- * @build TestShrinkAuxiliaryData TestShrinkAuxiliaryData20
- * @run main ClassFileInstaller sun.hotspot.WhiteBox
- *                              sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run driver/timeout=720 TestShrinkAuxiliaryData20
- */
-public class TestShrinkAuxiliaryData20 {
+package jtreg;
 
-    public static void main(String[] args) throws Exception {
-        new TestShrinkAuxiliaryData(20).test();
+/**
+ * {@code SkippedException} is an exception treaded by jtreg as an indication
+ * of skipped status.
+ */
+public final class SkippedException extends RuntimeException {
+    public SkippedException(String s, Throwable t) {
+        super(s, t);
+    }
+
+    public SkippedException(String s) {
+        super(s);
     }
 }


### PR DESCRIPTION
This backport brings in `jtreg.SkippedException` which is used by JDK-8308592 (and likely other potential future backports as well). It is a test-only change which allows a skipped test to be correctly reported to jtreg, rather than it appearing like a successful run.

The actual code changes to the HotSpot tests to use `SkippedException` were mostly clean. The main manual adaptations involved the placement of `import` statements (8u also doesn't have 8132919: 'Put compiler tests in packages') and copyright headers. Most tests also needed to have the library location `/test/lib` added. This is because the HotSpot tests are currently still using the HotSpot test library, not the top-level library. @zzambers work on this should eventually remove the need to reference both libraries. 

I've included with this change a number of follow-on changes which were necessary to make the changed tests pass. I don't know how the original version of 8208655 was committed as is, because it contains a number of typos and missing import statements which cause tests to fail.  The follow-up changes are:

* 8023735 backport. This change introduces the code which is altered by 8208655 to use `SkippedException`. The fix is simple enough to just backport with this change and fix the test in the process. It applied cleanly other than the `@ignore` line which has been replaced in 8u by a `ProblemList.txt` addition which is removed by this backport instead.
* Addition of `vm.debug`; this is cherry-picked from 8155219: "[TESTBUG] Rewrite compiler/ciReplay/TestVM.sh in java" which first introduced it in later JDKs. The implementation needs to be adapted to work around the absence of `jdk.debug` (JDK-8139986). Using `java.vm.version` matches what happens in the `Platform.java` test library code.
* 8208701: first fix for typos in 8208655 as committed. Some changes had to be manually applied due to context differences but otherwise a clean backport.
* 8208706: fixes a missing `import` line in `ConstantGettersTransitionsTest.java`, which was applied manually due to differing context.
* 8213410 backport which is necessary as 8208655 removes a number of checks altogether, replacing them with `@requires` statements. This is why we need `vm.debug` above and also this change due to the removed 32-bit check in `runtime/CompressedOops/CompressedClassPointers.java`
* For consistency, the debug build check in `TestLargePageUseForAuxMemory.java` was replaced with vm.debug. In 11u, this is removed through the enhancement [JDK-8152491](https://bugs.openjdk.org/browse/JDK-8152491): "Convert TracePageSizes to use UL"

Absent tests were omitted. Some may be worth a later backport and should ideally use `SkippedException` in backporting.

* `test/compiler/codecache/dtrace/SegmentedCodeCacheDtraceTest.java` - 8059625: JEP-197 JDK-8043304: Test task: DTrace- tests for segmented codecache feature
* `test/compiler/intrinsics/base64/TestBase64.java` - 8205528: Base64 encoding algorithm using AVX512 instructions
* `test/compiler/jvmci/compilerToVM/MaterializeVirtualObjectTest.java` - 8136421: JEP 243: Java-Level JVM Compiler Interface
* `test/runtime/libadimalloc.solaris.sparc/Testlibadimalloc.java` -- 8141445: Use of Solaris/SPARC M7 libadimalloc.so can generate unknown signal in hs_err file
* `test/runtime/signal/SigTestDriver.java` -- JDK-8200126 Open source VM runtime signal tests (needs dep JDK-8072842)
* `test/serviceability/jvmti/NotifyFramePop/NotifyFramePopTest.java` -- 8187289: NotifyFramePop request is not cleared if JVMTI_EVENT_FRAME_POP is disabled
* `test/serviceability/sa/ClhsdbCDSCore.java` -- 8174994: SA: clhsdb printmdo throws WrongTypeException when attached to a process with CDS
* `test/serviceability/sa/ClhsdbCDSJstackPrintAll.java` -- 8174994: SA: clhsdb printmdo throws WrongTypeException when attached to a process with CDS
* `test/serviceability/sa/ClhsdbInspect.java` -- 8192985: SA: Test cases for the clhsdb 'inspect', 'scanoops' and 'printas' commands
* `test/serviceability/sa/ClhsdbJdis.java` -- 8193124: SA: Testcases for clhsdb jdis and findpc commands
* `test/serviceability/sa/ClhsdbLongConstant.java` -- 8190198: SA: Framework for writing 'jhsdb clhsdb' commands tests and testcases for some of the commands
* `test/serviceability/sa/ClhsdbPrintAs.java` -- 8192985: SA: Test cases for the clhsdb 'inspect', 'scanoops' and 'printas' commands
* `test/serviceability/sa/ClhsdbRegionDetailsScanOopsForG1.java` -- 8175312: SA: clhsdb: Provide an improved heap summary for 'universe' for G1GC
* `test/serviceability/sa/ClhsdbScanOops.java` -- 8192985: SA: Test cases for the clhsdb 'inspect', 'scanoops' and 'printas' commands
* `test/serviceability/sa/DeadlockDetectionTest.java` -- 8086134: Deadlock detection fails to attach to core file
* `test/serviceability/sa/TestJmapCore.java` -- 8203491: [TESTBUG] Port heapdump tests into java
* `test/vmTestbase/gc/g1/unloading/UnloadingTest.java` -- 8199370: [TESTBUG] Open source vm testbase GC tests
* `test/vmTestbase/nsk/jdi/AttachingConnector/attach/attach004/TestDriver.java` -- 8199382: [TESTBUG] Open source VM  testbase JDI tests
* `test/vmTestbase/nsk/monitoring/stress/thread/strace001.java` -- 8199375: [TESTBUG] Open source vm testbase monitoring tests

The following two are present, but in much older versions in different locations:

* `test/compiler/codegen/aes/TestAESMain.java` -> `./test/compiler/7184394/TestAESMain.java 8207153: Some intrinsic tests take long time to run`
* `test/compiler/codegen/aes/TestCipherBlockChainingEncrypt.java` -> `./test/compiler/8209951/TestCipherBlockChainingEncrypt.java` 8219513: compiler/codegen/aes/TestCipherBlockChainingEncrypt.java timeout on Solaris-sparc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8208706](https://bugs.openjdk.org/browse/JDK-8208706) needs maintainer approval
- [x] [JDK-8183503](https://bugs.openjdk.org/browse/JDK-8183503) needs maintainer approval
- [x] [JDK-8023735](https://bugs.openjdk.org/browse/JDK-8023735) needs maintainer approval
- [x] [JDK-8213410](https://bugs.openjdk.org/browse/JDK-8213410) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8208655](https://bugs.openjdk.org/browse/JDK-8208655) needs maintainer approval
- [x] [JDK-8186095](https://bugs.openjdk.org/browse/JDK-8186095) needs maintainer approval
- [x] [JDK-8208701](https://bugs.openjdk.org/browse/JDK-8208701) needs maintainer approval

### Issues
 * [JDK-8208655](https://bugs.openjdk.org/browse/JDK-8208655): use JTreg skipped status in hotspot tests (**Enhancement** - P4 - Approved)
 * [JDK-8023735](https://bugs.openjdk.org/browse/JDK-8023735): [TESTBUG][macosx] runtime/XCheckJniJsig/XCheckJSig.java fails on MacOS X (**Bug** - P4 - Approved)
 * [JDK-8208701](https://bugs.openjdk.org/browse/JDK-8208701): Fix for JDK-8208655 causes test failures in CI tier1 (**Bug** - P2 - Approved)
 * [JDK-8208706](https://bugs.openjdk.org/browse/JDK-8208706): compiler/tiered/ConstantGettersTransitionsTest.java fails to compile (**Bug** - P3 - Approved)
 * [JDK-8186095](https://bugs.openjdk.org/browse/JDK-8186095): upgrade to jtreg 4.2 b08 (**Bug** - P4 - Approved)
 * [JDK-8183503](https://bugs.openjdk.org/browse/JDK-8183503): Update hotspot tests to allow for unique test classes directory (**Bug** - P4 - Approved)
 * [JDK-8213410](https://bugs.openjdk.org/browse/JDK-8213410): UseCompressedOops requirement check fails fails on 32-bit system (**Bug** - P4 - Approved)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - Committer)
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/387/head:pull/387` \
`$ git checkout pull/387`

Update a local copy of the PR: \
`$ git checkout pull/387` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/387/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 387`

View PR using the GUI difftool: \
`$ git pr show -t 387`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/387.diff">https://git.openjdk.org/jdk8u-dev/pull/387.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/387#issuecomment-1822165992)