### PR TITLE
Backport 704c02a180cafab1da03d5e5cfd09d92bc4cda8c

### DIFF
--- a/hotspot/src/cpu/x86/vm/vm_version_x86.cpp
+++ b/hotspot/src/cpu/x86/vm/vm_version_x86.cpp
@@ -390,15 +390,6 @@ class VM_Version_StubGenerator: public StubCodeGenerator {
   };
 };
 
-
-void VM_Version::get_cpu_info_wrapper() {
-  get_cpu_info_stub(&_cpuid_info);
-}
-
-#ifndef CALL_TEST_FUNC_WITH_WRAPPER_IF_NEEDED
-  #define CALL_TEST_FUNC_WITH_WRAPPER_IF_NEEDED(f) f()
-#endif
-
 void VM_Version::get_processor_features() {
 
   _cpu = 4; // 486 by default
@@ -412,9 +403,7 @@ void VM_Version::get_processor_features() {
   if (!Use486InstrsOnly) {
     // Get raw processor info
 
-    // Some platforms (like Win*) need a wrapper around here
-    // in order to properly handle SEGV for YMM registers test.
-    CALL_TEST_FUNC_WITH_WRAPPER_IF_NEEDED(get_cpu_info_wrapper);
+    get_cpu_info_stub(&_cpuid_info);
 
     assert_is_initialized();
     _cpu = extended_cpu_family();

--- a/hotspot/src/os/windows/vm/os_windows.cpp
+++ b/hotspot/src/os/windows/vm/os_windows.cpp
@@ -2870,17 +2870,6 @@ address os::win32::fast_jni_accessor_wrapper(BasicType type) {
 }
 #endif
 
-void os::win32::call_test_func_with_wrapper(void (*funcPtr)(void)) {
-  // Install a win32 structured exception handler around the test
-  // function call so the VM can generate an error dump if needed.
-  __try {
-    (*funcPtr)();
-  } __except(topLevelExceptionFilter(
-             (_EXCEPTION_POINTERS*)_exception_info())) {
-    // Nothing to do.
-  }
-}
-
 // Virtual Memory
 
 int os::vm_page_size() { return os::win32::vm_page_size(); }

--- a/hotspot/src/os/windows/vm/os_windows.hpp
+++ b/hotspot/src/os/windows/vm/os_windows.hpp
@@ -97,8 +97,6 @@ class win32 {
   static address fast_jni_accessor_wrapper(BasicType);
 #endif
 
-  static void call_test_func_with_wrapper(void (*funcPtr)(void));
-
   // filter function to ignore faults on serializations page
   static LONG WINAPI serialize_fault_filter(struct _EXCEPTION_POINTERS* e);
 };

--- a/hotspot/src/os/windows/vm/os_windows.inline.hpp
+++ b/hotspot/src/os/windows/vm/os_windows.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -95,8 +95,5 @@ inline size_t os::write(int fd, const void *buf, unsigned int nBytes) {
 inline int os::close(int fd) {
   return ::close(fd);
 }
-
-#define CALL_TEST_FUNC_WITH_WRAPPER_IF_NEEDED(f) \
-        os::win32::call_test_func_with_wrapper(f)
 
 #endif // OS_WINDOWS_VM_OS_WINDOWS_INLINE_HPP

--- a/hotspot/src/share/vm/prims/jni.cpp
+++ b/hotspot/src/share/vm/prims/jni.cpp
@@ -97,6 +97,9 @@
 
 static jint CurrentVersion = JNI_VERSION_1_8;
 
+#ifdef _WIN32
+extern LONG WINAPI topLevelExceptionFilter(_EXCEPTION_POINTERS* );
+#endif
 
 // The DT_RETURN_MARK macros create a scoped object to fire the dtrace
 // '-return' probe regardless of the return path is taken out of the function.
@@ -5186,12 +5189,11 @@ DT_RETURN_MARK_DECL(CreateJavaVM, jint
                     , HOTSPOT_JNI_CREATEJAVAVM_RETURN(_ret_ref));
 #endif /* USDT2 */
 
-_JNI_IMPORT_OR_EXPORT_ jint JNICALL JNI_CreateJavaVM(JavaVM **vm, void **penv, void *args) {
+static jint JNI_CreateJavaVM_inner(JavaVM **vm, void **penv, void *args) {
 #ifndef USDT2
   HS_DTRACE_PROBE3(hotspot_jni, CreateJavaVM__entry, vm, penv, args);
 #else /* USDT2 */
-  HOTSPOT_JNI_CREATEJAVAVM_ENTRY(
-                                 (void **) vm, penv, args);
+  HOTSPOT_JNI_CREATEJAVAVM_ENTRY((void **) vm, penv, args);
 #endif /* USDT2 */
 
   jint result = JNI_ERR;
@@ -5263,18 +5265,14 @@ _JNI_IMPORT_OR_EXPORT_ jint JNICALL JNI_CreateJavaVM(JavaVM **vm, void **penv, v
     post_thread_start_event(thread);
 
 #ifndef PRODUCT
-  #ifndef CALL_TEST_FUNC_WITH_WRAPPER_IF_NEEDED
-    #define CALL_TEST_FUNC_WITH_WRAPPER_IF_NEEDED(f) f()
-  #endif
-
     // Check if we should compile all classes on bootclasspath
     if (CompileTheWorld) ClassLoader::compile_the_world();
     if (ReplayCompiles) ciReplay::replay(thread);
 
     // Some platforms (like Win*) need a wrapper around these test
     // functions in order to properly handle error conditions.
-    CALL_TEST_FUNC_WITH_WRAPPER_IF_NEEDED(test_error_handler);
-    CALL_TEST_FUNC_WITH_WRAPPER_IF_NEEDED(execute_internal_vm_tests);
+    test_error_handler();
+    execute_internal_vm_tests();
 #endif
 
     // Since this is not a JVM_ENTRY we have to set the thread state manually before leaving.
@@ -5293,6 +5291,22 @@ _JNI_IMPORT_OR_EXPORT_ jint JNICALL JNI_CreateJavaVM(JavaVM **vm, void **penv, v
     OrderAccess::release_store(&vm_created, 0);
   }
 
+  return result;
+
+}
+
+_JNI_IMPORT_OR_EXPORT_ jint JNICALL JNI_CreateJavaVM(JavaVM **vm, void **penv, void *args) {
+  jint result = 0;
+  // On Windows, let CreateJavaVM run with SEH protection
+#ifdef _WIN32
+  __try {
+#endif
+    result = JNI_CreateJavaVM_inner(vm, penv, args);
+#ifdef _WIN32
+  } __except(topLevelExceptionFilter((_EXCEPTION_POINTERS*)_exception_info())) {
+    // Nothing to do.
+  }
+#endif
   return result;
 }
 


### PR DESCRIPTION
Hi,

This is a backport of [JDK-8082592](https://bugs.openjdk.org/browse/JDK-8082592) which adds Structured Exception Handling (SEH) to guard 'JNI_CreateJavaVM' on Windows.

The motivation for this backport is to help reduce the number of occurences where a VM might crash will terminate VM immediately without writing an error log Windows, making root cause analysis very difficult in such cases.

In addition, I plan to also backport [JDK-8186199](https://bugs.openjdk.org/browse/JDK-8186199) as a follow-up, which does something similar to guard 'JNI_DestroyJavaVM'.

Thanks!