### PR TITLE
8203691: [TESTBUG] Test /runtime/containers/cgroup/PlainRead.java fails

### DIFF
--- a/hotspot/test/runtime/containers/cgroup/PlainRead.java
+++ b/hotspot/test/runtime/containers/cgroup/PlainRead.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,9 +73,6 @@ public class PlainRead {
         if (wb.isContainerized()) {
             System.out.println("Inside a cgroup, testing...");
             isContainer(output);
-        } else {
-            System.out.println("Not in a cgroup, testing...");
-            isNotContainer(output);
         }
     }
 }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [2fa6eac4](https://github.com/openjdk/jdk11u-dev/commit/2fa6eac464048176087092c91c8430781ab15301) from the [openjdk/jdk11u-dev](https://git.openjdk.org/jdk11u-dev) repository.

The commit being backported was authored by Bob Vandette on 12 Jun 2018 and was reviewed by David Holmes, Mikhailo Seledtsov and Robbin Ehn.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8203691](https://bugs.openjdk.org/browse/JDK-8203691) needs maintainer approval

### Issue
 * [JDK-8203691](https://bugs.openjdk.org/browse/JDK-8203691): [TESTBUG] Test /runtime/containers/cgroup/PlainRead.java fails (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/477/head:pull/477` \
`$ git checkout pull/477`

Update a local copy of the PR: \
`$ git checkout pull/477` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/477/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 477`

View PR using the GUI difftool: \
`$ git pr show -t 477`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/477.diff">https://git.openjdk.org/jdk8u-dev/pull/477.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/477#issuecomment-2032420134)