### PR TITLE
8298887: On the latest macOS+XCode the Robot API may report wrong colors

### DIFF
--- a/jdk/src/macosx/native/sun/awt/CRobot.m
+++ b/jdk/src/macosx/native/sun/awt/CRobot.m
@@ -47,10 +47,6 @@
 
 #define k_JAVA_ROBOT_WHEEL_COUNT 1
 
-#if !defined(kCGBitmapByteOrder32Host)
-#define kCGBitmapByteOrder32Host 0
-#endif
-
 // In OS X, left and right mouse button share the same click count.
 // That is, if one starts clicking the left button rapidly and then
 // switches to the right button, then the click count will continue
@@ -324,7 +320,7 @@ Java_sun_lwawt_macosx_CRobot_nativeGetScreenPixels
                                             8, picWidth * sizeof(jint),
                                             picColorSpace,
                                             kCGBitmapByteOrder32Host |
-                                            kCGImageAlphaPremultipliedFirst);
+                                            kCGImageAlphaNoneSkipFirst);
 
     CGColorSpaceRelease(picColorSpace);
 

--- a/jdk/src/macosx/native/sun/awt/QuartzSurfaceData.h
+++ b/jdk/src/macosx/native/sun/awt/QuartzSurfaceData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,14 +27,6 @@
 #import "BufImgSurfaceData.h"
 #import "AWTFont.h"
 #import <Cocoa/Cocoa.h>
-
-// these flags are not defined on Tiger on PPC, so we need to make them a no-op
-#if !defined(kCGBitmapByteOrder32Host)
-#define kCGBitmapByteOrder32Host 0
-#endif
-#if !defined(kCGBitmapByteOrder16Host)
-#define kCGBitmapByteOrder16Host 0
-#endif
 
 // NOTE : Modify the printSurfaceDataDiagnostics API if you change this enum
 enum SDRenderType

--- a/jdk/test/java/awt/Robot/CheckCommonColors/CheckCommonColors.java
+++ b/jdk/test/java/awt/Robot/CheckCommonColors/CheckCommonColors.java
@@ -38,7 +38,7 @@ import javax.imageio.ImageIO;
 /**
  * @test
  * @key headful
- * @bug 8215105
+ * @bug 8215105 8298887
  * @summary tests that Robot can capture the common colors without artifacts
  */
 public final class CheckCommonColors {

--- a/jdk/test/java/awt/font/GlyphVector/MultiSlotFontTest.java
+++ b/jdk/test/java/awt/font/GlyphVector/MultiSlotFontTest.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8240756
+ * @bug 8240756 8298887
  * @summary Non-English characters are printed with wrong glyphs on MacOS
  * @modules java.desktop/sun.java2d java.desktop/sun.java2d.loops java.desktop/sun.font
  * @requires os.family == "mac"


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [ceb6793b](https://github.com/openjdk/jdk11u-dev/commit/ceb6793bf3b5855c7c521678b5d99d752800b441) from the [openjdk/jdk11u-dev](https://git.openjdk.org/jdk11u-dev) repository.

The commit being backported was authored by Sergey Bylokhov on 5 May 2023 and was reviewed by Paul Hohensee.

This patch is needed to support XCode 14.2+

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8298887](https://bugs.openjdk.org/browse/JDK-8298887) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298887](https://bugs.openjdk.org/browse/JDK-8298887): On the latest macOS+XCode the Robot API may report wrong colors (**Bug** - P3 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/457/head:pull/457` \
`$ git checkout pull/457`

Update a local copy of the PR: \
`$ git checkout pull/457` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/457/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 457`

View PR using the GUI difftool: \
`$ git pr show -t 457`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/457.diff">https://git.openjdk.org/jdk8u-dev/pull/457.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/457#issuecomment-1965316377)