### PR TITLE
8322511: [11u] JfrCheckpointThreadClosure::do_thread crashes when fetching thread_id

### DIFF
--- a/hotspot/src/share/vm/jfr/recorder/checkpoint/types/jfrType.cpp
+++ b/hotspot/src/share/vm/jfr/recorder/checkpoint/types/jfrType.cpp
@@ -105,7 +105,7 @@ void JfrCheckpointThreadClosure::do_thread(Thread* t) {
   if (t->is_Java_thread()) {
     JavaThread* const jt = (JavaThread*)t;
     _writer.write(jt->name());
-    _writer.write(java_lang_Thread::thread_id(jt->threadObj()));
+    _writer.write(jt->threadObj() != NULL ? java_lang_Thread::thread_id(jt->threadObj()) : 0);
     _writer.write(JfrThreadGroup::thread_group_id(jt, _curthread));
     // since we are iterating threads during a safepoint, also issue notification
     JfrJavaEventWriter::notify(jt);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [29f300eb](https://github.com/openjdk/jdk11u-dev/commit/29f300eb2ac4c038fad7f8e09eab8a53b69526c6) from the [openjdk/jdk11u-dev](https://git.openjdk.org/jdk11u-dev) repository.

The commit being backported was authored by Jiawei Tang on 11 Mar 2024 and was reviewed by Paul Hohensee.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] [JDK-8322511](https://bugs.openjdk.org/browse/JDK-8322511) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322511](https://bugs.openjdk.org/browse/JDK-8322511): [11u] JfrCheckpointThreadClosure::do_thread crashes when fetching thread_id (**Bug** - P4 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/486/head:pull/486` \
`$ git checkout pull/486`

Update a local copy of the PR: \
`$ git checkout pull/486` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/486/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 486`

View PR using the GUI difftool: \
`$ git pr show -t 486`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/486.diff">https://git.openjdk.org/jdk8u-dev/pull/486.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/486#issuecomment-2071548637)