### PR TITLE
8069389: CompilerOracle prefix wildcarding is broken for long strings

### DIFF
--- a/hotspot/src/share/vm/compiler/compilerOracle.cpp
+++ b/hotspot/src/share/vm/compiler/compilerOracle.cpp
@@ -493,7 +493,8 @@ static MethodMatcher::Mode check_mode(char name[], const char*& error_msg) {
   int match = MethodMatcher::Exact;
   while (name[0] == '*') {
     match |= MethodMatcher::Suffix;
-    strcpy(name, name + 1);
+    // Copy remaining string plus NUL to the beginning
+    memmove(name, name + 1, strlen(name + 1) + 1);
   }
 
   if (strcmp(name, "*") == 0) return MethodMatcher::Any;

--- a/hotspot/test/compiler/oracle/TestCompileCommand.java
+++ b/hotspot/test/compiler/oracle/TestCompileCommand.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.PrintWriter;
+import java.io.File;
+
+import com.oracle.java.testlibrary.*;
+
+/*
+ * @test TestCompileCommand
+ * @bug 8069389
+ * @summary "Regression tests of -XX:CompileCommand"
+ * @library /testlibrary
+ * @run main TestCompileCommand
+ */
+
+public class TestCompileCommand {
+
+    private static final String[][] ARGUMENTS = {
+        {
+            "-XX:CompileCommand=print,*01234567890123456789012345678901234567890123456789,*0123456789012345678901234567890123456789",
+            "-version"
+        }
+    };
+
+    private static final String[][] OUTPUTS = {
+        {
+            "print *01234567890123456789012345678901234567890123456789.*0123456789012345678901234567890123456789"
+        }
+    };
+
+    private static void verifyValidOption(String[] arguments, String[] expected_outputs) throws Exception {
+        ProcessBuilder pb;
+        OutputAnalyzer out;
+
+        pb = ProcessTools.createJavaProcessBuilder(arguments);
+        out = new OutputAnalyzer(pb.start());
+
+        for (String expected_output : expected_outputs) {
+            out.shouldContain(expected_output);
+        }
+
+        out.shouldNotContain("CompileCommand: An error occured during parsing");
+        out.shouldHaveExitValue(0);
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        if (ARGUMENTS.length != OUTPUTS.length) {
+            throw new RuntimeException("Test is set up incorrectly: length of arguments and expected outputs for type (1) options does not match.");
+        }
+
+        // Check if type (1) options are parsed correctly
+        for (int i = 0; i < ARGUMENTS.length; i++) {
+            verifyValidOption(ARGUMENTS[i], OUTPUTS[i]);
+        }
+    }
+}


### PR DESCRIPTION
Clean backport.

I've just found that the issue occurs even with short strings like "\*123\*", see my screenshot attached to JDK-8069389. This can be reproduced currently with "slowdebug" build on my Ubuntu 22.04 + gcc-9.5.0, however I believe we cannot rely on it isn't reproduced with "release" now.

Anyway, it wasn't good to use "strcpy" with overlapped buffers, because strcpy's docs says "The behavior is undefined if the strings overlap." So, I believe it should be fixed in jdk8 as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8069389](https://bugs.openjdk.org/browse/JDK-8069389) needs maintainer approval

### Issue
 * [JDK-8069389](https://bugs.openjdk.org/browse/JDK-8069389): CompilerOracle prefix wildcarding is broken for long strings (**Bug** - P4 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/446/head:pull/446` \
`$ git checkout pull/446`

Update a local copy of the PR: \
`$ git checkout pull/446` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/446/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 446`

View PR using the GUI difftool: \
`$ git pr show -t 446`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/446.diff">https://git.openjdk.org/jdk8u-dev/pull/446.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/446#issuecomment-1949088818)