### PR TITLE
8209398: sun/security/pkcs11/KeyStore/SecretKeysBasic.sh failed with "PKCS11Exception: CKR_ATTRIBUTE_SENSITIVE"

### DIFF
--- a/jdk/src/share/classes/sun/security/pkcs11/P11Key.java
+++ b/jdk/src/share/classes/sun/security/pkcs11/P11Key.java
@@ -90,6 +90,9 @@ abstract class P11Key implements Key, Length {
     // flags indicating whether the key is a token object, sensitive, extractable
     final boolean tokenObject, sensitive, extractable;
 
+    // flag indicating whether the current token is NSS
+    final transient boolean isNSS;
+
     private final NativeKeyHolder keyIDHolder;
 
     private static final boolean DISABLE_NATIVE_KEYS_EXTRACTION;
@@ -136,7 +139,7 @@ abstract class P11Key implements Key, Length {
         this.sensitive = sensitive;
         this.extractable = extractable;
         char[] tokenLabel = this.token.tokenInfo.label;
-        boolean isNSS = (tokenLabel[0] == 'N' && tokenLabel[1] == 'S'
+        isNSS = (tokenLabel[0] == 'N' && tokenLabel[1] == 'S'
                 && tokenLabel[2] == 'S');
         boolean extractKeyInfo = (!DISABLE_NATIVE_KEYS_EXTRACTION && isNSS &&
                 extractable && !tokenObject);
@@ -225,7 +228,8 @@ abstract class P11Key implements Key, Length {
         } else {
             // XXX short term serialization for unextractable keys
             throw new NotSerializableException
-                ("Cannot serialize sensitive and unextractable keys");
+                    ("Cannot serialize sensitive, unextractable " + (isNSS ?
+                    ", and NSS token keys" : "keys"));
         }
         return new KeyRep(type, getAlgorithm(), format, getEncoded());
     }
@@ -440,7 +444,7 @@ abstract class P11Key implements Key, Length {
         }
         public String getFormat() {
             token.ensureValid();
-            if (sensitive || (extractable == false)) {
+            if (sensitive || !extractable || (isNSS && tokenObject)) {
                 return null;
             } else {
                 return "RAW";


### PR DESCRIPTION
Backport fixes test failure on some systems (RHEL-8):
`sun/security/pkcs11/KeyStore/SecretKeysBasic.sh`

Changeset to `P11Key.java`, with path adjusted, applied cleanly. No change to `ProblemList.txt`, as test was not problem listed on jdk8u.

**Testing:**
GH tier1: OK (hotspot failure is unrelated)
jdk_security: OK (no regressions to master: [current master](https://github.com/zzambers/jdk-tester/actions/runs/8069404607/job/22044385458), [with backport](https://github.com/zzambers/jdk-tester/actions/runs/8069423815/job/22044444397))
(also manually tested on RHEL-8 - fixed issue)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8209398](https://bugs.openjdk.org/browse/JDK-8209398) needs maintainer approval

### Issue
 * [JDK-8209398](https://bugs.openjdk.org/browse/JDK-8209398): sun/security/pkcs11/KeyStore/SecretKeysBasic.sh failed with "PKCS11Exception: CKR_ATTRIBUTE_SENSITIVE" (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/462/head:pull/462` \
`$ git checkout pull/462`

Update a local copy of the PR: \
`$ git checkout pull/462` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/462/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 462`

View PR using the GUI difftool: \
`$ git pr show -t 462`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/462.diff">https://git.openjdk.org/jdk8u-dev/pull/462.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/462#issuecomment-1968968871)
</details>
