### PR TITLE
8186464: ZipFile cannot read some InfoZip ZIP64 zip files

### DIFF
--- a/jdk/src/share/demo/nio/zipfs/src/com/sun/nio/zipfs/ZipFileSystem.java
+++ b/jdk/src/share/demo/nio/zipfs/src/com/sun/nio/zipfs/ZipFileSystem.java
@@ -92,6 +92,7 @@ public class ZipFileSystem extends FileSystem {
     private final boolean createNew;     // create a new zip if not exists
     private static final boolean isWindows =
         System.getProperty("os.name").startsWith("Windows");
+    private final boolean forceEnd64;
 
     // a threshold, in bytes, to decide whether to create a temp file
     // for outputstream of a zip entry
@@ -112,12 +113,13 @@ public class ZipFileSystem extends FileSystem {
         if (this.defaultDir.charAt(0) != '/')
             throw new IllegalArgumentException("default dir should be absolute");
 
+        this.forceEnd64 = "true".equals(env.get("forceZIP64End"));
         this.provider = provider;
         this.zfpath = zfpath;
         if (Files.notExists(zfpath)) {
             if (createNew) {
                 try (OutputStream os = Files.newOutputStream(zfpath, CREATE_NEW, WRITE)) {
-                    new END().write(os, 0);
+                    new END().write(os, 0, forceEnd64);
                 }
             } else {
                 throw new FileSystemNotFoundException(zfpath.toString());
@@ -1014,28 +1016,36 @@ public class ZipFileSystem extends FileSystem {
                     end.cenoff = ENDOFF(buf);
                     end.comlen = ENDCOM(buf);
                     end.endpos = pos + i;
-                    if (end.cenlen == ZIP64_MINVAL ||
-                        end.cenoff == ZIP64_MINVAL ||
-                        end.centot == ZIP64_MINVAL32)
-                    {
-                        // need to find the zip64 end;
-                        byte[] loc64 = new byte[ZIP64_LOCHDR];
-                        if (readFullyAt(loc64, 0, loc64.length, end.endpos - ZIP64_LOCHDR)
-                            != loc64.length) {
-                            return end;
-                        }
-                        long end64pos = ZIP64_LOCOFF(loc64);
-                        byte[] end64buf = new byte[ZIP64_ENDHDR];
-                        if (readFullyAt(end64buf, 0, end64buf.length, end64pos)
-                            != end64buf.length) {
-                            return end;
-                        }
-                        // end64 found, re-calcualte everything.
-                        end.cenlen = ZIP64_ENDSIZ(end64buf);
-                        end.cenoff = ZIP64_ENDOFF(end64buf);
-                        end.centot = (int)ZIP64_ENDTOT(end64buf); // assume total < 2g
-                        end.endpos = end64pos;
+                    // try if there is zip64 end;
+                    byte[] loc64 = new byte[ZIP64_LOCHDR];
+                    if (end.endpos < ZIP64_LOCHDR ||
+                        readFullyAt(loc64, 0, loc64.length, end.endpos - ZIP64_LOCHDR)
+                        != loc64.length ||
+                        !locator64SigAt(loc64, 0)) {
+                        return end;
                     }
+                    long end64pos = ZIP64_LOCOFF(loc64);
+                    byte[] end64buf = new byte[ZIP64_ENDHDR];
+                    if (readFullyAt(end64buf, 0, end64buf.length, end64pos)
+                        != end64buf.length ||
+                        !end64SigAt(end64buf, 0)) {
+                        return end;
+                    }
+                    // end64 found,
+                    long cenlen64 = ZIP64_ENDSIZ(end64buf);
+                    long cenoff64 = ZIP64_ENDOFF(end64buf);
+                    long centot64 = ZIP64_ENDTOT(end64buf);
+                    // double-check
+                    if (cenlen64 != end.cenlen && end.cenlen != ZIP64_MINVAL ||
+                        cenoff64 != end.cenoff && end.cenoff != ZIP64_MINVAL ||
+                        centot64 != end.centot && end.centot != ZIP64_MINVAL32) {
+                        return end;
+                    }
+                    // to use the end64 values
+                    end.cenlen = cenlen64;
+                    end.cenoff = cenoff64;
+                    end.centot = (int)centot64; // assume total < 2g
+                    end.endpos = end64pos;
                     return end;
                 }
             }
@@ -1201,7 +1211,7 @@ public class ZipFileSystem extends FileSystem {
 
     // sync the zip file system, if there is any udpate
     private void sync() throws IOException {
-        //System.out.printf("->sync(%s) starting....!%n", toString());
+        // System.out.printf("->sync(%s) starting....!%n", toString());
         // check ex-closer
         if (!exChClosers.isEmpty()) {
             for (ExChannelCloser ecc : exChClosers) {
@@ -1292,7 +1302,7 @@ public class ZipFileSystem extends FileSystem {
             }
             end.centot = elist.size();
             end.cenlen = written - end.cenoff;
-            end.write(os, written);
+            end.write(os, written, forceEnd64);
         }
         if (!streams.isEmpty()) {
             //
@@ -1849,8 +1859,8 @@ public class ZipFileSystem extends FileSystem {
         long endpos;
         int disktot;
 
-        void write(OutputStream os, long offset) throws IOException {
-            boolean hasZip64 = false;
+        void write(OutputStream os, long offset, boolean forceEnd64) throws IOException {
+            boolean hasZip64 = forceEnd64; // false;
             long xlen = cenlen;
             long xoff = cenoff;
             if (xlen >= ZIP64_MINVAL) {
@@ -1875,8 +1885,8 @@ public class ZipFileSystem extends FileSystem {
                 writeShort(os, 45);               // version needed to extract
                 writeInt(os, 0);                  // number of this disk
                 writeInt(os, 0);                  // central directory start disk
-                writeLong(os, centot);            // number of directory entires on disk
-                writeLong(os, centot);            // number of directory entires
+                writeLong(os, centot);            // number of directory entries on disk
+                writeLong(os, centot);            // number of directory entries
                 writeLong(os, cenlen);            // length of central directory
                 writeLong(os, cenoff);            // offset of central directory
 

--- a/jdk/src/share/native/java/util/zip/zip_util.c
+++ b/jdk/src/share/native/java/util/zip/zip_util.c
@@ -385,6 +385,9 @@ findEND64(jzfile *zip, void *end64buf, jlong endpos)
 {
     char loc64[ZIP64_LOCHDR];
     jlong end64pos;
+    if (endpos < ZIP64_LOCHDR) {
+	return -1;
+    }
     if (readFullyAt(zip->zfd, loc64, ZIP64_LOCHDR, endpos - ZIP64_LOCHDR) == -1) {
         return -1;    // end64 locator not found
     }
@@ -567,6 +570,7 @@ readCEN(jzfile *zip, jint knownTotal)
 {
     /* Following are unsigned 32-bit */
     jlong endpos, end64pos, cenpos, cenlen, cenoff;
+    jlong cenlen64, cenoff64, centot64;
     /* Following are unsigned 16-bit */
     jint total, tablelen, i, j;
     unsigned char *cenbuf = NULL;
@@ -594,13 +598,20 @@ readCEN(jzfile *zip, jint knownTotal)
     cenlen = ENDSIZ(endbuf);
     cenoff = ENDOFF(endbuf);
     total  = ENDTOT(endbuf);
-    if (cenlen == ZIP64_MAGICVAL || cenoff == ZIP64_MAGICVAL ||
-        total == ZIP64_MAGICCOUNT) {
-        unsigned char end64buf[ZIP64_ENDHDR];
-        if ((end64pos = findEND64(zip, end64buf, endpos)) != -1) {
-            cenlen = ZIP64_ENDSIZ(end64buf);
-            cenoff = ZIP64_ENDOFF(end64buf);
-            total = (jint)ZIP64_ENDTOT(end64buf);
+    unsigned char end64buf[ZIP64_ENDHDR];
+    if ((end64pos = findEND64(zip, end64buf, endpos)) != -1) {
+	// end64 candidate found,
+	cenlen64 = ZIP64_ENDSIZ(end64buf);
+	cenoff64 = ZIP64_ENDOFF(end64buf);
+	centot64 = ZIP64_ENDTOT(end64buf);
+	// double-check
+	if ((cenlen64 == cenlen || cenlen == ZIP64_MAGICVAL) &&
+	    (cenoff64 == cenoff || cenoff == ZIP64_MAGICVAL) &&
+	    (centot64 == total || total == ZIP64_MAGICCOUNT)) {
+	    // to use the end64 values
+            cenlen = cenlen64;
+            cenoff = cenoff64;
+            total = (jint)centot64;
             endpos = end64pos;
             endhdrlen = ZIP64_ENDHDR;
         }

--- a/jdk/src/share/native/java/util/zip/zip_util.c
+++ b/jdk/src/share/native/java/util/zip/zip_util.c
@@ -386,7 +386,7 @@ findEND64(jzfile *zip, void *end64buf, jlong endpos)
     char loc64[ZIP64_LOCHDR];
     jlong end64pos;
     if (endpos < ZIP64_LOCHDR) {
-	return -1;
+        return -1;
     }
     if (readFullyAt(zip->zfd, loc64, ZIP64_LOCHDR, endpos - ZIP64_LOCHDR) == -1) {
         return -1;    // end64 locator not found
@@ -600,15 +600,15 @@ readCEN(jzfile *zip, jint knownTotal)
     total  = ENDTOT(endbuf);
     unsigned char end64buf[ZIP64_ENDHDR];
     if ((end64pos = findEND64(zip, end64buf, endpos)) != -1) {
-	// end64 candidate found,
-	cenlen64 = ZIP64_ENDSIZ(end64buf);
-	cenoff64 = ZIP64_ENDOFF(end64buf);
-	centot64 = ZIP64_ENDTOT(end64buf);
-	// double-check
-	if ((cenlen64 == cenlen || cenlen == ZIP64_MAGICVAL) &&
-	    (cenoff64 == cenoff || cenoff == ZIP64_MAGICVAL) &&
-	    (centot64 == total || total == ZIP64_MAGICCOUNT)) {
-	    // to use the end64 values
+        // end64 candidate found,
+        cenlen64 = ZIP64_ENDSIZ(end64buf);
+        cenoff64 = ZIP64_ENDOFF(end64buf);
+        centot64 = ZIP64_ENDTOT(end64buf);
+        // double-check
+        if ((cenlen64 == cenlen || cenlen == ZIP64_MAGICVAL) &&
+            (cenoff64 == cenoff || cenoff == ZIP64_MAGICVAL) &&
+            (centot64 == total || total == ZIP64_MAGICCOUNT)) {
+            // to use the end64 values
             cenlen = cenlen64;
             cenoff = cenoff64;
             total = (jint)centot64;

--- a/jdk/src/share/native/java/util/zip/zip_util.c
+++ b/jdk/src/share/native/java/util/zip/zip_util.c
@@ -571,6 +571,7 @@ readCEN(jzfile *zip, jint knownTotal)
     /* Following are unsigned 32-bit */
     jlong endpos, end64pos, cenpos, cenlen, cenoff;
     jlong cenlen64, cenoff64, centot64;
+    unsigned char end64buf[ZIP64_ENDHDR];
     /* Following are unsigned 16-bit */
     jint total, tablelen, i, j;
     unsigned char *cenbuf = NULL;
@@ -598,7 +599,6 @@ readCEN(jzfile *zip, jint knownTotal)
     cenlen = ENDSIZ(endbuf);
     cenoff = ENDOFF(endbuf);
     total  = ENDTOT(endbuf);
-    unsigned char end64buf[ZIP64_ENDHDR];
     if ((end64pos = findEND64(zip, end64buf, endpos)) != -1) {
         // end64 candidate found,
         cenlen64 = ZIP64_ENDSIZ(end64buf);

--- a/jdk/test/java/util/zip/ZipFile/ReadZip.java
+++ b/jdk/test/java/util/zip/ZipFile/ReadZip.java
@@ -169,8 +169,8 @@ public class ReadZip {
         try {
             URI uri = URI.create("jar:" + path.toUri());
             Map<String, Object> env = new HashMap<>();
-	    env.put("create", "true");
-	    env.put("forceZIP64End", "true");
+            env.put("create", "true");
+            env.put("forceZIP64End", "true");
             try (FileSystem fs = FileSystems.newFileSystem(uri, env)) {
                 Files.write(fs.getPath("hello"), "hello".getBytes());
             }


### PR DESCRIPTION
This is a re-do of #445 as we reached a deadlock where I could not make myself commit author, as I was not the PR author, and Thomas could not make me the author as he was not a Committer (see [SKARA-2173](https://bugs.openjdk.org/browse/SKARA-2173)). The content remains the same.

What follows is Thomas' introduction from the original PR:

This patch was applied to the Red Hat 1.8.0 RPMs in June 2020, so it has been deployed to Red Hat customers for over three years.

I verified that the patch applies cleanly to jdk8u-dev master. I confirmed that with the fix portion of the patch reverted, the ReadZip.java test portion of the patch produces this exception:

~~~
java.lang.RuntimeException: zipfile: zip64 end failed
	at ReadZip.main(ReadZip.java:209)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.sun.javatest.regtest.agent.MainWrapper$MainThread.run(MainWrapper.java:127)
	at java.lang.Thread.run(Thread.java:750)
~~~

With the fix applied the test passes:

~~~
Passed: java/util/zip/ZipFile/ReadZip.java
~~~

With the patch applied on top of jdk8u-dev master tip, 3dc011b7ff955f6c1334058f300708412b21a3ad, `make test` on Fedora 38 x86-64 passes, with:
~~~
Test results: passed: 3,122
~~~
I also retested the test cases in [JDK-8186464](https://bugs.openjdk.org/browse/JDK-8186464) and confirmed that without this backport, they fail, and with the backport they succeed.

Thank you,
Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8186464](https://bugs.openjdk.org/browse/JDK-8186464) needs maintainer approval

### Issue
 * [JDK-8186464](https://bugs.openjdk.org/browse/JDK-8186464): ZipFile cannot read some InfoZip ZIP64 zip files (**Bug** - P3)


### Contributors
 * Thomas Fitzsimmons `<fitzsim@redhat.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/452/head:pull/452` \
`$ git checkout pull/452`

Update a local copy of the PR: \
`$ git checkout pull/452` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/452/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 452`

View PR using the GUI difftool: \
`$ git pr show -t 452`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/452.diff">https://git.openjdk.org/jdk8u-dev/pull/452.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/452#issuecomment-1955050768)