### PR TITLE
8324587: @headful key is contained in ExceptionFromPrintableIsIgnoredTest.java

### DIFF
--- a/jdk/test/java/awt/print/PrinterJob/ExceptionFromPrintableIsIgnoredTest.java
+++ b/jdk/test/java/awt/print/PrinterJob/ExceptionFromPrintableIsIgnoredTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,6 @@
 
 /* @test
    @bug 8262731
-   @key headful printer
    @summary Verify that "PrinterJob.print" throws the expected exception,
             if "Printable.print" throws an exception.
    @run main ExceptionFromPrintableIsIgnoredTest MAIN PE


### PR DESCRIPTION
This fix removes the "@key headful printer" tag that was granted to ExceptionFromPrintableIsIgnoredTest.java in JDK-8273687. The test passed after this fix.
Would you review this fix, please?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8324587](https://bugs.openjdk.org/browse/JDK-8324587) needs maintainer approval

### Issue
 * [JDK-8324587](https://bugs.openjdk.org/browse/JDK-8324587): @<!---->headful key is contained in ExceptionFromPrintableIsIgnoredTest.java (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/425/head:pull/425` \
`$ git checkout pull/425`

Update a local copy of the PR: \
`$ git checkout pull/425` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/425/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 425`

View PR using the GUI difftool: \
`$ git pr show -t 425`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/425.diff">https://git.openjdk.org/jdk8u-dev/pull/425.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/425#issuecomment-1907491890)