### PR TITLE
8312065: Socket.connect does not timeout when profiling

### DIFF
--- a/jdk/src/aix/native/java/net/aix_close.c
+++ b/jdk/src/aix/native/java/net/aix_close.c
@@ -55,6 +55,7 @@
 #include <errno.h>
 
 #include <sys/poll.h>
+#include "jvm.h"
 
 /*
  * Stack allocated by thread when doing blocking operation
@@ -376,61 +377,61 @@ int NET_SocketClose(int fd) {
 /************** Basic I/O operations here ***************/
 
 /*
- * Macro to perform a blocking IO operation. Restarts
- * automatically if interrupted by signal (other than
- * our wakeup signal)
+ * Macro to perform a blocking IO operation.
+ * If interrupted by signal (other than our wakeup signal), and if RETRY is true,
+ * then restarts automatically
  */
-#define BLOCKING_IO_RETURN_INT(FD, FUNC) {      \
-    int ret;                                    \
-    threadEntry_t self;                         \
-    fdEntry_t *fdEntry = getFdEntry(FD);        \
-    if (fdEntry == NULL) {                      \
-        errno = EBADF;                          \
-        return -1;                              \
-    }                                           \
-    do {                                        \
-        startOp(fdEntry, &self);                \
-        ret = FUNC;                             \
-        endOp(fdEntry, &self);                  \
-    } while (ret == -1 && errno == EINTR);      \
-    return ret;                                 \
+#define BLOCKING_IO_RETURN_INT(FD, FUNC, RETRY) {     \
+    int ret;                                          \
+    threadEntry_t self;                               \
+    fdEntry_t *fdEntry = getFdEntry(FD);              \
+    if (fdEntry == NULL) {                            \
+        errno = EBADF;                                \
+        return -1;                                    \
+    }                                                 \
+    do {                                              \
+        startOp(fdEntry, &self);                      \
+        ret = FUNC;                                   \
+        endOp(fdEntry, &self);                        \
+    } while ((RETRY) && ret == -1 && errno == EINTR); \
+    return ret;                                       \
 }
 
 int NET_Read(int s, void* buf, size_t len) {
-    BLOCKING_IO_RETURN_INT( s, recv(s, buf, len, 0) );
+    BLOCKING_IO_RETURN_INT( s, recv(s, buf, len, 0), JNI_TRUE );
 }
 
 int NET_NonBlockingRead(int s, void* buf, size_t len) {
-    BLOCKING_IO_RETURN_INT(s, recv(s, buf, len, MSG_NONBLOCK));
+    BLOCKING_IO_RETURN_INT(s, recv(s, buf, len, MSG_NONBLOCK), JNI_TRUE );
 }
 
 int NET_ReadV(int s, const struct iovec * vector, int count) {
-    BLOCKING_IO_RETURN_INT( s, readv(s, vector, count) );
+    BLOCKING_IO_RETURN_INT( s, readv(s, vector, count), JNI_TRUE );
 }
 
 int NET_RecvFrom(int s, void *buf, int len, unsigned int flags,
        struct sockaddr *from, int *fromlen) {
     socklen_t socklen = *fromlen;
-    BLOCKING_IO_RETURN_INT( s, recvfrom(s, buf, len, flags, from, &socklen) );
+    BLOCKING_IO_RETURN_INT( s, recvfrom(s, buf, len, flags, from, &socklen), JNI_TRUE );
     *fromlen = socklen;
 }
 
 int NET_Send(int s, void *msg, int len, unsigned int flags) {
-    BLOCKING_IO_RETURN_INT( s, send(s, msg, len, flags) );
+    BLOCKING_IO_RETURN_INT( s, send(s, msg, len, flags), JNI_TRUE );
 }
 
 int NET_WriteV(int s, const struct iovec * vector, int count) {
-    BLOCKING_IO_RETURN_INT( s, writev(s, vector, count) );
+    BLOCKING_IO_RETURN_INT( s, writev(s, vector, count), JNI_TRUE );
 }
 
 int NET_SendTo(int s, const void *msg, int len,  unsigned  int
        flags, const struct sockaddr *to, int tolen) {
-    BLOCKING_IO_RETURN_INT( s, sendto(s, msg, len, flags, to, tolen) );
+    BLOCKING_IO_RETURN_INT( s, sendto(s, msg, len, flags, to, tolen), JNI_TRUE );
 }
 
 int NET_Accept(int s, struct sockaddr *addr, int *addrlen) {
     socklen_t socklen = *addrlen;
-    BLOCKING_IO_RETURN_INT( s, accept(s, addr, &socklen) );
+    BLOCKING_IO_RETURN_INT( s, accept(s, addr, &socklen), JNI_TRUE );
     *addrlen = socklen;
 }
 
