### PR TITLE
8248001: javadoc generates invalid HTML pages whose ftp:// links are broken

### DIFF
--- a/langtools/src/share/classes/com/sun/tools/doclets/formats/html/HtmlDocletWriter.java
+++ b/langtools/src/share/classes/com/sun/tools/doclets/formats/html/HtmlDocletWriter.java
@@ -1725,7 +1725,8 @@ public class HtmlDocletWriter extends HtmlDocWriter {
                 if (!(relativeLinkLowerCase.startsWith("mailto:") ||
                         relativeLinkLowerCase.startsWith("http:") ||
                         relativeLinkLowerCase.startsWith("https:") ||
-                        relativeLinkLowerCase.startsWith("file:"))) {
+                        relativeLinkLowerCase.startsWith("file:") ||
+                        relativeLinkLowerCase.startsWith("ftp:"))) {
                     relativeLink = "{@"+(new DocRootTaglet()).getName() + "}/"
                         + redirectPathFromRoot.resolve(relativeLink).getPath();
                     textBuff.replace(begin, end, relativeLink);

--- a/langtools/test/com/sun/javadoc/testHrefInDocComment/TestHrefInDocComment.java
+++ b/langtools/test/com/sun/javadoc/testHrefInDocComment/TestHrefInDocComment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 4638015
+ * @bug 4638015 8248001
  * @summary Determine if Hrefs are processed properly when they
  * appear in doc comments.
  * @author jamieh

--- a/langtools/test/com/sun/javadoc/testHrefInDocComment/pkg/J1.java
+++ b/langtools/test/com/sun/javadoc/testHrefInDocComment/pkg/J1.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package pkg;
+
+/**
+ *This class has <a href="{@docRoot}/pkg/J1.html#functions">various functions</a>,
+ * see <a href="ftp://www.example.com/">FTP Site</a>,
+ *  <a href="file:///path/to/somefile">file service</a> for further information
+ *<a id="functions">various functions</a>
+ *<ul>
+ *<li>function1</li>
+ *<li>function2</li>
+ *<li>function3</li>
+ *</ul>
+ *<a id="methods">special methods</a>
+ *<ul>
+ *<li>method1</li>
+ *<li>method2</li>
+ *<li>method3</li>
+ *</ul>
+ */
+public class J1 {
+    /**
+     *fields.
+     */
+    protected Object field1;
+
+    /**
+     *<a href="{@docRoot}/pkg/J1.html#functions">Creates an instance which has various functions.</a>
+     */
+    public J1(){
+    }
+
+    /**
+     *This is a<a href="#methods">special method</a>.
+     *@param p1 arg1
+     */
+    public void method1(int p1){
+    }
+
+    /**
+     *See <a href="ftp://www.example.com/">FTP Site</a> for more information.
+     *@param p1 arg1
+     */
+    public void method2(int p1){
+    }
+
+    /**
+     *See <a href="file:///path/to/somefile">file service</a> for more information.
+     *@param p1 arg1
+     */
+    public void method3(int p1){
+    }
+}


### PR DESCRIPTION
I would like to backport
8248001: javadoc generates invalid HTML pages whose ftp:// links are broken.
There are minor differences regarding DocRoot, but otherwise this is a clean backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8248001](https://bugs.openjdk.org/browse/JDK-8248001) needs maintainer approval

### Issue
 * [JDK-8248001](https://bugs.openjdk.org/browse/JDK-8248001): javadoc generates invalid HTML pages whose ftp:// links are broken (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/420/head:pull/420` \
`$ git checkout pull/420`

Update a local copy of the PR: \
`$ git checkout pull/420` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/420/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 420`

View PR using the GUI difftool: \
`$ git pr show -t 420`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/420.diff">https://git.openjdk.org/jdk8u-dev/pull/420.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/420#issuecomment-1892985789)
</details>
