### PR TITLE
8325927: [8u] Backport of JDK-8170552 missed part of the test

### DIFF
--- a/jdk/test/java/awt/font/TextLayout/DiacriticsDrawingTest.java
+++ b/jdk/test/java/awt/font/TextLayout/DiacriticsDrawingTest.java
@@ -24,6 +24,7 @@
 /* @test
  * @bug 8170552
  * @summary verify enabling text layout for complex text on macOS
+ * @requires os.family == "mac"
  */
 
 import java.awt.Color;


### PR DESCRIPTION
The next line is missed in the test in the jdk8u repo:
* @requires os.family == "mac"

compare commits:
jdk: https://github.com/openjdk/jdk/commit/d12dcc701f6e51f8fa65cd36fb16a3faa7d73fe8
jdk8u: https://github.com/openjdk/jdk8u-dev/commit/bb6f0c8f500b4b4777df888bdb8a3fcf3570de5a

The test should be macOS specific since it uses the "Menlo" font.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8325927](https://bugs.openjdk.org/browse/JDK-8325927) needs maintainer approval

### Issue
 * [JDK-8325927](https://bugs.openjdk.org/browse/JDK-8325927): [8u] Backport of JDK-8170552 missed part of the test (**Bug** - P4 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/444/head:pull/444` \
`$ git checkout pull/444`

Update a local copy of the PR: \
`$ git checkout pull/444` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/444/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 444`

View PR using the GUI difftool: \
`$ git pr show -t 444`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/444.diff">https://git.openjdk.org/jdk8u-dev/pull/444.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/444#issuecomment-1948962089)