### PR TITLE
8313081: MonitoringSupport_lock should be unconditionally initialized after 8304074

### DIFF
--- a/hotspot/src/share/vm/runtime/mutexLocker.cpp
+++ b/hotspot/src/share/vm/runtime/mutexLocker.cpp
@@ -209,9 +209,9 @@ void mutex_init() {
 
     def(StringDedupQueue_lock      , Monitor, leaf,        true );
     def(StringDedupTable_lock      , Mutex  , leaf,        true );
-
-    def(MonitoringSupport_lock     , Mutex  , leaf,        true );      // used for serviceability monitoring support
   }
+  def(MonitoringSupport_lock       , Mutex  , leaf,        true );      // used for serviceability monitoring support
+
   def(ParGCRareEvent_lock          , Mutex  , leaf     ,   true );
   def(DerivedPointerTableGC_lock   , Mutex,   leaf,        true );
   def(CodeCache_lock               , Mutex  , special,     true );

--- a/hotspot/src/share/vm/services/management.cpp
+++ b/hotspot/src/share/vm/services/management.cpp
@@ -2248,6 +2248,7 @@ JVM_ENTRY(jlong, jmm_GetTotalThreadAllocatedMemory(JNIEnv *env))
     }
 
     {
+      assert(MonitoringSupport_lock != NULL, "Must be");
       MutexLockerEx ml(MonitoringSupport_lock, Mutex::_no_safepoint_check_flag);
       if (result < high_water_result) {
         // Result wrapped to a negative value, in which case it's

--- a/jdk/test/com/sun/management/ThreadMXBean/ThreadAllocatedMemory.java
+++ b/jdk/test/com/sun/management/ThreadMXBean/ThreadAllocatedMemory.java
@@ -22,10 +22,19 @@
  */
 
 /*
- * @test
- * @bug     6173675 8231209 8304074
+ * @test    id=G1
+ * @bug     6173675 8231209 8304074 8313081
  * @summary Basic test of ThreadMXBean.getThreadAllocatedBytes
- * @author  Paul Hohensee
+ * @requires vm.gc == "G1"
+ * @run main/othervm -XX:+UseG1GC ThreadAllocatedMemory
+ */
+
+/*
+ * @test    id=Serial
+ * @bug     6173675 8231209 8304074 8313081
+ * @summary Basic test of ThreadMXBean.getThreadAllocatedBytes
+ * @requires vm.gc == "Serial"
+ * @run main/othervm -XX:+UseSerialGC ThreadAllocatedMemory
  */
 
 import java.lang.management.*;


### PR DESCRIPTION
This is a replacement for https://github.com/openjdk/jdk8u-dev/pull/393 and is identical to it.

Follow-on bug fix for [JDK-8304074](https://bugs.openjdk.org/browse/JDK-8304074) backport. Unclean backport from 11u, see https://github.com/openjdk/jdk11u-dev/pull/2287. Other than file location and context, the lock definition macro changed between 8 and 11, so the definition of MonitoringSupport_lock is different.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8313081](https://bugs.openjdk.org/browse/JDK-8313081) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313081](https://bugs.openjdk.org/browse/JDK-8313081): MonitoringSupport_lock should be unconditionally initialized after 8304074 (**Bug** - P4 - Approved)


### Reviewers
 * [Volker Simonis](https://openjdk.org/census#simonis) (@simonis - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/475/head:pull/475` \
`$ git checkout pull/475`

Update a local copy of the PR: \
`$ git checkout pull/475` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/475/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 475`

View PR using the GUI difftool: \
`$ git pr show -t 475`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/475.diff">https://git.openjdk.org/jdk8u-dev/pull/475.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/475#issuecomment-2024045770)