### PR TITLE
8324184: Windows VS2010 build failed with "error C2275: 'int64_t'"

### DIFF
--- a/jdk/src/share/native/common/check_code.c
+++ b/jdk/src/share/native/common/check_code.c
@@ -1683,12 +1683,13 @@ static int instruction_length(unsigned char *iptr, unsigned char *end)
     switch (instruction) {
         case JVM_OPC_tableswitch: {
             int *lpc = (int *)UCALIGN(iptr + 1);
+            int64_t low, high, index;
             if (lpc + 2 >= (int *)end) {
                 return -1; /* do not read pass the end */
             }
-            int64_t low  = _ck_ntohl(lpc[1]);
-            int64_t high = _ck_ntohl(lpc[2]);
-            int64_t index = high - low;
+            low  = _ck_ntohl(lpc[1]);
+            high = _ck_ntohl(lpc[2]);
+            index = high - low;
             // The value of low must be less than or equal to high - i.e. index >= 0
             if ((index < 0) || (index > 65535)) {
                 return -1;      /* illegal */


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [4d078930](https://github.com/openjdk/jdk21u/commit/4d078930eecfacb28a7c8324f233080eaf649334) from the [openjdk/jdk21u](https://git.openjdk.org/jdk21u) repository & the clean backport commit [4f80edf](https://github.com/openjdk/jdk17u-dev/commit/4f80edfae10e83f2709f297a553d2128712e4b51) from 17u, also now in 11u. A new bug ID, JDK-8324184, had to be created as JDK-8317331, the original bug, is private.

The commit being backported was authored by Coleen Phillimore on 2 Oct 2023 and had no reviewers.

The backport fixes the VS2010 build which is broken by the placing of the declarations of `low`, `high` and `index` in JDK-8314295 after statements; see https://github.com/gnu-andrew/jdk8u-dev/actions/runs/7549766959/job/20554342418. This positioning is disallowed by C90. 

Adding `-Werror=declaration-after-statement` to the build flags replicated the failure on GCC 8. I will look at adding this to the build in a follow-up fix. It also needs a number of other changes to fix Linux-specific code which has never been built to this standard.

Backport was clean and built fine on GNU/Linux with GCC 8.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8324184](https://bugs.openjdk.org/browse/JDK-8324184) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324184](https://bugs.openjdk.org/browse/JDK-8324184): Windows VS2010 build failed with "error C2275: 'int64_t'" (**Bug** - P4 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/435/head:pull/435` \
`$ git checkout pull/435`

Update a local copy of the PR: \
`$ git checkout pull/435` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/435/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 435`

View PR using the GUI difftool: \
`$ git pr show -t 435`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/435.diff">https://git.openjdk.org/jdk8u-dev/pull/435.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/435#issuecomment-1918322521)