### PR TITLE
[8u] GHA: update sysroot for cross builds to Debian bullseye

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -401,7 +401,7 @@ jobs:
           --verbose
           --include=fakeroot,symlinks,build-essential,libx11-dev,libxext-dev,libxrender-dev,libxrandr-dev,libxtst-dev,libxt-dev,libcups2-dev,libfontconfig1-dev,libasound2-dev,libfreetype6-dev,libpng-dev,libffi-dev
           --resolve-deps
-          buster
+          bullseye
           ~/sysroot-${{ matrix.debian-arch }}
           http://httpredir.debian.org/debian/
         if: matrix.debian-arch != '' && steps.cache-sysroot.outputs.cache-hit != 'true'


### PR DESCRIPTION
Updates GHA to use Debian `bullseye` for cross build sysroot. Motivation for this are broken builds on s390x and ppc64le in recent test runs. This is due to disappearance of s390x and ppc64le arches in [repos](http://httpredir.debian.org/debian/dists/buster/main/) of `buster` (currently used Debian). Not sure why arches disappeared, but turns out that `buster` soon reaches end of LTS support ([2024-06-30](https://wiki.debian.org/LTS)).

As Debian `bullseye` (next version) again has all aches in [its repos](http://httpredir.debian.org/debian/dists/bullseye/main/), update solves both issues. In newer JDKs, sysroot update to bullseye was included in [JDK-8293107](https://bugs.openjdk.org/browse/JDK-8293107) (GHA: Bump to Ubuntu 22.04). I have tried Ubuntu update in GHA as well, but it failed to build on some platforms (aarch64, ppc64le)  with errors such as:
```
/home/runner/work/jdk8u-dev/jdk8u-dev/jdk/hotspot/src/share/vm/adlc/arena.cpp:82:19: error: ISO C++17 does not allow ‘register’ storage class specifier [-Werror=register]
   82 |   register Chunk *k = _first;
      |                   ^
```
Seems to be [JDK-8281096](https://bugs.openjdk.org/browse/JDK-8281096)  (Flags introduced by configure script are not passed to ADLC build). So Ubuntu update is blocked by that (and there seem to be some complications there). That's why I would like to do this separately from Ubuntu upgrade.