### PR TITLE
8330973: Test8009761 fails on ppcle_linux: init recursive calls: 38. After deopt 37

### DIFF
--- a/hotspot/test/compiler/8009761/Test8009761.java
+++ b/hotspot/test/compiler/8009761/Test8009761.java
@@ -245,7 +245,8 @@ public class Test8009761 {
             m3(false, true);
         } catch(StackOverflowError soe) {
         }
-        if (c1 != count) {
+        // Allow number of recursive calls to vary by 1
+        if ((c1 < (count - 1)) || (c1 > (count + 1))) {
             System.out.println("Failed: init recursive calls: " + c1 + ". After deopt " + count);
             System.exit(97);
         } else {


### PR DESCRIPTION
In certain environments, the deopt count is known to vary by 1, as noted in JDK-8021775.

This is a backport for a portion of that fix, to allow this tolerance in JDK8's version of the test while not requiring the full body of the original fix.

https://bugs.openjdk.org/browse/JDK-8330973

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8330973](https://bugs.openjdk.org/browse/JDK-8330973) needs maintainer approval

### Issue
 * [JDK-8330973](https://bugs.openjdk.org/browse/JDK-8330973): Test8009761 fails on ppcle_linux: init recursive calls: 38. After deopt 37 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/487/head:pull/487` \
`$ git checkout pull/487`

Update a local copy of the PR: \
`$ git checkout pull/487` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/487/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 487`

View PR using the GUI difftool: \
`$ git pr show -t 487`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/487.diff">https://git.openjdk.org/jdk8u-dev/pull/487.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/487#issuecomment-2072254800)