### PR TITLE
8074092: Newly introduced unnecessary dependencies on internal API in client regtests

### DIFF
--- a/jdk/test/java/awt/Choice/ItemStateChangeTest/ItemStateChangeTest.java
+++ b/jdk/test/java/awt/Choice/ItemStateChangeTest/ItemStateChangeTest.java
@@ -28,15 +28,17 @@
   @summary awt Choice doesn't fire ItemStateChange when selecting item after select() call
   @author Oleg Pekhovskiy: area=awt-choice
   @library ../../regtesthelpers
+  @library ../../../../lib/testlibrary
   @build Util
+  @build jdk.testlibrary.OSInfo
   @run main ItemStateChangeTest
 */
 
 import test.java.awt.regtesthelpers.Util;
+import jdk.testlibrary.OSInfo;
 
 import java.awt.*;
 import java.awt.event.*;
-import sun.awt.OSInfo;
 
 public class ItemStateChangeTest extends Frame {
 

--- a/jdk/test/java/awt/Desktop/8064934/bug8064934.java
+++ b/jdk/test/java/awt/Desktop/8064934/bug8064934.java
@@ -25,10 +25,11 @@
  * @bug 8064934
  * @summary Incorrect Exception message from java.awt.Desktop.open()
  * @author Dmitry Markov
+ * @library ../../../../lib/testlibrary
+ * @build jdk.testlibrary.OSInfo
  * @run main bug8064934
  */
-import sun.awt.OSInfo;
-
+import jdk.testlibrary.OSInfo;
 import java.awt.*;
 import java.io.File;
 import java.io.IOException;

--- a/jdk/test/java/awt/Menu/OpensWithNoGrab/OpensWithNoGrab.java
+++ b/jdk/test/java/awt/Menu/OpensWithNoGrab/OpensWithNoGrab.java
@@ -28,6 +28,8 @@
   @summary REG: Menu does not disappear when clicked, keeping Choice's drop-down open, XToolkit
   @author andrei.dmitriev: area=awt.menu
   @library ../../regtesthelpers
+  @library ../../../../lib/testlibrary
+  @build jdk.testlibrary.OSInfo
   @build Util
   @run main OpensWithNoGrab
 */
@@ -35,7 +37,7 @@
 import java.awt.*;
 import java.awt.event.*;
 
-import sun.awt.OSInfo;
+import jdk.testlibrary.OSInfo;
 import test.java.awt.regtesthelpers.Util;
 
 public class OpensWithNoGrab

--- a/jdk/test/java/awt/SplashScreen/FullscreenAfterSplash/FullScreenAfterSplash.java
+++ b/jdk/test/java/awt/SplashScreen/FullscreenAfterSplash/FullScreenAfterSplash.java
@@ -21,8 +21,7 @@
 * questions.
 */
 
-import sun.awt.OSInfo;
-
+import jdk.testlibrary.OSInfo;
 import java.awt.*;
 import java.awt.Robot;
 import java.awt.event.InputEvent;
@@ -41,6 +40,8 @@ import javax.swing.WindowConstants;
  * @summary Native Mac OS X full screen does not work after showing the splash
  * @requires (os.family == "mac")
  * @library ../
+ * @library ../../../../lib/testlibrary
+ * @build jdk.testlibrary.OSInfo
  * @build GenerateTestImage
  * @run main GenerateTestImage
  * @author Petr Pchelko area=awt.event

--- a/jdk/test/java/awt/event/KeyEvent/SwallowKeyEvents/SwallowKeyEvents.java
+++ b/jdk/test/java/awt/event/KeyEvent/SwallowKeyEvents/SwallowKeyEvents.java
@@ -27,10 +27,13 @@
   @summary   Tests that key events with modifiers are not swallowed.
   @author    anton.tarasov: area=awt.focus
   @library   ../../../regtesthelpers
+  @library ../../../../../lib/testlibrary
+  @build jdk.testlibrary.OSInfo
   @build     Util
   @run       main SwallowKeyEvents
 */
 
+import jdk.testlibrary.OSInfo;
 import java.awt.AWTException;
 import java.awt.Frame;
 import java.awt.Robot;
@@ -49,7 +52,7 @@ public class SwallowKeyEvents {
     static Robot r;
 
     public static void main(String[] args) {
-        if (sun.awt.OSInfo.getOSType() == sun.awt.OSInfo.OSType.WINDOWS) {
+        if (OSInfo.getOSType() == OSInfo.OSType.WINDOWS) {
             System.out.println("Skipped. Test not for MS Windows.");
             return;
         }

--- a/jdk/test/javax/swing/JFileChooser/8062561/bug8062561.java
+++ b/jdk/test/javax/swing/JFileChooser/8062561/bug8062561.java
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import jdk.testlibrary.OSInfo;
 import java.awt.Robot;
 import java.awt.event.KeyEvent;
 import java.io.File;
@@ -31,12 +32,13 @@ import java.util.concurrent.TimeUnit;
 import javax.swing.JFileChooser;
 import javax.swing.SwingUtilities;
 import javax.swing.filechooser.FileSystemView;
-import sun.awt.OSInfo;
 
 /**
  * @test
  * @bug 8062561
  * @summary File system view returns null default directory
+ * @library ../../../../lib/testlibrary
+ * @build jdk.testlibrary.OSInfo
  * @run main/othervm bug8062561 GENERATE_POLICY
  * @run main/othervm/policy=security.policy bug8062561 CHECK_DEFAULT_DIR run
  */
@@ -72,7 +74,7 @@ public class bug8062561 {
         File defaultDirectory = FileSystemView.getFileSystemView().
                 getDefaultDirectory();
         if (defaultDirectory != null) {
-            throw new RuntimeException("File system default directory is null!");
+            throw new RuntimeException("File system default directory must be null! (FilePermission has not been granted in our policy file).");
         }
     }
     private static volatile JFileChooser fileChooser;

--- a/jdk/test/javax/swing/JPopupMenu/6827786/bug6827786.java
+++ b/jdk/test/javax/swing/JPopupMenu/6827786/bug6827786.java
@@ -27,9 +27,12 @@
  * @summary Tests duplicate mnemonics
  * @author Peter Zhelezniakov
  * @library ../../regtesthelpers
+ * @library ../../../../lib/testlibrary
+ * @build jdk.testlibrary.OSInfo
  * @build Util
  * @run main bug6827786
  */
+import jdk.testlibrary.OSInfo;
 import java.awt.*;
 import java.awt.event.KeyEvent;
 import javax.swing.*;
@@ -63,7 +66,7 @@ public class bug6827786 {
         checkfocus();
 
         // select menu
-        if (sun.awt.OSInfo.getOSType() == sun.awt.OSInfo.OSType.MACOSX) {
+        if (OSInfo.getOSType() == OSInfo.OSType.MACOSX) {
             Util.hitKeys(robot, KeyEvent.VK_CONTROL, KeyEvent.VK_ALT, KeyEvent.VK_F);
         } else {
             Util.hitKeys(robot, KeyEvent.VK_ALT, KeyEvent.VK_F);


### PR DESCRIPTION
Apply clean except for jdk/test/javax/swing/JButton/4796987/bug4796987.java, which no longer exists.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8074092](https://bugs.openjdk.org/browse/JDK-8074092) needs maintainer approval

### Issue
 * [JDK-8074092](https://bugs.openjdk.org/browse/JDK-8074092): Newly introduced unnecessary dependencies on internal API in client regtests (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/461/head:pull/461` \
`$ git checkout pull/461`

Update a local copy of the PR: \
`$ git checkout pull/461` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/461/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 461`

View PR using the GUI difftool: \
`$ git pr show -t 461`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/461.diff">https://git.openjdk.org/jdk8u-dev/pull/461.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/461#issuecomment-1968021380)
</details>
