### PR TITLE
8315020: The macro definition for LoongArch64 zero build is not accurate.

### DIFF
--- a/common/autoconf/platform.m4
+++ b/common/autoconf/platform.m4
@@ -381,6 +381,7 @@ AC_DEFUN([PLATFORM_SETUP_LEGACY_VARS],
 
   # ZERO_ARCHDEF is used to enable architecture-specific code
   case "${OPENJDK_TARGET_CPU}" in
+    loongarch64)  ZERO_ARCHDEF=LOONGARCH64 ;;
     ppc)     ZERO_ARCHDEF=PPC32 ;;
     ppc64)   ZERO_ARCHDEF=PPC64 ;;
     s390*)   ZERO_ARCHDEF=S390  ;;

--- a/common/autoconf/platform.m4
+++ b/common/autoconf/platform.m4
@@ -381,7 +381,6 @@ AC_DEFUN([PLATFORM_SETUP_LEGACY_VARS],
 
   # ZERO_ARCHDEF is used to enable architecture-specific code
   case "${OPENJDK_TARGET_CPU}" in
-    loongarch64)  ZERO_ARCHDEF=LOONGARCH64 ;;
     ppc)     ZERO_ARCHDEF=PPC32 ;;
     ppc64)   ZERO_ARCHDEF=PPC64 ;;
     s390*)   ZERO_ARCHDEF=S390  ;;

--- a/hotspot/src/os/linux/vm/os_linux.cpp
+++ b/hotspot/src/os/linux/vm/os_linux.cpp
@@ -2008,11 +2008,11 @@ void * os::dll_load(const char *filename, char *ebuf, int ebuflen)
     static  Elf32_Half running_arch_code=EM_68K;
   #elif  (defined AARCH64)
     static  Elf32_Half running_arch_code=EM_AARCH64;
-  #elif  (defined LOONGARCH)
+  #elif  (defined LOONGARCH64)
     static  Elf32_Half running_arch_code=EM_LOONGARCH;
   #else
     #error Method os::dll_load requires that one of following is defined:\
-         IA32, AMD64, IA64, __sparc, __powerpc__, ARM, S390, ALPHA, MIPS, MIPSEL, PARISC, M68K, AARCH64, LOONGARCH
+         IA32, AMD64, IA64, __sparc, __powerpc__, ARM, S390, ALPHA, MIPS, MIPSEL, PARISC, M68K, AARCH64, LOONGARCH64
   #endif
 
   // Identify compatability class for VM's architecture and library's architecture


### PR DESCRIPTION
Hi,

I'd like to backport this patch to jdk8u. `common/autoconf/platform.m4` and `hotspot/src/os/linux/vm/os_linux.cpp` do not apply cleanly due to context difference, but it is easy to resolve them manually.

A native build on LoongArch hardware is tested.

Debian: https://mail.openjdk.org/pipermail/jdk8u-dev/2024-April/018378.html

```
$ ./build/images/j2sdk-image/bin/java -version
openjdk version "1.8.0_412"
OpenJDK Runtime Environment (build 1.8.0_412-8u412-ga-1-b08)
OpenJDK 64-Bit Zero VM (build 25.412-b08, interpreted mode)
```

Loongnix Desktop:

```
$ ./build/linux-loongarch64-normal-zero-release/images/j2sdk-image/bin/java -version
openjdk version "1.8.0_422-internal"
OpenJDK Runtime Environment (build 1.8.0_422-internal-zhaixiang_2024_04_28_10_57-b00)
OpenJDK 64-Bit Zero VM (build 25.422-b00, interpreted mode)
```

The risk of the downport is low.

Thanks,
Leslie Zhai

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] [JDK-8315020](https://bugs.openjdk.org/browse/JDK-8315020) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315020](https://bugs.openjdk.org/browse/JDK-8315020): The macro definition for LoongArch64 zero build is not accurate. (**Bug** - P4 - Requested)


### Reviewers
 * @mirabilos (no known openjdk.org user name / role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/489/head:pull/489` \
`$ git checkout pull/489`

Update a local copy of the PR: \
`$ git checkout pull/489` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/489/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 489`

View PR using the GUI difftool: \
`$ git pr show -t 489`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/489.diff">https://git.openjdk.org/jdk8u-dev/pull/489.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/489#issuecomment-2081361534)