### PR TITLE
8330561: [Windows][8u] IME candidate window wrong position

### DIFF
--- a/jdk/src/windows/native/sun/windows/awt_Component.cpp
+++ b/jdk/src/windows/native/sun/windows/awt_Component.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -3840,7 +3840,7 @@ void AwtComponent::OpenCandidateWindow(int x, int y)
 {
     UINT bits = 1;
     POINT p = {0, 0}; // upper left corner of the client area
-    HWND hWnd = GetHWnd();
+    HWND hWnd = ImmGetHWnd();
     if (!::IsWindowVisible(hWnd)) {
         return;
     }


### PR DESCRIPTION
This fix includes a fix for JDK-8189687 in JDK9.
JDK-8189687 contains two fixes to AwtComponent:: OpenCandidateWindow

1. Fix to make OpenCandidateWindow reference the correct Window
Fix OpenCandidateWindow to reference the proxy window that has focus when getting "HWND."

```diff
--- a/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
@@ -3880,19 +3880,21 @@ void AwtComponent::OpenCandidateWindow(int x, int y)
 {
     UINT bits = 1;
     POINT p = {0, 0}; // upper left corner of the client area
-    HWND hWnd = GetHWnd();
+    HWND hWnd = ImmGetHWnd();
     if (!::IsWindowVisible(hWnd)) {
         return;
     }

```

2. Scaling fixes to enhance JDK-8073320
OpenJDK9 has supported HiDPI Graphics since JEP 263 (JDK-8055212). This fix is one of its enhancements: when OpenCandidateWindow opens an IME conversion candidate, it corrects the coordinates for the device.

```diff
--- a/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
@@ -3880,19 +3880,21 @@ void AwtComponent::OpenCandidateWindow(int x, int y)
     HWND hTop = GetTopLevelParentForWindow(hWnd);
     ::ClientToScreen(hTop, &p);
+    int sx = ScaleUpX(x) - p.x;
+    int sy = ScaleUpY(y) - p.y;
     if (!m_bitsCandType) {
-        SetCandidateWindow(m_bitsCandType, x - p.x, y - p.y);
+        SetCandidateWindow(m_bitsCandType, sx, sy);
         return;
     }
     for (int iCandType=0; iCandType<32; iCandType++, bits<<=1) {
         if ( m_bitsCandType & bits )
-            SetCandidateWindow(iCandType, x - p.x, y - p.y);
+            SetCandidateWindow(iCandType, sx, sy);
     }
 }
```

In attatchmented test which reproduces the issue problem, the Panel containing the TextField is a child component, so it refers to the wrong window to get the position coordinate of the candidate window.
Therefore, the candidate window will appear in the correct position with the "1" fix.
Note that OpenJDK8 does not implement JEP 263, so the "2" fix is not included in this pull request.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8330561](https://bugs.openjdk.org/browse/JDK-8330561) needs maintainer approval

### Issue
 * [JDK-8330561](https://bugs.openjdk.org/browse/JDK-8330561): [Windows][8u] IME candidate window wrong position (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/483/head:pull/483` \
`$ git checkout pull/483`

Update a local copy of the PR: \
`$ git checkout pull/483` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/483/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 483`

View PR using the GUI difftool: \
`$ git pr show -t 483`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/483.diff">https://git.openjdk.org/jdk8u-dev/pull/483.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/483#issuecomment-2063362543)