### PR TITLE
8258855: Two tests sun/security/krb5/auto/ReplayCacheTestProc.java and ReplayCacheTestProcWithMD5.java failed on OL8.3

### DIFF
--- a/jdk/test/sun/security/krb5/auto/ReplayCacheTestProc.java
+++ b/jdk/test/sun/security/krb5/auto/ReplayCacheTestProc.java
@@ -27,7 +27,10 @@
  * @summary More krb5 tests
  * @library ../../../../java/security/testlibrary/ /test/lib
  * @compile -XDignore.symbol.file ReplayCacheTestProc.java
- * @run main/othervm/timeout=300 -Dsun.net.spi.nameservice.provider.1=ns,mock ReplayCacheTestProc
+ * @run main/othervm/timeout=300 -Dsun.net.spi.nameservice.provider.1=ns,mock
+ *      -Dtest.libs=J ReplayCacheTestProc
+ * @run main/othervm/timeout=300 -Dsun.net.spi.nameservice.provider.1=ns,mock
+ *      -Dtest.libs=N ReplayCacheTestProc
  */
 
 import java.io.*;
@@ -43,6 +46,7 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import jdk.test.lib.Asserts;
 import jdk.test.lib.Platform;
 import sun.security.jgss.GSSUtil;
 import sun.security.krb5.internal.rcache.AuthTime;
@@ -51,9 +55,8 @@ import sun.security.krb5.internal.rcache.AuthTime;
  * This test runs multiple acceptor Procs to mimic AP-REQ replays.
  * These system properties are supported:
  *
- * - test.libs on what types of acceptors to use
+ * - test.libs on what types of acceptors to use. Cannot be null.
  *   Format: CSV of (J|N|N<suffix>=<libname>|J<suffix>=<launcher>)
- *   Default: J,N on Solaris and Linux where N is available, or J
  *   Example: J,N,N14=/krb5-1.14/lib/libgssapi_krb5.so,J8=/java8/bin/java
  *
  * - test.runs on manual runs. If empty, a iterate through all pattern
@@ -117,6 +120,16 @@ public class ReplayCacheTestProc {
                 uid = -1;
             }
 
+            // User-provided libs
+            String userLibs = System.getProperty("test.libs");
+            Asserts.assertNotNull(userLibs, "test.libs property must be provided");
+            libs = userLibs.split(",");
+            if (Arrays.asList(libs).contains("N") && !isNativeLibAvailable()) {
+                // Skip test when native GSS libs are not available in running platform
+                System.out.println("Native mode not available - skipped");
+                return;
+            }
+
             KDC kdc = KDC.create(OneKDC.REALM, HOST, 0, true);
             for (int i=0; i<nc; i++) {
                 kdc.addPrincipal(client(i), OneKDC.PASS);
@@ -128,25 +141,6 @@ public class ReplayCacheTestProc {
 
             kdc.writeKtab(OneKDC.KTAB);
             KDC.saveConfig(OneKDC.KRB5_CONF, kdc);
-
-            // User-provided libs
-            String userLibs = System.getProperty("test.libs");
-
-            if (userLibs != null) {
-                libs = userLibs.split(",");
-            } else {
-                if (Platform.isOSX() || Platform.isWindows()) {
-                    // macOS uses Heimdal and Windows has no native lib
-                    libs = new String[]{"J"};
-                } else {
-                    if (acceptor("N", "sanity").waitFor() != 0) {
-                        Proc.d("Native mode sanity check failed, only java");
-                        libs = new String[]{"J"};
-                    } else {
-                        libs = new String[]{"J", "N"};
-                    }
-                }
-            }
 
             pi = Proc.create("ReplayCacheTestProc").debug("C")
                     .args("initiator")
@@ -321,6 +315,13 @@ public class ReplayCacheTestProc {
             Proc.d(e);
             throw e;
         }
+    }
+
+    // returns true if native lib is available in running platform
+    // macOS uses Heimdal and Windows has no native lib
+    private static boolean isNativeLibAvailable() throws Exception {
+        return !Platform.isOSX() && !Platform.isWindows()
+                && acceptor("N", "sanity").waitFor() == 0;
     }
 
     // returns the client name

--- a/jdk/test/sun/security/krb5/auto/rcache_usemd5.sh
+++ b/jdk/test/sun/security/krb5/auto/rcache_usemd5.sh
@@ -24,7 +24,9 @@
 # @test
 # @bug 8168518
 # @library ../../../../java/security/testlibrary/ /test/lib
-# @run main/othervm/timeout=300 -Dsun.net.spi.nameservice.provider.1=ns,mock -Djdk.krb5.rcache.useMD5=true ReplayCacheTestProc
+# @run main/othervm/timeout=300 -Dsun.net.spi.nameservice.provider.1=ns,mock
+#           -Djdk.krb5.rcache.useMD5=true
+#           -Dtest.libs=J ReplayCacheTestProc
 # @summary  testing jdk.krb5.rcache.useMD5. This action is put in a separate
 #           test so that ReplayCacheTestProc.java can be launched with special
 #           test.* system properties easily.


### PR DESCRIPTION
In testing `sun/security/krb5/auto/ReplayCacheTestProc.java` following [JDK-8168518](https://bugs.openjdk.org/browse/JDK-8168518), I found both it and `sun/security/krb5/auto/rcache_usemd5.sh` failed on RHEL 8.  This did not seem to be a regression caused by the 8u412 change as it failed on the current release, 8u402.  The failure was further confirmed by @martinuy who found it was due to the newer Kerberos version on RHEL 8, and it passed on Fedora 31.

 @jerboaa alerted me to [JDK-8258855](https://bugs.openjdk.org/browse/JDK-8258855) and backporting this change to 8u makes the tests pass.

The code changes apply as is. The headers have to be adjusted slightly to take into account the different DNS options used in 8u.  The change to `test/jdk/sun/security/krb5/auto/ReplayCacheTestProcWithMD5.java` also moves to `jdk/test/sun/security/krb5/auto/rcache_usemd5.sh` on 8u and has to be manually applied. I looked briefly at backporting [JDK-8180569](https://bugs.openjdk.org/browse/JDK-8180569) which refactors these Kerberos shell tests into Java tests, and I think it has merit, but is likely quite involved and requires other test library backports. For now, we can just backport this change as the shell script is different to the one removed by 8180569 with or without this patch applied first.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8258855](https://bugs.openjdk.org/browse/JDK-8258855) needs maintainer approval

### Issue
 * [JDK-8258855](https://bugs.openjdk.org/browse/JDK-8258855): Two tests sun/security/krb5/auto/ReplayCacheTestProc.java and ReplayCacheTestProcWithMD5.java failed on OL8.3 (**Bug** - P3 - Approved)


### Reviewers
 * [Martin Balao](https://openjdk.org/census#mbalao) (@martinuy - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/481/head:pull/481` \
`$ git checkout pull/481`

Update a local copy of the PR: \
`$ git checkout pull/481` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/481/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 481`

View PR using the GUI difftool: \
`$ git pr show -t 481`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/481.diff">https://git.openjdk.org/jdk8u-dev/pull/481.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/481#issuecomment-2059715144)