@@ -490,13 +491,13 @@ int NET_Connect(int s, struct sockaddr *addr, int addrlen) {
 
 #ifndef USE_SELECT
 int NET_Poll(struct pollfd *ufds, unsigned int nfds, int timeout) {
-    BLOCKING_IO_RETURN_INT( ufds[0].fd, poll(ufds, nfds, timeout) );
+    BLOCKING_IO_RETURN_INT( ufds[0].fd, poll(ufds, nfds, timeout), JNI_FALSE );
 }
 #else
 int NET_Select(int s, fd_set *readfds, fd_set *writefds,
                fd_set *exceptfds, struct timeval *timeout) {
     BLOCKING_IO_RETURN_INT( s-1,
-                            select(s, readfds, writefds, exceptfds, timeout) );
+                            select(s, readfds, writefds, exceptfds, timeout), JNI_TRUE );
 }
 #endif
 

--- a/jdk/src/solaris/native/java/net/bsd_close.c
+++ b/jdk/src/solaris/native/java/net/bsd_close.c
@@ -39,6 +39,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <sys/poll.h>
+#include "jvm.h"
 
 /*
  * Stack allocated by thread when doing blocking operation
@@ -347,55 +348,55 @@ int NET_SocketClose(int fd) {
 /************** Basic I/O operations here ***************/
 
 /*
- * Macro to perform a blocking IO operation. Restarts
- * automatically if interrupted by signal (other than
- * our wakeup signal)
+ * Macro to perform a blocking IO operation.
+ * If interrupted by signal (other than our wakeup signal), and if RETRY is true,
+ * then restarts automatically
  */
