### PR TITLE
8265019: Update tests for additional TestNG test permissions

### DIFF
--- a/jdk/test/java/sql/testng/util/TestPolicy.java
+++ b/jdk/test/java/sql/testng/util/TestPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 package util;
 
 import java.io.FilePermission;
+import java.lang.reflect.ReflectPermission;
 import java.security.AllPermission;
 import java.security.CodeSource;
 import java.security.Permission;
@@ -101,12 +102,17 @@ public class TestPolicy extends Policy {
         permissions.add(new RuntimePermission("getClassLoader"));
         permissions.add(new RuntimePermission("setSecurityManager"));
         permissions.add(new RuntimePermission("createSecurityManager"));
-        permissions.add(new PropertyPermission("testng.show.stack.frames",
-                "read"));
         permissions.add(new PropertyPermission("line.separator", "read"));
         permissions.add(new PropertyPermission("fileStringBuffer", "read"));
         permissions.add(new PropertyPermission("dataproviderthreadcount", "read"));
         permissions.add(new PropertyPermission("java.io.tmpdir", "read"));
+        permissions.add(new PropertyPermission("testng.show.stack.frames",
+                "read"));
+        permissions.add(new PropertyPermission("testng.thread.affinity", "read"));
+        permissions.add(new PropertyPermission("testng.mode.dryrun", "read"));
+        permissions.add(new PropertyPermission("testng.report.xml.name", "read"));
+        permissions.add(new PropertyPermission("testng.timezone", "read"));
+        permissions.add(new ReflectPermission("suppressAccessChecks"));
         permissions.add(new FilePermission("<<ALL FILES>>",
                 "read, write, delete"));
     }


### PR DESCRIPTION
Backport fixes 2 tests failures, when newer jtreg is used (6+1). Affects only test code. It excludes changes to `test/jdk/java/lang/ProcessHandle/PermissionTest.java` as jdk8 does not have this file (ProcessHandle is jdk9+). Otherwise, when dealt with different paths, changeset applied cleanly (except for copyright line, which was  done manually).

**Fixed tests:**
```
javax/sql/testng/test/rowset/spi/SyncFactoryPermissionsTests.java
java/sql/testng/test/sql/DriverManagerPermissionsTests.java
```

**Exception:**
```
java.security.AccessControlException: access denied ("java.util.PropertyPermission" "testng.thread.affinity" "read")
    at java.security.AccessControlContext.checkPermission(AccessControlContext.java:472)
    at java.security.AccessController.checkPermission(AccessController.java:886)
    at java.lang.SecurityManager.checkPermission(SecurityManager.java:549)
    at java.lang.SecurityManager.checkPropertyAccess(SecurityManager.java:1294)
    at java.lang.System.getProperty(System.java:769)
    at org.testng.internal.RuntimeBehavior.enforceThreadAffinity(RuntimeBehavior.java:106)
    at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:111)
    at java.util.ArrayList.forEach(ArrayList.java:1259)
    at org.testng.TestRunner.privateRun(TestRunner.java:764)
    at org.testng.TestRunner.run(TestRunner.java:585)
    at org.testng.SuiteRunner.runTest(SuiteRunner.java:384)
    at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:378)
    at org.testng.SuiteRunner.privateRun(SuiteRunner.java:337)
    at org.testng.SuiteRunner.run(SuiteRunner.java:286)
    at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:53)
    at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:96)
    at org.testng.TestNG.runSuitesSequentially(TestNG.java:1218)
    at org.testng.TestNG.runSuitesLocally(TestNG.java:1140)
    at org.testng.TestNG.runSuites(TestNG.java:1069)
    at org.testng.TestNG.run(TestNG.java:1037)
    at com.sun.javatest.regtest.agent.TestNGRunner.main(TestNGRunner.java:94)
    at com.sun.javatest.regtest.agent.TestNGRunner.main(TestNGRunner.java:54)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at com.sun.javatest.regtest.agent.MainWrapper$MainThread.run(MainWrapper.java:127)
    at java.lang.Thread.run(Thread.java:750) 
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8265019](https://bugs.openjdk.org/browse/JDK-8265019) needs maintainer approval

### Issue
 * [JDK-8265019](https://bugs.openjdk.org/browse/JDK-8265019): Update tests for additional TestNG test permissions (**Bug** - P3 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/469/head:pull/469` \
`$ git checkout pull/469`

Update a local copy of the PR: \
`$ git checkout pull/469` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/469/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 469`

View PR using the GUI difftool: \
`$ git pr show -t 469`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/469.diff">https://git.openjdk.org/jdk8u-dev/pull/469.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/469#issuecomment-2007669692)
</details>
