### PR TITLE
8276125: RunThese24H.java SIGSEGV in JfrThreadGroup::thread_group_id

### DIFF
--- a/hotspot/src/share/vm/jfr/recorder/checkpoint/types/jfrThreadGroup.cpp
+++ b/hotspot/src/share/vm/jfr/recorder/checkpoint/types/jfrThreadGroup.cpp
@@ -150,8 +150,12 @@ int JfrThreadGroupsHelper::populate_thread_group_hierarchy(const JavaThread* jt,
   assert(current != NULL, "invariant");
   assert(_thread_group_hierarchy != NULL, "invariant");
 
+  oop thread_oop = jt->threadObj();
+  if (thread_oop == NULL) {
+    return 0;
+  }
   // immediate thread group
-  Handle thread_group_handle(current, java_lang_Thread::threadGroup(jt->threadObj()));
+  Handle thread_group_handle(current, java_lang_Thread::threadGroup(thread_oop));
   if (thread_group_handle == NULL) {
     return 0;
   }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [a4a5c7fe](https://github.com/openjdk/jdk11u-dev/commit/a4a5c7fe66679ce4d9022443e3cd1f9ec38059ac) from the [openjdk/jdk11u-dev](https://git.openjdk.org/jdk11u-dev) repository.

The commit being backported was authored by Jiawei Tang on 4 Mar 2024 and was reviewed by Markus Grönlund.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8276125](https://bugs.openjdk.org/browse/JDK-8276125) needs maintainer approval

### Issue
 * [JDK-8276125](https://bugs.openjdk.org/browse/JDK-8276125): RunThese24H.java SIGSEGV in JfrThreadGroup::thread_group_id (**Bug** - P3 - Requested)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/485/head:pull/485` \
`$ git checkout pull/485`

Update a local copy of the PR: \
`$ git checkout pull/485` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/485/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 485`

View PR using the GUI difftool: \
`$ git pr show -t 485`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/485.diff">https://git.openjdk.org/jdk8u-dev/pull/485.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/485#issuecomment-2071538939)