-#define BLOCKING_IO_RETURN_INT(FD, FUNC) {      \
-    int ret;                                    \
-    threadEntry_t self;                         \
-    fdEntry_t *fdEntry = getFdEntry(FD);        \
-    if (fdEntry == NULL) {                      \
-        errno = EBADF;                          \
-        return -1;                              \
-    }                                           \
-    do {                                        \
-        startOp(fdEntry, &self);                \
-        ret = FUNC;                             \
-        endOp(fdEntry, &self);                  \
-    } while (ret == -1 && errno == EINTR);      \
-    return ret;                                 \
+#define BLOCKING_IO_RETURN_INT(FD, FUNC, RETRY) {     \
+    int ret;                                          \
+    threadEntry_t self;                               \
+    fdEntry_t *fdEntry = getFdEntry(FD);              \
+    if (fdEntry == NULL) {                            \
+        errno = EBADF;                                \
+        return -1;                                    \
+    }                                                 \
+    do {                                              \
+        startOp(fdEntry, &self);                      \
+        ret = FUNC;                                   \
+        endOp(fdEntry, &self);                        \
+    } while ((RETRY) && ret == -1 && errno == EINTR); \
+    return ret;                                       \
 }
 
 int NET_Read(int s, void* buf, size_t len) {
-    BLOCKING_IO_RETURN_INT( s, recv(s, buf, len, 0) );
+    BLOCKING_IO_RETURN_INT( s, recv(s, buf, len, 0), JNI_TRUE );
 }
 
 int NET_NonBlockingRead(int s, void* buf, size_t len) {
-    BLOCKING_IO_RETURN_INT( s, recv(s, buf, len, MSG_DONTWAIT));
+    BLOCKING_IO_RETURN_INT( s, recv(s, buf, len, MSG_DONTWAIT), JNI_TRUE );
 }
 
 int NET_ReadV(int s, const struct iovec * vector, int count) {
-    BLOCKING_IO_RETURN_INT( s, readv(s, vector, count) );
+    BLOCKING_IO_RETURN_INT( s, readv(s, vector, count), JNI_TRUE );
 }
 
 int NET_RecvFrom(int s, void *buf, int len, unsigned int flags,
        struct sockaddr *from, int *fromlen) {
     /* casting int *fromlen -> socklen_t* Both are ints */
-    BLOCKING_IO_RETURN_INT( s, recvfrom(s, buf, len, flags, from, (socklen_t *)fromlen) );
+    BLOCKING_IO_RETURN_INT( s, recvfrom(s, buf, len, flags, from, (socklen_t *)fromlen), JNI_TRUE );
 }
 
 int NET_Send(int s, void *msg, int len, unsigned int flags) {
-    BLOCKING_IO_RETURN_INT( s, send(s, msg, len, flags) );
+    BLOCKING_IO_RETURN_INT( s, send(s, msg, len, flags), JNI_TRUE );
 }
 
 int NET_WriteV(int s, const struct iovec * vector, int count) {
-    BLOCKING_IO_RETURN_INT( s, writev(s, vector, count) );
+    BLOCKING_IO_RETURN_INT( s, writev(s, vector, count), JNI_TRUE );
 }
 
 int NET_SendTo(int s, const void *msg, int len,  unsigned  int
        flags, const struct sockaddr *to, int tolen) {
-    BLOCKING_IO_RETURN_INT( s, sendto(s, msg, len, flags, to, tolen) );
+    BLOCKING_IO_RETURN_INT( s, sendto(s, msg, len, flags, to, tolen), JNI_TRUE );
 }
 
 int NET_Accept(int s, struct sockaddr *addr, int *addrlen) {
@@ -403,22 +404,22 @@ int NET_Accept(int s, struct sockaddr *addr, int *addrlen) {
     int error = accept(s, addr, &len);
     if (error != -1)
         *addrlen = (int)len;
-    BLOCKING_IO_RETURN_INT( s, error );
+    BLOCKING_IO_RETURN_INT( s, error, JNI_FALSE );
 }
 
 int NET_Connect(int s, struct sockaddr *addr, int addrlen) {
-    BLOCKING_IO_RETURN_INT( s, connect(s, addr, addrlen) );
+    BLOCKING_IO_RETURN_INT( s, connect(s, addr, addrlen), JNI_TRUE );
 }
 
 #ifndef USE_SELECT
 int NET_Poll(struct pollfd *ufds, unsigned int nfds, int timeout) {
-    BLOCKING_IO_RETURN_INT( ufds[0].fd, poll(ufds, nfds, timeout) );
+    BLOCKING_IO_RETURN_INT( ufds[0].fd, poll(ufds, nfds, timeout), JNI_FALSE );
 }
 #else
 int NET_Select(int s, fd_set *readfds, fd_set *writefds,
                fd_set *exceptfds, struct timeval *timeout) {
     BLOCKING_IO_RETURN_INT( s-1,
-                            select(s, readfds, writefds, exceptfds, timeout) );
+                            select(s, readfds, writefds, exceptfds, timeout), JNI_TRUE );
 }
 #endif
 

--- a/jdk/src/solaris/native/java/net/linux_close.c
+++ b/jdk/src/solaris/native/java/net/linux_close.c
@@ -37,6 +37,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <sys/poll.h>
+#include "jvm.h"
 
 /*
  * Stack allocated by thread when doing blocking operation
@@ -343,77 +344,77 @@ int NET_SocketClose(int fd) {
 /************** Basic I/O operations here ***************/
 
 /*
- * Macro to perform a blocking IO operation. Restarts
- * automatically if interrupted by signal (other than
- * our wakeup signal)
+ * Macro to perform a blocking IO operation.
+ * If interrupted by signal (other than our wakeup signal), and if RETRY is true,
+ * then restarts automatically
  */
