### PR TITLE
JDK-8324530: Build error with gcc 10

### DIFF
--- a/hotspot/src/share/vm/ci/ciMethodBlocks.cpp
+++ b/hotspot/src/share/vm/ci/ciMethodBlocks.cpp
@@ -379,7 +379,7 @@ static const char *flagnames[] = {
 
 void ciBlock::dump() {
   tty->print(" [%d .. %d), {", _start_bci, _limit_bci);
-  for (int i = 0; i < 8; i++) {
+  for (int i = 0; i < 7; i++) {
     if ((_flags & (1 << i)) != 0) {
       tty->print(" %s", flagnames[i]);
     }


### PR DESCRIPTION
This is a trivial fix to a build error (and the underlying off-by-one error, which is only theoretical) gcc 10 warns about.

Note that this issue has been fixed in JDK 11 and later as part of 8140594: "Various minor code improvements (compiler)", but that patch is much larger and would need more intense review. Here, I'd like to just fix this one problem that breaks the build with gcc 10.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8324530](https://bugs.openjdk.org/browse/JDK-8324530) needs maintainer approval

### Issue
 * [JDK-8324530](https://bugs.openjdk.org/browse/JDK-8324530): Build error with gcc 10 (**Bug** - P4 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/424/head:pull/424` \
`$ git checkout pull/424`

Update a local copy of the PR: \
`$ git checkout pull/424` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/424/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 424`

View PR using the GUI difftool: \
`$ git pr show -t 424`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/424.diff">https://git.openjdk.org/jdk8u-dev/pull/424.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/424#issuecomment-1906270665)