### PR TITLE
8323640: [TESTBUG]testMemoryFailCount in jdk/internal/platform/docker/TestDockerMemoryMetrics.java always fail because OOM killed

### DIFF
--- a/jdk/test/jdk/internal/platform/docker/MetricsMemoryTester.java
+++ b/jdk/test/jdk/internal/platform/docker/MetricsMemoryTester.java
@@ -75,12 +75,12 @@ public class MetricsMemoryTester {
         } else {
             long count = Metrics.systemMetrics().getMemoryFailCount();
 
-            // Allocate 512M of data
-            byte[][] bytes = new byte[64][];
+            // Allocate 512M of data in 1M chunks per iteration
+            byte[][] bytes = new byte[64 * 8][];
             boolean atLeastOneAllocationWorked = false;
-            for (int i = 0; i < 64; i++) {
+            for (int i = 0; i < 64 * 8; i++) {
                 try {
-                    bytes[i] = new byte[8 * 1024 * 1024];
+                    bytes[i] = new byte[1024 * 1024];
                     atLeastOneAllocationWorked = true;
                     // Break out as soon as we see an increase in failcount
                     // to avoid getting killed by the OOM killer.


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8323640](https://bugs.openjdk.org/browse/JDK-8323640) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323640](https://bugs.openjdk.org/browse/JDK-8323640): [TESTBUG]testMemoryFailCount in jdk/internal/platform/docker/TestDockerMemoryMetrics.java always fail because OOM killed (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/426/head:pull/426` \
`$ git checkout pull/426`

Update a local copy of the PR: \
`$ git checkout pull/426` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/426/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 426`

View PR using the GUI difftool: \
`$ git pr show -t 426`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/426.diff">https://git.openjdk.org/jdk8u-dev/pull/426.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/426#issuecomment-1908261234)