-#define BLOCKING_IO_RETURN_INT(FD, FUNC) {      \
-    int ret;                                    \
-    threadEntry_t self;                         \
-    fdEntry_t *fdEntry = getFdEntry(FD);        \
-    if (fdEntry == NULL) {                      \
-        errno = EBADF;                          \
-        return -1;                              \
-    }                                           \
-    do {                                        \
-        startOp(fdEntry, &self);                \
-        ret = FUNC;                             \
-        endOp(fdEntry, &self);                  \
-    } while (ret == -1 && errno == EINTR);      \
-    return ret;                                 \
+#define BLOCKING_IO_RETURN_INT(FD, FUNC, RETRY) {     \
+    int ret;                                          \
+    threadEntry_t self;                               \
+    fdEntry_t *fdEntry = getFdEntry(FD);              \
+    if (fdEntry == NULL) {                            \
+        errno = EBADF;                                \
+        return -1;                                    \
+    }                                                 \
+    do {                                              \
+        startOp(fdEntry, &self);                      \
+        ret = FUNC;                                   \
+        endOp(fdEntry, &self);                        \
+    } while ((RETRY) && ret == -1 && errno == EINTR); \
+    return ret;                                       \
 }
 
 int NET_Read(int s, void* buf, size_t len) {
-    BLOCKING_IO_RETURN_INT( s, recv(s, buf, len, 0) );
+    BLOCKING_IO_RETURN_INT( s, recv(s, buf, len, 0), JNI_TRUE );
 }
 
 int NET_NonBlockingRead(int s, void* buf, size_t len) {
-    BLOCKING_IO_RETURN_INT( s, recv(s, buf, len, MSG_DONTWAIT) );
+    BLOCKING_IO_RETURN_INT( s, recv(s, buf, len, MSG_DONTWAIT), JNI_TRUE );
 }
 
 int NET_ReadV(int s, const struct iovec * vector, int count) {
-    BLOCKING_IO_RETURN_INT( s, readv(s, vector, count) );
+    BLOCKING_IO_RETURN_INT( s, readv(s, vector, count), JNI_TRUE );
 }
 
 int NET_RecvFrom(int s, void *buf, int len, unsigned int flags,
        struct sockaddr *from, int *fromlen) {
     socklen_t socklen = *fromlen;
-    BLOCKING_IO_RETURN_INT( s, recvfrom(s, buf, len, flags, from, &socklen) );
+    BLOCKING_IO_RETURN_INT( s, recvfrom(s, buf, len, flags, from, &socklen), JNI_TRUE );
     *fromlen = socklen;
 }
 
 int NET_Send(int s, void *msg, int len, unsigned int flags) {
-    BLOCKING_IO_RETURN_INT( s, send(s, msg, len, flags) );
+    BLOCKING_IO_RETURN_INT( s, send(s, msg, len, flags), JNI_TRUE );
 }
 
 int NET_WriteV(int s, const struct iovec * vector, int count) {
-    BLOCKING_IO_RETURN_INT( s, writev(s, vector, count) );
+    BLOCKING_IO_RETURN_INT( s, writev(s, vector, count), JNI_TRUE );
 }
 
 int NET_SendTo(int s, const void *msg, int len,  unsigned  int
        flags, const struct sockaddr *to, int tolen) {
-    BLOCKING_IO_RETURN_INT( s, sendto(s, msg, len, flags, to, tolen) );
+    BLOCKING_IO_RETURN_INT( s, sendto(s, msg, len, flags, to, tolen), JNI_TRUE );
 }
 
 int NET_Accept(int s, struct sockaddr *addr, int *addrlen) {
     socklen_t socklen = *addrlen;
-    BLOCKING_IO_RETURN_INT( s, accept(s, addr, &socklen) );
+    BLOCKING_IO_RETURN_INT( s, accept(s, addr, &socklen), JNI_TRUE );
     *addrlen = socklen;
 }
 
 int NET_Connect(int s, struct sockaddr *addr, int addrlen) {
-    BLOCKING_IO_RETURN_INT( s, connect(s, addr, addrlen) );
+    BLOCKING_IO_RETURN_INT( s, connect(s, addr, addrlen), JNI_TRUE );
 }
 
 #ifndef USE_SELECT
 int NET_Poll(struct pollfd *ufds, unsigned int nfds, int timeout) {
-    BLOCKING_IO_RETURN_INT( ufds[0].fd, poll(ufds, nfds, timeout) );
+    BLOCKING_IO_RETURN_INT( ufds[0].fd, poll(ufds, nfds, timeout), JNI_FALSE );
 }
 #else
 int NET_Select(int s, fd_set *readfds, fd_set *writefds,
                fd_set *exceptfds, struct timeval *timeout) {
     BLOCKING_IO_RETURN_INT( s-1,
-                            select(s, readfds, writefds, exceptfds, timeout) );
+                            select(s, readfds, writefds, exceptfds, timeout), JNI_TRUE );
 }
 #endif
 

