### PR TITLE
8276139: TestJpsHostName.java not reliable, better to expand HostIdentifierCreate.java test

### DIFF
--- a/jdk/src/share/classes/sun/jvmstat/monitor/HostIdentifier.java
+++ b/jdk/src/share/classes/sun/jvmstat/monitor/HostIdentifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/jdk/src/share/classes/sun/jvmstat/monitor/HostIdentifier.java
+++ b/jdk/src/share/classes/sun/jvmstat/monitor/HostIdentifier.java
@@ -112,7 +112,7 @@ public class HostIdentifier {
             return new URI(uriString);
         }
 
-	if (Character.isDigit(uriString.charAt(0))) {
+        if (Character.isDigit(uriString.charAt(0))) {
             // may be hostname or hostname:port since it starts with digits
             uriString = "//" + uriString;
         }

--- a/jdk/src/share/classes/sun/jvmstat/monitor/HostIdentifier.java
+++ b/jdk/src/share/classes/sun/jvmstat/monitor/HostIdentifier.java
@@ -112,6 +112,11 @@ public class HostIdentifier {
             return new URI(uriString);
         }
 
+	if (Character.isDigit(uriString.charAt(0))) {
+            // may be hostname or hostname:port since it starts with digits
+            uriString = "//" + uriString;
+        }
+
         URI u = new URI(uriString);
 
         if (u.isAbsolute()) {

--- a/jdk/test/sun/jvmstat/monitor/HostIdentifier/HostIdentifierCreate.java
+++ b/jdk/test/sun/jvmstat/monitor/HostIdentifier/HostIdentifierCreate.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 4990825
+ * @bug 4990825 8251155
  * @summary test that HostIdentifier objects get created as expected
  */
 

--- a/jdk/test/sun/jvmstat/monitor/HostIdentifier/testcases
+++ b/jdk/test/sun/jvmstat/monitor/HostIdentifier/testcases
@@ -199,7 +199,7 @@ protocol, dotted hostname, port, and specificed server name, with query and frag
 
 <testcase id="28" HostIdentifierInput="file://localhost">
 <description>
-file URI 
+file URI
 </description>
 <HostIdentifier> file://localhost </HostIdentifier>
 </testcase>
@@ -216,6 +216,20 @@ special syntax - not a valid URI, but allowed by HostIdentifier
 special syntax - not a valid URI, but allowed by HostIdentifier
 </description>
 <HostIdentifier> rmi://10.0.0.1:1234 </HostIdentifier>
+</testcase>
+
+<testcase id="31" HostIdentifierInput="12345">
+<description>
+Purely numeric
+</description>
+<HostIdentifier> //12345 </HostIdentifier>
+</testcase>
+
+<testcase id="32" HostIdentifierInput="12345:123">
+<description>
+Purely numeric
+</description>
+<HostIdentifier> //12345:123 </HostIdentifier>
 </testcase>
 
 </HostIdentifierTests>

--- a/jdk/test/sun/jvmstat/monitor/HostIdentifier/testcases
+++ b/jdk/test/sun/jvmstat/monitor/HostIdentifier/testcases
@@ -199,7 +199,7 @@ protocol, dotted hostname, port, and specificed server name, with query and frag
 
 <testcase id="28" HostIdentifierInput="file://localhost">
 <description>
-file URI
+file URI 
 </description>
 <HostIdentifier> file://localhost </HostIdentifier>
 </testcase>

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,1 @@
+submit patch to trigger the test

--- a/test.txt
+++ b/test.txt
@@ -1,1 +1,0 @@
-submit patch to trigger the test


### PR DESCRIPTION
I backport JDK-8251155 and JDK-8276139.
Apply clean except for test path. And test have been locally verified to pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8251155](https://bugs.openjdk.org/browse/JDK-8251155) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8276139](https://bugs.openjdk.org/browse/JDK-8276139) needs maintainer approval

### Issues
 * [JDK-8276139](https://bugs.openjdk.org/browse/JDK-8276139): TestJpsHostName.java not reliable, better to expand HostIdentifierCreate.java test (**Bug** - P4 - Approved)
 * [JDK-8251155](https://bugs.openjdk.org/browse/JDK-8251155): HostIdentifier fails to canonicalize hostnames starting with digits (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/411/head:pull/411` \
`$ git checkout pull/411`

Update a local copy of the PR: \
`$ git checkout pull/411` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/411/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 411`

View PR using the GUI difftool: \
`$ git pr show -t 411`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/411.diff">https://git.openjdk.org/jdk8u-dev/pull/411.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/411#issuecomment-1873602204)