### PR TITLE
8299677: Formatter.format might take a long time to format an integer or floating-point

### DIFF
--- a/jdk/src/share/classes/java/util/Formatter.java
+++ b/jdk/src/share/classes/java/util/Formatter.java
@@ -4381,8 +4381,9 @@ public final class Formatter implements Closeable, Flushable {
             // apply zero padding
             len = sb.length();
             if (width > len && f.contains(Flags.ZERO_PAD)) {
-                String zeros = new String(new char[width - len]).replace("\0", "0");
-                sb.insert(begin, zeros);
+                char[] zeros = new char[width - len];
+                Arrays.fill(zeros, zero);
+                sb.insert(begin, new String(zeros));
             }
 
             return sb;

--- a/jdk/src/share/classes/java/util/Formatter.java
+++ b/jdk/src/share/classes/java/util/Formatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -4380,9 +4380,10 @@ public final class Formatter implements Closeable, Flushable {
 
             // apply zero padding
             len = sb.length();
-            if (width != -1 && f.contains(Flags.ZERO_PAD))
-                for (int k = 0; k < width - len; k++)
-                    sb.insert(begin, zero);
+            if (width > len && f.contains(Flags.ZERO_PAD)) {
+                String zeros = new String(new char[width - len]).replace("\0", "0");
+                sb.insert(begin, zeros);
+            }
 
             return sb;
         }

--- a/jdk/src/share/classes/java/util/Formatter.java
+++ b/jdk/src/share/classes/java/util/Formatter.java
@@ -4383,7 +4383,7 @@ public final class Formatter implements Closeable, Flushable {
             if (width > len && f.contains(Flags.ZERO_PAD)) {
                 char[] zeros = new char[width - len];
                 Arrays.fill(zeros, zero);
-                sb.insert(begin, new String(zeros));
+                sb.insert(begin, zeros);
             }
 
             return sb;

--- a/jdk/src/share/classes/java/util/Formatter.java
+++ b/jdk/src/share/classes/java/util/Formatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/jdk/test/java/util/Formatter/Padding.java
+++ b/jdk/test/java/util/Formatter/Padding.java
@@ -1,0 +1,316 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4906370
+ * @summary Tests to excercise padding on int and double values,
+ *      with various flag combinations.
+ */
+
+public class Padding {
+
+    private static class Argument {
+        String expected;
+        String format;
+        Object value;
+
+        Argument(String expected, String format, Object value) {
+            this.expected = expected;
+            this.format = format;
+            this.value = value;
+        }
+    }
+
+    static Argument[] arguments = {
+        /* blank padding, right adjusted, optional plus sign */
+        new Argument("12", "%1d", 12),
+        new Argument("12", "%2d", 12),
+        new Argument(" 12", "%3d", 12),
+        new Argument("  12", "%4d", 12),
+        new Argument("   12", "%5d", 12),
+        new Argument("        12", "%10d", 12),
+
+        new Argument("-12", "%1d", -12),
+        new Argument("-12", "%2d", -12),
+        new Argument("-12", "%3d", -12),
+        new Argument(" -12", "%4d", -12),
+        new Argument("  -12", "%5d", -12),
+        new Argument("       -12", "%10d", -12),
+
+        new Argument("1.2", "%1.1f", 1.2),
+        new Argument("1.2", "%2.1f", 1.2),
+        new Argument("1.2", "%3.1f", 1.2),
+        new Argument(" 1.2", "%4.1f", 1.2),
+        new Argument("  1.2", "%5.1f", 1.2),
+        new Argument("       1.2", "%10.1f", 1.2),
+
+        new Argument("-1.2", "%1.1f", -1.2),
+        new Argument("-1.2", "%2.1f", -1.2),
+        new Argument("-1.2", "%3.1f", -1.2),
+        new Argument("-1.2", "%4.1f", -1.2),
+        new Argument(" -1.2", "%5.1f", -1.2),
+        new Argument("      -1.2", "%10.1f", -1.2),
+
+        /* blank padding, right adjusted, mandatory plus sign */
+        new Argument("+12", "%+1d", 12),
+        new Argument("+12", "%+2d", 12),
+        new Argument("+12", "%+3d", 12),
+        new Argument(" +12", "%+4d", 12),
+        new Argument("  +12", "%+5d", 12),
+        new Argument("       +12", "%+10d", 12),
+
+        new Argument("-12", "%+1d", -12),
+        new Argument("-12", "%+2d", -12),
+        new Argument("-12", "%+3d", -12),
+        new Argument(" -12", "%+4d", -12),
+        new Argument("  -12", "%+5d", -12),
+        new Argument("       -12", "%+10d", -12),
+
+        new Argument("+1.2", "%+1.1f", 1.2),
+        new Argument("+1.2", "%+2.1f", 1.2),
+        new Argument("+1.2", "%+3.1f", 1.2),
+        new Argument("+1.2", "%+4.1f", 1.2),
+        new Argument(" +1.2", "%+5.1f", 1.2),
+        new Argument("      +1.2", "%+10.1f", 1.2),
+
+        new Argument("-1.2", "%+1.1f", -1.2),
+        new Argument("-1.2", "%+2.1f", -1.2),
+        new Argument("-1.2", "%+3.1f", -1.2),
+        new Argument("-1.2", "%+4.1f", -1.2),
+        new Argument(" -1.2", "%+5.1f", -1.2),
+        new Argument("      -1.2", "%+10.1f", -1.2),
+
+        /* blank padding, right adjusted, mandatory blank sign */
+        new Argument(" 12", "% 1d", 12),
+        new Argument(" 12", "% 2d", 12),
+        new Argument(" 12", "% 3d", 12),
+        new Argument("  12", "% 4d", 12),
+        new Argument("   12", "% 5d", 12),
+        new Argument("        12", "% 10d", 12),
+
+        new Argument("-12", "% 1d", -12),
+        new Argument("-12", "% 2d", -12),
+        new Argument("-12", "% 3d", -12),
+        new Argument(" -12", "% 4d", -12),
+        new Argument("  -12", "% 5d", -12),
+        new Argument("       -12", "% 10d", -12),
+
+        new Argument(" 1.2", "% 1.1f", 1.2),
+        new Argument(" 1.2", "% 2.1f", 1.2),
+        new Argument(" 1.2", "% 3.1f", 1.2),
+        new Argument(" 1.2", "% 4.1f", 1.2),
+        new Argument("  1.2", "% 5.1f", 1.2),
+        new Argument("       1.2", "% 10.1f", 1.2),
+
+        new Argument("-1.2", "% 1.1f", -1.2),
+        new Argument("-1.2", "% 2.1f", -1.2),
+        new Argument("-1.2", "% 3.1f", -1.2),
+        new Argument("-1.2", "% 4.1f", -1.2),
+        new Argument(" -1.2", "% 5.1f", -1.2),
+        new Argument("      -1.2", "% 10.1f", -1.2),
+
+        /* blank padding, left adjusted, optional sign */
+        new Argument("12", "%-1d", 12),
+        new Argument("12", "%-2d", 12),
+        new Argument("12 ", "%-3d", 12),
+        new Argument("12  ", "%-4d", 12),
+        new Argument("12   ", "%-5d", 12),
+        new Argument("12        ", "%-10d", 12),
+
+        new Argument("-12", "%-1d", -12),
+        new Argument("-12", "%-2d", -12),
+        new Argument("-12", "%-3d", -12),
+        new Argument("-12 ", "%-4d", -12),
+        new Argument("-12  ", "%-5d", -12),
+        new Argument("-12       ", "%-10d", -12),
+
+        new Argument("1.2", "%-1.1f", 1.2),
+        new Argument("1.2", "%-2.1f", 1.2),
+        new Argument("1.2", "%-3.1f", 1.2),
+        new Argument("1.2 ", "%-4.1f", 1.2),
+        new Argument("1.2  ", "%-5.1f", 1.2),
+        new Argument("1.2       ", "%-10.1f", 1.2),
+
+        new Argument("-1.2", "%-1.1f", -1.2),
+        new Argument("-1.2", "%-2.1f", -1.2),
+        new Argument("-1.2", "%-3.1f", -1.2),
+        new Argument("-1.2", "%-4.1f", -1.2),
+        new Argument("-1.2 ", "%-5.1f", -1.2),
+        new Argument("-1.2      ", "%-10.1f", -1.2),
+
+        /* blank padding, left adjusted, mandatory plus sign */
+        new Argument("+12", "%-+1d", 12),
+        new Argument("+12", "%-+2d", 12),
+        new Argument("+12", "%-+3d", 12),
+        new Argument("+12 ", "%-+4d", 12),
+        new Argument("+12  ", "%-+5d", 12),
+        new Argument("+12       ", "%-+10d", 12),
+
+        new Argument("-12", "%-+1d", -12),
+        new Argument("-12", "%-+2d", -12),
+        new Argument("-12", "%-+3d", -12),
+        new Argument("-12 ", "%-+4d", -12),
+        new Argument("-12  ", "%-+5d", -12),
+        new Argument("-12       ", "%-+10d", -12),
+
+        new Argument("+1.2", "%-+1.1f", 1.2),
+        new Argument("+1.2", "%-+2.1f", 1.2),
+        new Argument("+1.2", "%-+3.1f", 1.2),
+        new Argument("+1.2", "%-+4.1f", 1.2),
+        new Argument("+1.2 ", "%-+5.1f", 1.2),
+        new Argument("+1.2      ", "%-+10.1f", 1.2),
+
+        new Argument("-1.2", "%-+1.1f", -1.2),
+        new Argument("-1.2", "%-+2.1f", -1.2),
+        new Argument("-1.2", "%-+3.1f", -1.2),
+        new Argument("-1.2", "%-+4.1f", -1.2),
+        new Argument("-1.2 ", "%-+5.1f", -1.2),
+        new Argument("-1.2      ", "%-+10.1f", -1.2),
+
+        /* blank padding, left adjusted, mandatory blank sign */
+        new Argument(" 12", "%- 1d", 12),
+        new Argument(" 12", "%- 2d", 12),
+        new Argument(" 12", "%- 3d", 12),
+        new Argument(" 12 ", "%- 4d", 12),
+        new Argument(" 12  ", "%- 5d", 12),
+        new Argument(" 12       ", "%- 10d", 12),
+
+        new Argument("-12", "%- 1d", -12),
+        new Argument("-12", "%- 2d", -12),
+        new Argument("-12", "%- 3d", -12),
+        new Argument("-12 ", "%- 4d", -12),
+        new Argument("-12  ", "%- 5d", -12),
+        new Argument("-12       ", "%- 10d", -12),
+
+        new Argument(" 1.2", "%- 1.1f", 1.2),
+        new Argument(" 1.2", "%- 2.1f", 1.2),
+        new Argument(" 1.2", "%- 3.1f", 1.2),
+        new Argument(" 1.2", "%- 4.1f", 1.2),
+        new Argument(" 1.2 ", "%- 5.1f", 1.2),
+        new Argument(" 1.2      ", "%- 10.1f", 1.2),
+
+        new Argument("-1.2", "%- 1.1f", -1.2),
+        new Argument("-1.2", "%- 2.1f", -1.2),
+        new Argument("-1.2", "%- 3.1f", -1.2),
+        new Argument("-1.2", "%- 4.1f", -1.2),
+        new Argument("-1.2 ", "%- 5.1f", -1.2),
+        new Argument("-1.2      ", "%- 10.1f", -1.2),
+
+        /* zero padding, right adjusted, optional sign */
+        new Argument("12", "%01d", 12),
+        new Argument("12", "%02d", 12),
+        new Argument("012", "%03d", 12),
+        new Argument("0012", "%04d", 12),
+        new Argument("00012", "%05d", 12),
+        new Argument("0000000012", "%010d", 12),
+
+        new Argument("-12", "%01d", -12),
+        new Argument("-12", "%02d", -12),
+        new Argument("-12", "%03d", -12),
+        new Argument("-012", "%04d", -12),
+        new Argument("-0012", "%05d", -12),
+        new Argument("-000000012", "%010d", -12),
+
+        new Argument("1.2", "%01.1f", 1.2),
+        new Argument("1.2", "%02.1f", 1.2),
+        new Argument("1.2", "%03.1f", 1.2),
+        new Argument("01.2", "%04.1f", 1.2),
+        new Argument("001.2", "%05.1f", 1.2),
+        new Argument("00000001.2", "%010.1f", 1.2),
+
+        new Argument("-1.2", "%01.1f", -1.2),
+        new Argument("-1.2", "%02.1f", -1.2),
+        new Argument("-1.2", "%03.1f", -1.2),
+        new Argument("-1.2", "%04.1f", -1.2),
+        new Argument("-01.2", "%05.1f", -1.2),
+        new Argument("-0000001.2", "%010.1f", -1.2),
+
+        /* zero padding, right adjusted, mandatory plus sign */
+        new Argument("+12", "%+01d", 12),
+        new Argument("+12", "%+02d", 12),
+        new Argument("+12", "%+03d", 12),
+        new Argument("+012", "%+04d", 12),
+        new Argument("+0012", "%+05d", 12),
+        new Argument("+000000012", "%+010d", 12),
+
+        new Argument("-12", "%+01d", -12),
+        new Argument("-12", "%+02d", -12),
+        new Argument("-12", "%+03d", -12),
+        new Argument("-012", "%+04d", -12),
+        new Argument("-0012", "%+05d", -12),
+        new Argument("-000000012", "%+010d", -12),
+
+        new Argument("+1.2", "%+01.1f", 1.2),
+        new Argument("+1.2", "%+02.1f", 1.2),
+        new Argument("+1.2", "%+03.1f", 1.2),
+        new Argument("+1.2", "%+04.1f", 1.2),
+        new Argument("+01.2", "%+05.1f", 1.2),
+        new Argument("+0000001.2", "%+010.1f", 1.2),
+
+        new Argument("-1.2", "%+01.1f", -1.2),
+        new Argument("-1.2", "%+02.1f", -1.2),
+        new Argument("-1.2", "%+03.1f", -1.2),
+        new Argument("-1.2", "%+04.1f", -1.2),
+        new Argument("-01.2", "%+05.1f", -1.2),
+        new Argument("-0000001.2", "%+010.1f", -1.2),
+
+        /* zero padding, right adjusted, mandatory blank sign */
+        new Argument(" 12", "% 01d", 12),
+        new Argument(" 12", "% 02d", 12),
+        new Argument(" 12", "% 03d", 12),
+        new Argument(" 012", "% 04d", 12),
+        new Argument(" 0012", "% 05d", 12),
+        new Argument(" 000000012", "% 010d", 12),
+
+        new Argument("-12", "% 01d", -12),
+        new Argument("-12", "% 02d", -12),
+        new Argument("-12", "% 03d", -12),
+        new Argument("-012", "% 04d", -12),
+        new Argument("-0012", "% 05d", -12),
+        new Argument("-000000012", "% 010d", -12),
+
+        new Argument(" 1.2", "% 01.1f", 1.2),
+        new Argument(" 1.2", "% 02.1f", 1.2),
+        new Argument(" 1.2", "% 03.1f", 1.2),
+        new Argument(" 1.2", "% 04.1f", 1.2),
+        new Argument(" 01.2", "% 05.1f", 1.2),
+        new Argument(" 0000001.2", "% 010.1f", 1.2),
+
+        new Argument("-1.2", "% 01.1f", -1.2),
+        new Argument("-1.2", "% 02.1f", -1.2),
+        new Argument("-1.2", "% 03.1f", -1.2),
+        new Argument("-1.2", "% 04.1f", -1.2),
+        new Argument("-01.2", "% 05.1f", -1.2),
+        new Argument("-0000001.2", "% 010.1f", -1.2),
+    };
+
+    public static void main(String [] args) {
+        for(Argument arg : arguments) {
+            if(!arg.expected.equals(String.format(arg.format, arg.value))) {
+                throw new RuntimeException("Expected value " + arg.expected +
+                " not returned from String.format(" + arg.format + ", " + arg.value + ")");
+            }
+        }
+    }
+}

--- a/jdk/test/java/util/Formatter/Padding.java
+++ b/jdk/test/java/util/Formatter/Padding.java
@@ -31,9 +31,9 @@
 public class Padding {
 
     private static class Argument {
-        String expected;
-        String format;
-        Object value;
+        final String expected;
+        final String format;
+        final Object value;
 
         Argument(String expected, String format, Object value) {
             this.expected = expected;
@@ -306,8 +306,8 @@ public class Padding {
     };
 
     public static void main(String [] args) {
-        for(Argument arg : arguments) {
-            if(!arg.expected.equals(String.format(arg.format, arg.value))) {
+        for (Argument arg : arguments) {
+            if (!arg.expected.equals(String.format(arg.format, arg.value))) {
                 throw new RuntimeException("Expected value " + arg.expected +
                 " not returned from String.format(" + arg.format + ", " + arg.value + ")");
             }

--- a/jdk/test/java/util/Formatter/Padding.java
+++ b/jdk/test/java/util/Formatter/Padding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Backport of [JDK-8299677](https://bugs.openjdk.org/browse/JDK-8299677)

Backport was not clean. Rewrote test to not include junit `ParameterizedTest`. Rewrote fix since `String.repeat` is not in JDK8

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8299677](https://bugs.openjdk.org/browse/JDK-8299677) needs maintainer approval

### Issue
 * [JDK-8299677](https://bugs.openjdk.org/browse/JDK-8299677): Formatter.format might take a long time to format an integer or floating-point (**Bug** - P4 - Approved)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/459/head:pull/459` \
`$ git checkout pull/459`

Update a local copy of the PR: \
`$ git checkout pull/459` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/459/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 459`

View PR using the GUI difftool: \
`$ git pr show -t 459`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/459.diff">https://git.openjdk.org/jdk8u-dev/pull/459.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/459#issuecomment-1965372112)