--- a/jdk/test/java/net/Socket/B8312065.java
+++ b/jdk/test/java/net/Socket/B8312065.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2023, Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8312065
+ * @summary Socket.connect does not timeout as expected when profiling (i.e. keep receiving signal)
+ * @requires (os.family != "windows")
+ * @build B8312065
+ * @run shell B8312065.sh
+ */
+
+import sun.misc.Signal;
+
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+import java.util.concurrent.TimeUnit;
+
+public class B8312065 {
+    public static void main(String[] args) throws Exception {
+        System.loadLibrary("NativeThread");
+
+        // Setup SIGPIPE handler
+        Signal.handle(new Signal("PIPE"), System.out::println);
+
+        long osThreadId = NativeThread.getID();
+
+        int timeoutMillis = 2000;
+        int n = 10;
+        Thread t = new Thread(() -> {
+            // Send SIGPIPE to the thread every second
+            for (int i = 0; i < n; i++) {
+                if (NativeThread.signal(osThreadId, NativeThread.SIGPIPE) != 0) {
+                    System.out.println("Test FAILED: failed to send signal");
+                    System.exit(1);
+                }
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    System.out.println("Test FAILED: unexpected interrupt");
+                    System.exit(1);
+                }
+            }
+            System.out.println("Test FAILED: Socket.connect blocked " + n + " seconds, " +
+                    "expected around " + timeoutMillis / 1000 + " seconds");
+            System.exit(1);
+        });
+        t.setDaemon(true);
+        t.start();
+
+        long startTime = System.nanoTime();
+
+        try {
+            Socket socket = new Socket();
+            // There is no good way to mock SocketTimeoutException, just assume 192.168.255.255 is not in use
+            socket.connect(new InetSocketAddress("192.168.255.255", 8080), timeoutMillis);
+        } catch (SocketTimeoutException e) {
+            long duration = TimeUnit.MILLISECONDS.convert(System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
+            if (duration >= timeoutMillis) {
+                System.out.println("Test passed");
+            } else {
+                System.out.println("Test FAILED: duration " + duration + " ms, expected >= " + timeoutMillis + " ms");
+                System.exit(1);
+            }
+        }
+    }
+}

--- a/jdk/test/java/net/Socket/B8312065.sh
+++ b/jdk/test/java/net/Socket/B8312065.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -ex
+
+if [ "x$TESTGCC" = "x" ]; then
+  TESTGCC=$(readlink -f $(which gcc))
+fi
+
+if [ "x$TESTGCC" = "x" ]; then
+  echo "WARNING: gcc not found. Cannot execute test." 2>&1
+  exit 1;
+fi
+
+if [ "x$TESTROOT" = "x" ]; then
+  echo "TESTROOT pointintg to top level sources is not set. that is fatal"
+  exit 2;
+fi
+
+if [ "x$TESTJAVA" = "x" ]; then
+  TESTJAVA=$(dirname $(dirname $(readlink -f $(which java))))
+fi
+
+JDK_TOPDIR="${TESTROOT}/.."
+JAVA="${TESTJAVA}/bin/java"
+TEST_ENV_SH="${JDK_TOPDIR}/../hotspot/test/test_env.sh"
+
+ls -l "${TEST_ENV_SH}"
+set +e
+  . "${TEST_ENV_SH}"
+set -e
+
+"${TESTGCC}" \
+    -fPIC \
+    -shared \
+    ${CFLAGBITS} \
+    -o ${TESTCLASSES}/libNativeThread.so \
+    -I${JDK_TOPDIR}/src/share/bin \
+    -I${JDK_TOPDIR}/src/share/javavm/export \
+    -I${JDK_TOPDIR}/src/macosx/javavm/export \
+    -I${JDK_TOPDIR}/src/solaris/bin \
+    ${TESTSRC}/libNativeThread.c
+
+"${JAVA}" -Dtest.jdk=${TESTJAVA} \
+          -Dtest.nativepath=${TESTCLASSES} \
+          -Djava.library.path=${TESTCLASSES} \
+          -cp ${TESTCLASSPATH}:${TESTCLASSES} B8312065

