### PR TITLE
8079441: Intermittent failures on Windows with "Unexpected exit from test [exit code: 1080890248]" (0x406d1388)

### DIFF
--- a/hotspot/src/os/windows/vm/os_windows.cpp
+++ b/hotspot/src/os/windows/vm/os_windows.cpp
@@ -751,6 +751,11 @@ void os::set_native_thread_name(const char *name) {
   // is already attached to a debugger; debugger must observe
   // the exception below to show the correct name.
 
+  // If there is no debugger attached skip raising the exception
+  if (!IsDebuggerPresent()) {
+    return;
+  }
+
   const DWORD MS_VC_EXCEPTION = 0x406D1388;
   struct {
     DWORD dwType;     // must be 0x1000


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [b1c82624](https://github.com/openjdk/jdk11u-dev/commit/b1c82624b9a700c74339139dee096b07c46db854) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Robbin Ehn on Jan 11, 2017 and was reviewed by Ioi Lam and Thomas Stuefe.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8079441](https://bugs.openjdk.org/browse/JDK-8079441) needs maintainer approval

### Issue
 * [JDK-8079441](https://bugs.openjdk.org/browse/JDK-8079441): Intermittent failures on Windows with "Unexpected exit from test [exit code: 1080890248]" (0x406d1388) (**Bug** - P3 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/448/head:pull/448` \
`$ git checkout pull/448`

Update a local copy of the PR: \
`$ git checkout pull/448` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/448/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 448`

View PR using the GUI difftool: \
`$ git pr show -t 448`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/448.diff">https://git.openjdk.org/jdk8u-dev/pull/448.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/448#issuecomment-1952913531)