### PR TITLE
8329544: [8u] sun/security/krb5/auto/ReplayCacheTestProc.java cannot find the testlibrary

### DIFF
--- a/jdk/test/sun/security/krb5/auto/ReplayCacheTestProc.java
+++ b/jdk/test/sun/security/krb5/auto/ReplayCacheTestProc.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 7152176 8168518
  * @summary More krb5 tests
- * @library ../../../../java/security/testlibrary/
+ * @library ../../../../java/security/testlibrary/ /test/lib
  * @compile -XDignore.symbol.file ReplayCacheTestProc.java
  * @run main/othervm/timeout=300 -Dsun.net.spi.nameservice.provider.1=ns,mock ReplayCacheTestProc
  */


### PR DESCRIPTION
`sun/security/krb5/auto/ReplayCacheTestProc.java` fails on jdk8u-412 due to a compilation error. This is because the classpath is being set incorrectly by the `@library` annotation.

```
TEST: sun/security/krb5/auto/ReplayCacheTestProc.java
TEST JDK: /home/ianrichr/openjdk/jdk8u/build/linux-x86_64-normal-server-release/images/j2sdk-image

ACTION: compile -- Failed. Compilation failed: Compilation failed
REASON: User specified action: run compile -XDignore.symbol.file ReplayCacheTestProc.java
TIME:   0.752 seconds
messages:
command: compile -XDignore.symbol.file /local/home/ianrichr/openjdk/jdk8u/jdk/test/sun/security/krb5/auto/ReplayCacheTestProc.java
reason: User specified action: run compile -XDignore.symbol.file ReplayCacheTestProc.java
Mode: agentvm
Agent id: 1
elapsed time (seconds): 0.752
configuration:
Boot Layer (javac runtime environment)
  class path: /home/ianrichr/openjdk/jdk8u/build/linux-x86_64-normal-server-release/images/j2sdk-image/lib/tools.jar
              /local/home/ianrichr/openjdk/jtreg/lib/javatest.jar
              /local/home/ianrichr/openjdk/jtreg/lib/jtreg.jar

javac compilation environment
  source path: /local/home/ianrichr/openjdk/jdk8u/jdk/test/sun/security/krb5/auto
               /local/home/ianrichr/openjdk/jdk8u/jdk/test/java/security/testlibrary
  class path:  /local/home/ianrichr/openjdk/jdk8u/jdk/test/sun/security/krb5/auto
               /local/home/ianrichr/openjdk/jdk8u/build/linux-x86_64-normal-server-release/testoutput/jdk_adhoc/JTwork/classes/0/sun/security/krb5/auto
               /home/ianrichr/openjdk/jdk8u/build/linux-x86_64-normal-server-release/images/j2sdk-image/lib/tools.jar

rerun:
cd /local/home/ianrichr/openjdk/jdk8u/build/linux-x86_64-normal-server-release/testoutput/jdk_adhoc/JTwork/scratch/0 && \
HOME=/home/ianrichr \
LANG=en_US.UTF-8 \
PATH=/bin:/usr/bin:/usr/sbin \
    /home/ianrichr/openjdk/jdk8u/build/linux-x86_64-normal-server-release/images/j2sdk-image/bin/javac \
        -J-ea \
        -J-esa \
        -J-Xmx512m \
        -J-Dtest.vm.opts='-ea -esa -Xmx512m' \
        -J-Dtest.tool.vm.opts='-J-ea -J-esa -J-Xmx512m' \
        -J-Dtest.compiler.opts= \
        -J-Dtest.java.opts= \
        -J-Dtest.jdk=/home/ianrichr/openjdk/jdk8u/build/linux-x86_64-normal-server-release/images/j2sdk-image \
        -J-Dcompile.jdk=/home/ianrichr/openjdk/jdk8u/build/linux-x86_64-normal-server-release/images/j2sdk-image \
        -J-Dtest.timeout.factor=4.0 \
        -J-Dtest.root=/local/home/ianrichr/openjdk/jdk8u/jdk/test \
        -J-Dtest.name=sun/security/krb5/auto/ReplayCacheTestProc.java \
        -J-Dtest.file=/local/home/ianrichr/openjdk/jdk8u/jdk/test/sun/security/krb5/auto/ReplayCacheTestProc.java \
        -J-Dtest.src=/local/home/ianrichr/openjdk/jdk8u/jdk/test/sun/security/krb5/auto \
        -J-Dtest.src.path=/local/home/ianrichr/openjdk/jdk8u/jdk/test/sun/security/krb5/auto:/local/home/ianrichr/openjdk/jdk8u/jdk/test/java/security/testlibrary \
        -J-Dtest.classes=/local/home/ianrichr/openjdk/jdk8u/build/linux-x86_64-normal-server-release/testoutput/jdk_adhoc/JTwork/classes/0/sun/security/krb5/auto \
        -J-Dtest.class.path=/local/home/ianrichr/openjdk/jdk8u/build/linux-x86_64-normal-server-release/testoutput/jdk_adhoc/JTwork/classes/0/sun/security/krb5/auto:/local/home/ianrichr/openjdk/jdk8u/build/linux-x86_64-normal-server-release/testoutput/jdk_adhoc/JTwork/classes/0/java/security/testlibrary \
        -J-Dtest.class.path.prefix=/local/home/ianrichr/openjdk/jdk8u/build/linux-x86_64-normal-server-release/testoutput/jdk_adhoc/JTwork/classes/0/sun/security/krb5/auto:/local/home/ianrichr/openjdk/jdk8u/jdk/test/sun/security/krb5/auto \
        -d /local/home/ianrichr/openjdk/jdk8u/build/linux-x86_64-normal-server-release/testoutput/jdk_adhoc/JTwork/classes/0/sun/security/krb5/auto \
        -sourcepath /local/home/ianrichr/openjdk/jdk8u/jdk/test/sun/security/krb5/auto:/local/home/ianrichr/openjdk/jdk8u/jdk/test/java/security/testlibrary \
        -classpath /local/home/ianrichr/openjdk/jdk8u/jdk/test/sun/security/krb5/auto:/local/home/ianrichr/openjdk/jdk8u/build/linux-x86_64-normal-server-release/testoutput/jdk_adhoc/JTwork/classes/0/sun/security/krb5/auto:/home/ianrichr/openjdk/jdk8u/build/linux-x86_64-normal-server-release/images/j2sdk-image/lib/tools.jar \
        -XDignore.symbol.file /local/home/ianrichr/openjdk/jdk8u/jdk/test/sun/security/krb5/auto/ReplayCacheTestProc.java
direct:
/local/home/ianrichr/openjdk/jdk8u/jdk/test/sun/security/krb5/auto/ReplayCacheTestProc.java:46: error: package jdk.test.lib does not exist
import jdk.test.lib.Platform;
                   ^
/local/home/ianrichr/openjdk/jdk8u/jdk/test/sun/security/krb5/auto/ReplayCacheTestProc.java:138: error: cannot find symbol
                if (Platform.isOSX() || Platform.isWindows()) {
                    ^
  symbol:   variable Platform
  location: class ReplayCacheTestProc
/local/home/ianrichr/openjdk/jdk8u/jdk/test/sun/security/krb5/auto/ReplayCacheTestProc.java:138: error: cannot find symbol
                if (Platform.isOSX() || Platform.isWindows()) {
                                        ^
  symbol:   variable Platform
  location: class ReplayCacheTestProc
Note: /local/home/ianrichr/openjdk/jdk8u/jdk/test/sun/security/krb5/auto/KDC.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
3 errors

TEST RESULT: Failed. Compilation failed: Compilation failed
--------------------------------------------------
Test results: failed: 1
Report written to /local/home/ianrichr/openjdk/jdk8u/build/linux-x86_64-normal-server-release/testoutput/jdk_adhoc/JTreport/html/report.html
Results written to /local/home/ianrichr/openjdk/jdk8u/build/linux-x86_64-normal-server-release/testoutput/jdk_adhoc/JTwork
Error: Some tests failed or other problems occurred.
Summary: jdk_adhoc
FAILED: sun/security/krb5/auto/ReplayCacheTestProc.java
```

Appending `/test/lib` to the `@library` annotation allows the compilation to succeed and the test passes.

```
Passed: sun/security/krb5/auto/ReplayCacheTestProc.java
Test results: passed: 1
```

This was introduced with this PR/issue https://bugs.openjdk.org/browse/JDK-8168518 when the `import jdk.test.lib.Platform;` was added to the test file.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8329544](https://bugs.openjdk.org/browse/JDK-8329544) needs maintainer approval

### Issue
 * [JDK-8329544](https://bugs.openjdk.org/browse/JDK-8329544): [8u] sun/security/krb5/auto/ReplayCacheTestProc.java cannot find the testlibrary (**Bug** - P4 - Approved)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/478/head:pull/478` \
`$ git checkout pull/478`

Update a local copy of the PR: \
`$ git checkout pull/478` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/478/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 478`

View PR using the GUI difftool: \
`$ git pr show -t 478`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/478.diff">https://git.openjdk.org/jdk8u-dev/pull/478.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/478#issuecomment-2032582096)