--- a/jdk/test/java/net/Socket/NativeThread.java
+++ b/jdk/test/java/net/Socket/NativeThread.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+public class NativeThread {
+
+    public static final int SIGPIPE;
+
+    static {
+        SIGPIPE = getSIGPIPE();
+    }
+
+    public static native long getID();
+
+    public static native int signal(long threadId, int sig);
+
+    private static native int getSIGPIPE();
+}

--- a/jdk/test/java/net/Socket/libNativeThread.c
+++ b/jdk/test/java/net/Socket/libNativeThread.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+#include<jni.h>
+#include<signal.h>
+#include<stdlib.h>
+#if  defined(__linux__) || defined(_ALLBSD_SOURCE) || defined(_AIX)
+#include <pthread.h>
+#endif
+
+/*
+ * Class:     NativeThread
+ * Method:    getID
+ * Signature: ()J
+ */
+JNIEXPORT jlong JNICALL Java_NativeThread_getID(JNIEnv *env, jclass class)
+{
+    #if  defined(__linux__) || defined(_ALLBSD_SOURCE) || defined(_AIX)
+        return (jlong)pthread_self();
+    #else
+        return 0;
+    #endif
+}
+
+/*
+ * Class:     NativeThread
+ * Method:    signal
+ * Signature: (JI)I
+ */
+JNIEXPORT jint JNICALL Java_NativeThread_signal(JNIEnv *env, jclass class, jlong thread, jint sig)
+{
+    #if  defined(__linux__) || defined(_ALLBSD_SOURCE) || defined(_AIX)
+        return pthread_kill((pthread_t)thread, sig);
+    #else
+        return 0;
+    #endif
+}
+
+/*
+ * Class:     NativeThread
+ * Method:    getSIGPIPE
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_NativeThread_getSIGPIPE(JNIEnv *env, jclass class)
+{
+    #if  defined(__linux__) || defined(_ALLBSD_SOURCE) || defined(_AIX)
+        return SIGPIPE;
+    #else
+        return 0;
+    #endif
+}


### PR DESCRIPTION
Hi,

This pull request contains the backport of [JDK-8312065](https://bugs.openjdk.org/browse/JDK-8312065), commit [1ce12c4](https://github.com/openjdk/jdk17u-dev/commit/1ce12c4f33d3d6905703d95df2574f4037dfd57d) from the [openjdk/jdk17u-dev](https://github.com/openjdk/jdk17u-dev) repository.

I added the test `B8312065.java`. The test will fail on the JDK8 without my fix, and it will pass on the JDK8 containing my fix.
This test relies on [libNativeThread](https://github.com/openjdk/jdk/blob/master/test/jdk/java/net/Socket/libNativeThread.c) to get the `OS thread ID` of the `Java threads`, and send signals to `OS threads`.
The `libNativeThread` was introduced to test the fix for [JDK-8237858](https://bugs.openjdk.org/browse/JDK-8237858). However, `JDK-8237858` only exists in Java 10 and above. There is no `JDK-8237858` problem on Java 8, so `JDK-8237858` cannot be backported to Java 8.
In order to use `libNativeThread`, I copied it to my backport.

I ran all the `jtreg` tests in `test/jdk/java/net/ServerSocket`,`test/jdk/java/net/Socket`,`test/jdk/java/net/SocketOption`,`test/jdk/java/net/ipv6` on my host, all passed.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8312065](https://bugs.openjdk.org/browse/JDK-8312065) needs maintainer approval

### Issue
 * [JDK-8312065](https://bugs.openjdk.org/browse/JDK-8312065): Socket.connect does not timeout when profiling (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/410/head:pull/410` \
`$ git checkout pull/410`

Update a local copy of the PR: \
`$ git checkout pull/410` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/410/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 410`

View PR using the GUI difftool: \
`$ git pr show -t 410`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/410.diff">https://git.openjdk.org/jdk8u-dev/pull/410.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/410#issuecomment-1865882706)
</details>
