### PR TITLE
Backport a4fbee71455e8f06be1288a3886b17796ccd1f39

### DIFF
--- a/jdk/make/src/classes/build/tools/generatenimbus/PainterGenerator.java
+++ b/jdk/make/src/classes/build/tools/generatenimbus/PainterGenerator.java
@@ -57,6 +57,9 @@ import java.util.Map;
  * @author  Jasper Potts
  */
 public class PainterGenerator {
+
+    private static final boolean debug = false;
+
     //a handful of counters, incremented whenever the associated object type is encounted.
     //These counters form the basis of the field and method suffixes.
     //These are all 1 based, because I felt like it :-)
@@ -384,16 +387,24 @@ public class PainterGenerator {
         }
 
         if (Float.isNaN(r)) {
-            System.err.println("[Error] Encountered NaN: encode(" + x + ", " + a + ", " + b + ", " + w + ")");
+            if (debug) {
+                System.err.println("[Error] Encountered NaN: encode(" + x + ", " + a + ", " + b + ", " + w + ")");
+            }
             return 0;
         } else if (Float.isInfinite(r)) {
-            System.err.println("[Error] Encountered Infinity: encode(" + x + ", " + a + ", " + b + ", " + w + ")");
+            if (debug) {
+                System.err.println("[Error] Encountered Infinity: encode(" + x + ", " + a + ", " + b + ", " + w + ")");
+            }
             return 0;
         } else if (r < 0) {
-            System.err.println("[Error] encoded value was less than 0: encode(" + x + ", " + a + ", " + b + ", " + w + ")");
+            if (debug) {
+                System.err.println("[Error] encoded value was less than 0: encode(" + x + ", " + a + ", " + b + ", " + w + ")");
+            }
             return 0;
         } else if (r > 3) {
-            System.err.println("[Error] encoded value was greater than 3: encode(" + x + ", " + a + ", " + b + ", " + w + ")");
+            if (debug) {
+                System.err.println("[Error] encoded value was greater than 3: encode(" + x + ", " + a + ", " + b + ", " + w + ")");
+            }
             return 3;
         } else {
             return r;


### PR DESCRIPTION
Hi,

This is a clean backport of [JDK-8016451: Scary messages emitted by build.tools.generatenimbus.PainterGenerator during build](https://bugs.openjdk.org/browse/JDK-8016451).
Backporting this will eliminate some serious-sounding-yet-innocuous messages from the build logs and reduce the overall amount of noise there.
This will bring OpenJDK to parity with Oracle JDK 8 where it was backported to 8u371. 
This risk is low as the patch is trivial.

Thanks
