### PR TITLE
fix processAnnotations method abort in a certain round, resulting in a compilation failure, but Javac considers it successful

### DIFF
--- a/langtools/src/share/classes/com/sun/tools/javac/main/JavaCompiler.java
+++ b/langtools/src/share/classes/com/sun/tools/javac/main/JavaCompiler.java
@@ -861,11 +861,29 @@ public class JavaCompiler {
             delegateCompiler.close();
             elapsed_msec = delegateCompiler.elapsed_msec;
         } catch (Abort ex) {
+            correctDelegateCompilerIfNeed();
             if (devVerbose)
                 ex.printStackTrace(System.err);
         } finally {
             if (procEnvImpl != null)
                 procEnvImpl.close();
+        }
+    }
+
+    /**
+     * If processAnnotations abort in a certain round,
+     * delegateCompiler is likely to be null,
+     * resulting in a random compilation failure,
+     * but Javac considers it successful,
+     * so it may be necessary to find the final compiler used here
+     */
+    private void correctDelegateCompilerIfNeed() {
+        if(delegateCompiler != null){
+            return;
+        }
+        Context procContext = procEnvImpl.getContext();
+        if(procContext != context){
+            delegateCompiler = JavaCompiler.instance(procContext);
         }
     }
 


### PR DESCRIPTION
When I was building my application using Maven 3.6.3, I had two applications A and B that had a dependency relationship. B relied on A's jar. When I built both A and B simultaneously, A successfully built them. Although B threw an exception, Javac believed that B had built successfully. I unpacked the jar package that B typed and found that there was no class file inside. So I searched for the reason based on the exception information, and found that Javac was divided into multiple rounds when processing annotations. If an abort occurred in a certain round stage, Javac would not be able to find the delegate compiler. If Javac's own errors were 0 at this time, it would consider compilation successful, but the specific error information was reported to the global DiagnosticCollector by the delegate compiler, So even though Maven printed an error, it didn't stop working due to the error, but instead continued to package and ultimately printed an incorrect package.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/419/head:pull/419` \
`$ git checkout pull/419`

Update a local copy of the PR: \
`$ git checkout pull/419` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/419/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 419`

View PR using the GUI difftool: \
`$ git pr show -t 419`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/419.diff">https://git.openjdk.org/jdk8u-dev/pull/419.diff</a>

</details>
