### PR TITLE
8312126: NullPointerException in CertStore.getCRLs after 8297955

### DIFF
--- a/jdk/src/share/classes/sun/security/provider/certpath/ldap/LDAPCertStore.java
+++ b/jdk/src/share/classes/sun/security/provider/certpath/ldap/LDAPCertStore.java
@@ -873,9 +873,13 @@ public final class LDAPCertStore extends CertStoreSpi {
                 } catch (IllegalArgumentException e) {
                     continue;
                 }
-            } else {
+            } else if (nameObject instanceof String) {
                 issuerName = (String)nameObject;
+            } else {
+                throw new CertStoreException(
+                    "unrecognized issuerName: must be String or byte[]");
             }
+
             // If all we want is CA certs, try to get the (probably shorter) ARL
             Collection<X509CRL> entryCRLs = Collections.emptySet();
             if (certChecking == null || certChecking.getBasicConstraints() != -1) {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [3c743cfe](https://github.com/openjdk/jdk/commit/3c743cfea00692d0b938cb1cbde936084eecf369) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Sean Mullan on 15 Sep 2023 and was reviewed by Weijun Wang. It was backported to 17u on 2023-11-10 and [a PR is open for 11u](https://github.com/openjdk/jdk11u-dev/pull/2299).

It is a simple fix and clean backport for a regression introduced by [JDK-8297955](https://bugs.openjdk.org/browse/JDK-8297955) which was backported in [PR 388](https://github.com/openjdk/jdk8u-dev/pull/388). The new code in JDK-8297955 failed to catch a null  IssuerName, allowing a NullPointerException to be thrown instead of the specified CertStoreException.

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8312126](https://bugs.openjdk.org/browse/JDK-8312126) needs maintainer approval

### Issue
 * [JDK-8312126](https://bugs.openjdk.org/browse/JDK-8312126): NullPointerException in CertStore.getCRLs after 8297955 (**Bug** - P4 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**) ⚠️ Review applies to [69299277](https://git.openjdk.org/jdk8u-dev/pull/389/files/69299277ab30bab41e413e637adefefcf0181388)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/389/head:pull/389` \
`$ git checkout pull/389`

Update a local copy of the PR: \
`$ git checkout pull/389` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/389/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 389`

View PR using the GUI difftool: \
`$ git pr show -t 389`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/389.diff">https://git.openjdk.org/jdk8u-dev/pull/389.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/389#issuecomment-1825248333)