### PR TITLE
8256152: tests fail because of ambiguous method resolution

### DIFF
--- a/jdk/test/java/util/stream/boottest/java/util/stream/DoubleNodeTest.java
+++ b/jdk/test/java/util/stream/boottest/java/util/stream/DoubleNodeTest.java
@@ -65,7 +65,7 @@ public class DoubleNodeTest extends OpTestCase {
     private static void assertEqualsListDoubleArray(List<Double> list, double[] array) {
         assertEquals(list.size(), array.length);
         for (int i = 0; i < array.length; i++)
-            assertEquals(array[i], list.get(i));
+            assertEquals(array[i], (double) list.get(i));
     }
 
     private List<Double> toList(double[] a) {


### PR DESCRIPTION
Backport to fix test build failures.

Actually, it seems, that whether test build failures happen depends on jtreg used, as test class indirectly inherits from `org.testng.Assert`. (probably methods were added there, which introduced ambiguity)

After dealing with different test path on 8,  patch applies cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8256152](https://bugs.openjdk.org/browse/JDK-8256152) needs maintainer approval

### Issue
 * [JDK-8256152](https://bugs.openjdk.org/browse/JDK-8256152): tests fail because of ambiguous method resolution (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/468/head:pull/468` \
`$ git checkout pull/468`

Update a local copy of the PR: \
`$ git checkout pull/468` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/468/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 468`

View PR using the GUI difftool: \
`$ git pr show -t 468`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/468.diff">https://git.openjdk.org/jdk8u-dev/pull/468.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/468#issuecomment-2003872729)