### PR TITLE
8321060: [8u] hotspot needs to recognise VS2022

### DIFF
--- a/hotspot/make/windows/makefiles/compile.make
+++ b/hotspot/make/windows/makefiles/compile.make
@@ -172,6 +172,9 @@ COMPILER_NAME=VS2017
 !if "$(MSC_VER)" >= "1920" && "$(MSC_VER)" <= "1929"
 COMPILER_NAME=VS2019
 !endif
+!if "$(MSC_VER)" >= "1930" && "$(MSC_VER)" <= "1938"
+COMPILER_NAME=VS2022
+!endif
 !endif
 
 # By default, we do not want to use the debug version of the msvcrt.dll file
@@ -322,6 +325,21 @@ SAFESEH_FLAG = /SAFESEH
 !endif
 
 !if "$(COMPILER_NAME)" == "VS2019"
+PRODUCT_OPT_OPTION   = /O2 /Oy-
+FASTDEBUG_OPT_OPTION = /O2 /Oy-
+DEBUG_OPT_OPTION     = /Od
+GX_OPTION = /EHsc
+LD_FLAGS = /manifest $(LD_FLAGS)
+MP_FLAG = /MP
+# Manifest Tool - used in VS2005 and later to adjust manifests stored
+# as resources inside build artifacts.
+!if "x$(MT)" == "x"
+MT=mt.exe
+!endif
+SAFESEH_FLAG = /SAFESEH
+!endif
+
+!if "$(COMPILER_NAME)" == "VS2022"
 PRODUCT_OPT_OPTION   = /O2 /Oy-
 FASTDEBUG_OPT_OPTION = /O2 /Oy-
 DEBUG_OPT_OPTION     = /Od

--- a/hotspot/make/windows/makefiles/sanity.make
+++ b/hotspot/make/windows/makefiles/sanity.make
@@ -33,6 +33,8 @@ checkCL:
 	if "$(MSC_VER)" NEQ "1912" \
 	if "$(MSC_VER)" NEQ "1920" if "$(MSC_VER)" NEQ "1921" if "$(MSC_VER)" NEQ "1922" if "$(MSC_VER)" NEQ "1923" if "$(MSC_VER)" NEQ "1924" \
 	if "$(MSC_VER)" NEQ "1925" if "$(MSC_VER)" NEQ "1926" if "$(MSC_VER)" NEQ "1927" if "$(MSC_VER)" NEQ "1928" if "$(MSC_VER)" NEQ "1929" \
+	if "$(MSC_VER)" NEQ "1930" if "$(MSC_VER)" NEQ "1931" if "$(MSC_VER)" NEQ "1932" if "$(MSC_VER)" NEQ "1933" if "$(MSC_VER)" NEQ "1934" \
+	if "$(MSC_VER)" NEQ "1935" if "$(MSC_VER)" NEQ "1936" if "$(MSC_VER)" NEQ "1937" if "$(MSC_VER)" NEQ "1938" \
 	echo *** WARNING *** unrecognized cl.exe version $(MSC_VER) ($(RAW_MSC_VER)).  Use FORCE_MSC_VER to override automatic detection.
 
 checkLink:
@@ -43,4 +45,6 @@ checkLink:
 	if "$(LD_VER)" NEQ "1412" \
 	if "$(LD_VER)" NEQ "1420" if "$(LD_VER)" NEQ "1421" if "$(LD_VER)" NEQ "1422" if "$(LD_VER)" NEQ "1423" if "$(LD_VER)" NEQ "1424" \
 	if "$(LD_VER)" NEQ "1425" if "$(LD_VER)" NEQ "1426" if "$(LD_VER)" NEQ "1427" if "$(LD_VER)" NEQ "1428" if "$(LD_VER)" NEQ "1429" \
+	if "$(LD_VER)" NEQ "1430" if "$(LD_VER)" NEQ "1431" if "$(LD_VER)" NEQ "1432" if "$(LD_VER)" NEQ "1433" if "$(LD_VER)" NEQ "1434" \
+	if "$(LD_VER)" NEQ "1435" if "$(LD_VER)" NEQ "1436" if "$(LD_VER)" NEQ "1437" if "$(LD_VER)" NEQ "1438" \
 	echo *** WARNING *** unrecognized link.exe version $(LD_VER) ($(RAW_LD_VER)).  Use FORCE_LD_VER to override automatic detection.

--- a/hotspot/make/windows/makefiles/vm.make
+++ b/hotspot/make/windows/makefiles/vm.make
@@ -129,7 +129,7 @@ CXX_DONT_USE_PCH=/D DONT_USE_PRECOMPILED_HEADER
 
 !if "$(USE_PRECOMPILED_HEADER)" != "0"
 CXX_USE_PCH=/Fp"vm.pch" /Yu"precompiled.hpp"
-!if "$(COMPILER_NAME)" == "VS2012" || "$(COMPILER_NAME)" == "VS2013" || "$(COMPILER_NAME)" == "VS2015" || "$(COMPILER_NAME)" == "VS2017" || "$(COMPILER_NAME)" == "VS2019"
+!if "$(COMPILER_NAME)" == "VS2012" || "$(COMPILER_NAME)" == "VS2013" || "$(COMPILER_NAME)" == "VS2015" || "$(COMPILER_NAME)" == "VS2017" || "$(COMPILER_NAME)" == "VS2019" || "$(COMPILER_NAME)" == "VS2022"
 # VS2012 and later require this object file to be listed:
 LD_FLAGS=$(LD_FLAGS) _build_pch_file.obj
 !endif


### PR DESCRIPTION
The hotspot build scripts are updated to recognize the latest versions of VS2022. The fix is similar to:
https://github.com/openjdk/jdk8u-dev/pull/187

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8321060](https://bugs.openjdk.org/browse/JDK-8321060) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321060](https://bugs.openjdk.org/browse/JDK-8321060): [8u] hotspot needs to recognise VS2022 (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/412/head:pull/412` \
`$ git checkout pull/412`

Update a local copy of the PR: \
`$ git checkout pull/412` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/412/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 412`

View PR using the GUI difftool: \
`$ git pr show -t 412`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/412.diff">https://git.openjdk.org/jdk8u-dev/pull/412.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/412#issuecomment-1874762816)