### PR TITLE
6622468: TEST_BUG: Time to retire the @debuggeeVMOptions mechanism used in the com.sun.jdi infrastructure

### DIFF
--- a/jdk/test/com/sun/jdi/AccessSpecifierTest.java
+++ b/jdk/test/com/sun/jdi/AccessSpecifierTest.java
@@ -30,7 +30,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g AccessSpecifierTest.java
- *  @run main AccessSpecifierTest
+ *  @run driver AccessSpecifierTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/AfterThreadDeathTest.java
+++ b/jdk/test/com/sun/jdi/AfterThreadDeathTest.java
@@ -30,7 +30,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g AfterThreadDeathTest.java
- *  @run main AfterThreadDeathTest
+ *  @run driver AfterThreadDeathTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/AllLineLocations.java
+++ b/jdk/test/com/sun/jdi/AllLineLocations.java
@@ -31,7 +31,7 @@
  *  @run compile -g RefTypes.java
  *  @run build AllLineLocations
  *
- *  @run main AllLineLocations RefTypes
+ *  @run driver AllLineLocations RefTypes
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/AnyDebuggeeTest.java
+++ b/jdk/test/com/sun/jdi/AnyDebuggeeTest.java
@@ -29,7 +29,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g AnyDebuggeeTest.java
- *  @run main AnyDebuggeeeTest
+ *  @run driver AnyDebuggeeeTest
  *
  *  This test is intended to be run manually to investigate behaviors;
  *  it is not an actual test of any specific functionality, it just

--- a/jdk/test/com/sun/jdi/ArgumentValuesTest.java
+++ b/jdk/test/com/sun/jdi/ArgumentValuesTest.java
@@ -7,7 +7,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile ArgumentValuesTest.java
- *  @run main ArgumentValuesTest
+ *  @run driver ArgumentValuesTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/ArrayRangeTest.java
+++ b/jdk/test/com/sun/jdi/ArrayRangeTest.java
@@ -32,7 +32,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g ArrayRangeTest.java
- *  @run main ArrayRangeTest
+ *  @run driver ArrayRangeTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/BacktraceFieldTest.java
+++ b/jdk/test/com/sun/jdi/BacktraceFieldTest.java
@@ -30,7 +30,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g BacktraceFieldTest.java
- *  @run main BacktraceFieldTest
+ *  @run driver BacktraceFieldTest
  */
 
 /*

--- a/jdk/test/com/sun/jdi/BadHandshakeTest.java
+++ b/jdk/test/com/sun/jdi/BadHandshakeTest.java
@@ -27,7 +27,7 @@
  * @library /lib/testlibrary
  *
  * @build jdk.testlibrary.* VMConnection BadHandshakeTest Exit0
- * @run main BadHandshakeTest
+ * @run driver BadHandshakeTest
  *
  */
 import java.net.Socket;

--- a/jdk/test/com/sun/jdi/BreakpointTest.java
+++ b/jdk/test/com/sun/jdi/BreakpointTest.java
@@ -30,7 +30,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g BreakpointTest.java
- *  @run main BreakpointTest
+ *  @run driver BreakpointTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/ClassLoaderClassesTest.java
+++ b/jdk/test/com/sun/jdi/ClassLoaderClassesTest.java
@@ -32,7 +32,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g ClassLoaderClassesTest.java
- *  @run main ClassLoaderClassesTest
+ *  @run driver ClassLoaderClassesTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/ClassesByName.java
+++ b/jdk/test/com/sun/jdi/ClassesByName.java
@@ -33,7 +33,7 @@
  *  @summary ClassesByName verifies that all the classes in the
  *  loaded class list can be found with classesByName..
  *
- *  @run main ClassesByName HelloWorld
+ *  @run driver ClassesByName HelloWorld
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/ClassesByName2Test.java
+++ b/jdk/test/com/sun/jdi/ClassesByName2Test.java
@@ -30,7 +30,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g ClassesByName2Test.java
- *  @run main ClassesByName2Test
+ *  @run driver ClassesByName2Test
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/ConnectedVMs.java
+++ b/jdk/test/com/sun/jdi/ConnectedVMs.java
@@ -28,10 +28,10 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g InstTarg.java
- *  @run main ConnectedVMs Kill
- *  @run main ConnectedVMs Resume-to-exit
- *  @run main ConnectedVMs dispose()
- *  @run main ConnectedVMs exit()
+ *  @run driver ConnectedVMs Kill
+ *  @run driver ConnectedVMs Resume-to-exit
+ *  @run driver ConnectedVMs dispose()
+ *  @run driver ConnectedVMs exit()
  *
  * @summary ConnectedVMs checks the method
  * VirtualMachineManager.connectedVirtualMachines()

--- a/jdk/test/com/sun/jdi/ConstantPoolInfo.java
+++ b/jdk/test/com/sun/jdi/ConstantPoolInfo.java
@@ -30,7 +30,7 @@
  *
  *  @run build TestScaffold VMConnection
  *  @run compile -g ConstantPoolInfo.java
- *  @run main ConstantPoolInfo
+ *  @run driver ConstantPoolInfo
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/CountEvent.java
+++ b/jdk/test/com/sun/jdi/CountEvent.java
@@ -31,7 +31,7 @@
  *
  *  @run build TestScaffold VMConnection TargetAdapter TargetListener
  *  @run compile -g CountEvent.java
- *  @run main CountEvent
+ *  @run driver CountEvent
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/CountFilterTest.java
+++ b/jdk/test/com/sun/jdi/CountFilterTest.java
@@ -30,7 +30,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g CountFilterTest.java
- *  @run main CountFilterTest
+ *  @run driver CountFilterTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/DataModelTest.java
+++ b/jdk/test/com/sun/jdi/DataModelTest.java
@@ -34,7 +34,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g DataModelTest.java
- *  @run main DataModelTest
+ *  @run driver DataModelTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/DebuggerThreadTest.java
+++ b/jdk/test/com/sun/jdi/DebuggerThreadTest.java
@@ -30,7 +30,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g DebuggerThreadTest.java
- *  @run main DebuggerThreadTest
+ *  @run driver DebuggerThreadTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/DeleteAllBkptsTest.java
+++ b/jdk/test/com/sun/jdi/DeleteAllBkptsTest.java
@@ -31,7 +31,7 @@
  *  @library ..
  *  @run build  TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g DeleteAllBkptsTest.java
- *  @run main DeleteAllBkptsTest
+ *  @run driver DeleteAllBkptsTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/DeleteEventRequestsTest.java
+++ b/jdk/test/com/sun/jdi/DeleteEventRequestsTest.java
@@ -30,7 +30,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g DeleteEventRequestsTest.java
- *  @run main DeleteEventRequestsTest
+ *  @run driver DeleteEventRequestsTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/EarlyReturnNegativeTest.java
+++ b/jdk/test/com/sun/jdi/EarlyReturnNegativeTest.java
@@ -29,7 +29,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g EarlyReturnNegativeTest.java
- *  @run main EarlyReturnNegativeTest
+ *  @run driver EarlyReturnNegativeTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/EarlyReturnTest.java
+++ b/jdk/test/com/sun/jdi/EarlyReturnTest.java
@@ -36,7 +36,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g EarlyReturnTest.java
- *  @run main EarlyReturnTest
+ *  @run driver EarlyReturnTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/EnumTest.java
+++ b/jdk/test/com/sun/jdi/EnumTest.java
@@ -30,7 +30,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g EnumTest.java
- *  @run main EnumTest
+ *  @run driver EnumTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/EventQueueDisconnectTest.java
+++ b/jdk/test/com/sun/jdi/EventQueueDisconnectTest.java
@@ -28,7 +28,7 @@
  *
  *  @run build VMConnection
  *  @run compile -g EventQueueDisconnectTest.java
- *  @run main EventQueueDisconnectTest
+ *  @run driver EventQueueDisconnectTest
  *
  *  @summary EventQueueDisconnectTest checks to see that
  *  VMDisconnectedException is never thrown before VMDisconnectEvent.
@@ -64,7 +64,7 @@ public class EventQueueDisconnectTest {
                                        "com.sun.jdi.CommandLineLaunch:",
                                        VirtualMachine.TRACE_NONE);
         connection.setConnectorArg("main", "EventQueueDisconnectTarg");
-        String debuggeeVMOptions = connection.getDebuggeeVMOptions();
+        String debuggeeVMOptions = VMConnection.getDebuggeeVMOptions();
         if (!debuggeeVMOptions.equals("")) {
             if (connection.connectorArg("options").length() > 0) {
                 throw new IllegalArgumentException("VM options in two places");

--- a/jdk/test/com/sun/jdi/ExceptionEvents.java
+++ b/jdk/test/com/sun/jdi/ExceptionEvents.java
@@ -31,32 +31,32 @@
  *  @run build TestScaffold VMConnection
  *  @run compile -g ExceptionEvents.java
  *
- *  @run main/othervm ExceptionEvents N A StackOverflowCaughtTarg java.lang.Exception
- *  @run main/othervm ExceptionEvents C A StackOverflowCaughtTarg null
- *  @run main/othervm ExceptionEvents C A StackOverflowCaughtTarg java.lang.Error
- *  @run main/othervm ExceptionEvents C A StackOverflowCaughtTarg java.lang.StackOverflowError
- *  @run main/othervm ExceptionEvents N A StackOverflowCaughtTarg java.lang.NullPointerException
+ *  @run driver ExceptionEvents N A StackOverflowCaughtTarg java.lang.Exception
+ *  @run driver ExceptionEvents C A StackOverflowCaughtTarg null
+ *  @run driver ExceptionEvents C A StackOverflowCaughtTarg java.lang.Error
+ *  @run driver ExceptionEvents C A StackOverflowCaughtTarg java.lang.StackOverflowError
+ *  @run driver ExceptionEvents N A StackOverflowCaughtTarg java.lang.NullPointerException
 
- *  @run main/othervm ExceptionEvents N T StackOverflowCaughtTarg java.lang.Exception
- *  @run main/othervm ExceptionEvents C T StackOverflowCaughtTarg null
- *  @run main/othervm ExceptionEvents C T StackOverflowCaughtTarg java.lang.Error
- *  @run main/othervm ExceptionEvents C T StackOverflowCaughtTarg java.lang.StackOverflowError
- *  @run main/othervm ExceptionEvents N T StackOverflowCaughtTarg java.lang.NullPointerException
+ *  @run driver ExceptionEvents N T StackOverflowCaughtTarg java.lang.Exception
+ *  @run driver ExceptionEvents C T StackOverflowCaughtTarg null
+ *  @run driver ExceptionEvents C T StackOverflowCaughtTarg java.lang.Error
+ *  @run driver ExceptionEvents C T StackOverflowCaughtTarg java.lang.StackOverflowError
+ *  @run driver ExceptionEvents N T StackOverflowCaughtTarg java.lang.NullPointerException
 
- *  @run main/othervm ExceptionEvents N N StackOverflowCaughtTarg java.lang.Exception
- *  @run main/othervm ExceptionEvents C N StackOverflowCaughtTarg null
- *  @run main/othervm ExceptionEvents C N StackOverflowCaughtTarg java.lang.Error
- *  @run main/othervm ExceptionEvents C N StackOverflowCaughtTarg java.lang.StackOverflowError
- *  @run main/othervm ExceptionEvents N N StackOverflowCaughtTarg java.lang.NullPointerException
+ *  @run driver ExceptionEvents N N StackOverflowCaughtTarg java.lang.Exception
+ *  @run driver ExceptionEvents C N StackOverflowCaughtTarg null
+ *  @run driver ExceptionEvents C N StackOverflowCaughtTarg java.lang.Error
+ *  @run driver ExceptionEvents C N StackOverflowCaughtTarg java.lang.StackOverflowError
+ *  @run driver ExceptionEvents N N StackOverflowCaughtTarg java.lang.NullPointerException
 
- *  @run main/othervm ExceptionEvents N A StackOverflowUncaughtTarg java.lang.Exception
- *  @run main/othervm ExceptionEvents U A StackOverflowUncaughtTarg null
- *  @run main/othervm ExceptionEvents U A StackOverflowUncaughtTarg java.lang.Error
- *  @run main/othervm ExceptionEvents U A StackOverflowUncaughtTarg java.lang.StackOverflowError
- *  @run main/othervm ExceptionEvents N A StackOverflowUncaughtTarg java.lang.NullPointerException
+ *  @run driver ExceptionEvents N A StackOverflowUncaughtTarg java.lang.Exception
+ *  @run driver ExceptionEvents U A StackOverflowUncaughtTarg null
+ *  @run driver ExceptionEvents U A StackOverflowUncaughtTarg java.lang.Error
+ *  @run driver ExceptionEvents U A StackOverflowUncaughtTarg java.lang.StackOverflowError
+ *  @run driver ExceptionEvents N A StackOverflowUncaughtTarg java.lang.NullPointerException
 
- *  @run main/othervm ExceptionEvents N T StackOverflowUncaughtTarg java.lang.NullPointerException
- *  @run main/othervm ExceptionEvents N N StackOverflowUncaughtTarg java.lang.NullPointerException
+ *  @run driver ExceptionEvents N T StackOverflowUncaughtTarg java.lang.NullPointerException
+ *  @run driver ExceptionEvents N N StackOverflowUncaughtTarg java.lang.NullPointerException
 
  */
 import com.sun.jdi.*;

--- a/jdk/test/com/sun/jdi/ExclusiveBind.java
+++ b/jdk/test/com/sun/jdi/ExclusiveBind.java
@@ -28,7 +28,7 @@
  * @library /lib/testlibrary
  *
  * @build jdk.testlibrary.* VMConnection ExclusiveBind HelloWorld
- * @run main ExclusiveBind
+ * @run driver ExclusiveBind
  */
 import java.net.ServerSocket;
 import com.sun.jdi.Bootstrap;

--- a/jdk/test/com/sun/jdi/ExpiredRequestDeletionTest.java
+++ b/jdk/test/com/sun/jdi/ExpiredRequestDeletionTest.java
@@ -31,7 +31,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g ExpiredRequestDeletionTest.java
- *  @run main ExpiredRequestDeletionTest
+ *  @run driver ExpiredRequestDeletionTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/FetchLocals.java
+++ b/jdk/test/com/sun/jdi/FetchLocals.java
@@ -7,7 +7,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g FetchLocals.java
- *  @run main FetchLocals
+ *  @run driver FetchLocals
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/FieldWatchpoints.java
+++ b/jdk/test/com/sun/jdi/FieldWatchpoints.java
@@ -30,7 +30,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g FieldWatchpoints.java
- *  @run main/othervm FieldWatchpoints
+ *  @run driver FieldWatchpoints
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/FilterMatch.java
+++ b/jdk/test/com/sun/jdi/FilterMatch.java
@@ -30,7 +30,7 @@
  *
  *  @run build JDIScaffold VMConnection
  *  @run compile -g HelloWorld.java
- *  @run main/othervm FilterMatch
+ *  @run driver FilterMatch
  */
 
 /* Look at patternMatch in JDK file:

--- a/jdk/test/com/sun/jdi/FilterNoMatch.java
+++ b/jdk/test/com/sun/jdi/FilterNoMatch.java
@@ -30,7 +30,7 @@
  *
  *  @run build JDIScaffold VMConnection
  *  @run compile -g HelloWorld.java
- *  @run main/othervm FilterNoMatch
+ *  @run driver FilterNoMatch
  */
 
 /* This tests the patternMatch function in JDK file:

--- a/jdk/test/com/sun/jdi/FinalLocalsTest.java
+++ b/jdk/test/com/sun/jdi/FinalLocalsTest.java
@@ -32,7 +32,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g FinalLocalsTest.java
- *  @run main FinalLocalsTest
+ *  @run driver FinalLocalsTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/FinalizerTest.java
+++ b/jdk/test/com/sun/jdi/FinalizerTest.java
@@ -30,7 +30,7 @@
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g FinalizerTest.java
  *
- *  @run main FinalizerTest
+ *  @run driver FinalizerTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/FramesTest.java
+++ b/jdk/test/com/sun/jdi/FramesTest.java
@@ -30,7 +30,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g FramesTest.java
- *  @run main FramesTest
+ *  @run driver FramesTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/GenericsTest.java
+++ b/jdk/test/com/sun/jdi/GenericsTest.java
@@ -30,7 +30,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g GenericsTest.java
- *  @run main GenericsTest
+ *  @run driver GenericsTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/GetLocalVariables.java
+++ b/jdk/test/com/sun/jdi/GetLocalVariables.java
@@ -7,7 +7,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g GetLocalVariables.java
- *  @run main GetLocalVariables
+ *  @run driver GetLocalVariables
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/GetLocalVariables2Test.java
+++ b/jdk/test/com/sun/jdi/GetLocalVariables2Test.java
@@ -30,7 +30,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g GetLocalVariables2Test.java
- *  @run main GetLocalVariables2Test
+ *  @run driver GetLocalVariables2Test
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/GetSetLocalTest.java
+++ b/jdk/test/com/sun/jdi/GetSetLocalTest.java
@@ -7,7 +7,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g GetSetLocalTest.java
- *  @run main GetSetLocalTest
+ *  @run driver GetSetLocalTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/GetUninitializedStringValue.java
+++ b/jdk/test/com/sun/jdi/GetUninitializedStringValue.java
@@ -30,7 +30,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g GetUninitializedStringValue.java
- *  @run main GetUninitializedStringValue
+ *  @run driver GetUninitializedStringValue
  */
 import com.sun.jdi.ReferenceType;
 import com.sun.jdi.StackFrame;

--- a/jdk/test/com/sun/jdi/HomeTest.java
+++ b/jdk/test/com/sun/jdi/HomeTest.java
@@ -30,7 +30,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g HomeTest.java
- *  @run main HomeTest
+ *  @run driver HomeTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.connect.*;

--- a/jdk/test/com/sun/jdi/InstanceFilter.java
+++ b/jdk/test/com/sun/jdi/InstanceFilter.java
@@ -31,7 +31,7 @@
  *
  *  @run build TestScaffold VMConnection TargetAdapter TargetListener
  *  @run compile -g InstanceFilter.java
- *  @run main/othervm InstanceFilter
+ *  @run driver InstanceFilter
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/InstancesTest.java
+++ b/jdk/test/com/sun/jdi/InstancesTest.java
@@ -29,7 +29,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g InstancesTest.java
- *  @run main InstancesTest
+ *  @run driver InstancesTest
  */
 
 /*

--- a/jdk/test/com/sun/jdi/InterfaceMethodsTest.java
+++ b/jdk/test/com/sun/jdi/InterfaceMethodsTest.java
@@ -29,7 +29,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run build InterfaceMethodsTest
- *  @run main InterfaceMethodsTest
+ *  @run driver InterfaceMethodsTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/InterruptHangTest.java
+++ b/jdk/test/com/sun/jdi/InterruptHangTest.java
@@ -7,7 +7,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g InterruptHangTest.java
- *  @run main InterruptHangTest
+ *  @run driver InterruptHangTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/InvokeHangTest.java
+++ b/jdk/test/com/sun/jdi/InvokeHangTest.java
@@ -30,7 +30,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g InvokeHangTest.java
- *  @run main InvokeHangTest
+ *  @run driver InvokeHangTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/InvokeTest.java
+++ b/jdk/test/com/sun/jdi/InvokeTest.java
@@ -31,7 +31,7 @@
  *  @library ..
  *  @run build  TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g InvokeTest.java
- *  @run main InvokeTest
+ *  @run driver InvokeTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/JITDebug.java
+++ b/jdk/test/com/sun/jdi/JITDebug.java
@@ -46,7 +46,7 @@
  *  assure that launching on uncaught exception works
  *
  *  @author Robert Field
- *  @run main/othervm JITDebug
+ *  @run driver JITDebug
  */
 
 import com.sun.jdi.*;

--- a/jdk/test/com/sun/jdi/Java_gTest.java
+++ b/jdk/test/com/sun/jdi/Java_gTest.java
@@ -30,7 +30,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g Java_gTest.java
- *  @run main Java_gTest
+ *  @run driver Java_gTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/LambdaBreakpointTest.java
+++ b/jdk/test/com/sun/jdi/LambdaBreakpointTest.java
@@ -31,7 +31,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g LambdaBreakpointTest.java
- *  @run main LambdaBreakpointTest
+ *  @run driver LambdaBreakpointTest
  */
 import java.util.List;
 

--- a/jdk/test/com/sun/jdi/LambdaStepTest.java
+++ b/jdk/test/com/sun/jdi/LambdaStepTest.java
@@ -29,7 +29,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g LambdaStepTest.java
- *  @run main LambdaStepTest
+ *  @run driver LambdaStepTest
  */
 import com.sun.jdi.LocalVariable;
 import com.sun.jdi.ObjectReference;

--- a/jdk/test/com/sun/jdi/LaunchCommandLine.java
+++ b/jdk/test/com/sun/jdi/LaunchCommandLine.java
@@ -31,7 +31,7 @@
  *  @run compile -g HelloWorld.java
  *  @run build LaunchCommandLine
  *
- *  @run main LaunchCommandLine
+ *  @run driver LaunchCommandLine
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/LineNumberInfo.java
+++ b/jdk/test/com/sun/jdi/LineNumberInfo.java
@@ -30,7 +30,7 @@
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g LineNumberInfo.java ControlFlow.java
  *
- *  @run main LineNumberInfo
+ *  @run driver LineNumberInfo
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/LineNumberOnBraceTest.java
+++ b/jdk/test/com/sun/jdi/LineNumberOnBraceTest.java
@@ -7,7 +7,7 @@
  *
  *  @run build VMConnection TargetListener TargetAdapter
  *  @run compile -g LineNumberOnBraceTest.java
- *  @run main LineNumberOnBraceTest
+ *  @run driver LineNumberOnBraceTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/LocalVariableEqual.java
+++ b/jdk/test/com/sun/jdi/LocalVariableEqual.java
@@ -30,7 +30,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g LocalVariableEqual.java
- *  @run main LocalVariableEqual
+ *  @run driver LocalVariableEqual
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/LocationTest.java
+++ b/jdk/test/com/sun/jdi/LocationTest.java
@@ -30,7 +30,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g LocationTest.java
- *  @run main LocationTest
+ *  @run driver LocationTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/MethodEntryExitEvents.java
+++ b/jdk/test/com/sun/jdi/MethodEntryExitEvents.java
@@ -29,9 +29,9 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g MethodEntryExitEvents.java
- *  @run main MethodEntryExitEvents SUSPEND_EVENT_THREAD MethodEntryExitEventsDebugee
- *  @run main MethodEntryExitEvents SUSPEND_NONE MethodEntryExitEventsDebugee
- *  @run main MethodEntryExitEvents SUSPEND_ALL MethodEntryExitEventsDebugee
+ *  @run driver MethodEntryExitEvents SUSPEND_EVENT_THREAD MethodEntryExitEventsDebugee
+ *  @run driver MethodEntryExitEvents SUSPEND_NONE MethodEntryExitEventsDebugee
+ *  @run driver MethodEntryExitEvents SUSPEND_ALL MethodEntryExitEventsDebugee
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/MethodExitReturnValuesTest.java
+++ b/jdk/test/com/sun/jdi/MethodExitReturnValuesTest.java
@@ -29,7 +29,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g MethodExitReturnValuesTest.java
- *  @run main MethodExitReturnValuesTest
+ *  @run driver MethodExitReturnValuesTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/ModificationWatchpoints.java
+++ b/jdk/test/com/sun/jdi/ModificationWatchpoints.java
@@ -31,7 +31,7 @@
  *
  *  @run build JDIScaffold VMConnection
  *  @run compile -g ModificationWatchpoints.java
- *  @run main/othervm ModificationWatchpoints
+ *  @run driver ModificationWatchpoints
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/MonitorEventTest.java
+++ b/jdk/test/com/sun/jdi/MonitorEventTest.java
@@ -30,7 +30,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g MonitorEventTest.java
- *  @run main MonitorEventTest
+ *  @run driver MonitorEventTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/MonitorFrameInfo.java
+++ b/jdk/test/com/sun/jdi/MonitorFrameInfo.java
@@ -31,7 +31,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g MonitorFrameInfo.java
- *  @run main MonitorFrameInfo
+ *  @run driver MonitorFrameInfo
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/MultiBreakpointsTest.java
+++ b/jdk/test/com/sun/jdi/MultiBreakpointsTest.java
@@ -31,7 +31,7 @@
  *
  *  @build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g MultiBreakpointsTest.java
- *  @run main MultiBreakpointsTest
+ *  @run driver MultiBreakpointsTest
  */
 
 /*

--- a/jdk/test/com/sun/jdi/NativeInstanceFilter.java
+++ b/jdk/test/com/sun/jdi/NativeInstanceFilter.java
@@ -30,7 +30,7 @@
  *
  *  @run build JDIScaffold VMConnection
  *  @compile -XDignore.symbol.file NativeInstanceFilterTarg.java
- *  @run main/othervm NativeInstanceFilter
+ *  @run driver NativeInstanceFilter
  */
 
 /*

--- a/jdk/test/com/sun/jdi/NewInstanceTest.java
+++ b/jdk/test/com/sun/jdi/NewInstanceTest.java
@@ -31,7 +31,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g NewInstanceTest.java
- *  @run main NewInstanceTest
+ *  @run driver NewInstanceTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/NoLaunchOptionTest.java
+++ b/jdk/test/com/sun/jdi/NoLaunchOptionTest.java
@@ -29,7 +29,7 @@
  *
  *  @run compile -g NoLaunchOptionTest.java
  *  @build VMConnection
- *  @run main/othervm NoLaunchOptionTest
+ *  @run driver NoLaunchOptionTest
  */
 
 import java.net.ServerSocket;

--- a/jdk/test/com/sun/jdi/NoLocInfoTest.java
+++ b/jdk/test/com/sun/jdi/NoLocInfoTest.java
@@ -31,7 +31,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g:none NoLocInfoTest.java
- *  @run main NoLocInfoTest
+ *  @run driver NoLocInfoTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/NullThreadGroupNameTest.java
+++ b/jdk/test/com/sun/jdi/NullThreadGroupNameTest.java
@@ -27,7 +27,7 @@
  *  @summary Ensure that JDWP doesn't crash with a null thread group name
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
- *  @run main NullThreadGroupNameTest
+ *  @run driver NullThreadGroupNameTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.connect.*;

--- a/jdk/test/com/sun/jdi/OnThrowTest.java
+++ b/jdk/test/com/sun/jdi/OnThrowTest.java
@@ -30,7 +30,7 @@
  *  @run compile -g OnThrowTest.java
  *  @run compile -g OnThrowTarget.java
  *  @run compile -g VMConnection.java
- *  @run main/othervm OnThrowTest
+ *  @run driver OnThrowTest
  */
 
 import java.io.File;

--- a/jdk/test/com/sun/jdi/OptionTest.java
+++ b/jdk/test/com/sun/jdi/OptionTest.java
@@ -30,7 +30,7 @@
  *  @run compile -g OptionTest.java
  *  @run compile -g HelloWorld.java
  *  @run compile -g VMConnection.java
- *  @run main/othervm OptionTest
+ *  @run driver OptionTest
  */
 
 import java.net.ServerSocket;

--- a/jdk/test/com/sun/jdi/PopAndInvokeTest.java
+++ b/jdk/test/com/sun/jdi/PopAndInvokeTest.java
@@ -31,7 +31,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g PopAndInvokeTest.java
- *  @run main PopAndInvokeTest
+ *  @run driver PopAndInvokeTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/PopAndStepTest.java
+++ b/jdk/test/com/sun/jdi/PopAndStepTest.java
@@ -10,7 +10,7 @@
  *  @library ..
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g PopAndStepTest.java
- *  @run main PopAndStepTest
+ *  @run driver PopAndStepTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/PopAsynchronousTest.java
+++ b/jdk/test/com/sun/jdi/PopAsynchronousTest.java
@@ -31,7 +31,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g PopAsynchronousTest.java
- *  @run main PopAsynchronousTest
+ *  @run driver PopAsynchronousTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/PopSynchronousTest.java
+++ b/jdk/test/com/sun/jdi/PopSynchronousTest.java
@@ -31,7 +31,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g PopSynchronousTest.java
- *  @run main PopSynchronousTest
+ *  @run driver PopSynchronousTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/RedefineCrossEvent.java
+++ b/jdk/test/com/sun/jdi/RedefineCrossEvent.java
@@ -46,26 +46,26 @@
  *  @run compile -g RepStepTarg.java
  *  @run compile -g RequestReflectionTest.java
  *
- *  @run main AccessSpecifierTest -redefstart -redefevent
- *  @run main AfterThreadDeathTest -redefstart -redefevent
- *  @run main ArrayRangeTest -redefstart -redefevent
- *  @run main BacktraceFieldTest -redefstart -redefevent
- *  @run main ClassesByName2Test -redefstart -redefevent
- *  @run main DebuggerThreadTest -redefstart -redefevent
- *  @run main DeleteEventRequestsTest -redefstart -redefevent
- *  @run main/othervm ExceptionEvents -redefstart -redefevent N A StackOverflowCaughtTarg java.lang.Exception
- *  @run main/othervm ExceptionEvents -redefstart -redefevent C A StackOverflowCaughtTarg null
- *  @run main/othervm ExceptionEvents -redefstart -redefevent C A StackOverflowCaughtTarg java.lang.StackOverflowError
- *  @run main/othervm ExceptionEvents -redefstart -redefevent N A StackOverflowCaughtTarg java.lang.NullPointerException
- *  @run main/othervm ExceptionEvents -redefstart -redefevent C T StackOverflowCaughtTarg java.lang.Error
- *  @run main/othervm ExceptionEvents -redefstart -redefevent N T StackOverflowCaughtTarg java.lang.NullPointerException
- *  @run main/othervm ExceptionEvents -redefstart -redefevent N N StackOverflowCaughtTarg java.lang.Exception
- *  @run main/othervm ExceptionEvents -redefstart -redefevent C N StackOverflowCaughtTarg java.lang.Error
- *  @run main/othervm ExceptionEvents -redefstart -redefevent N A StackOverflowUncaughtTarg java.lang.Exception
- *  @run main ExpiredRequestDeletionTest -redefstart -redefevent
- *  @run main/othervm FieldWatchpoints -redefstart -redefevent
- *  @run main/othervm InstanceFilter -redefstart -redefevent
- *  @run main LocationTest -redefstart -redefevent
- *  @run main NewInstanceTest -redefstart -redefevent
- *  @run main RequestReflectionTest -redefstart -redefevent
+ *  @run driver AccessSpecifierTest -redefstart -redefevent
+ *  @run driver AfterThreadDeathTest -redefstart -redefevent
+ *  @run driver ArrayRangeTest -redefstart -redefevent
+ *  @run driver BacktraceFieldTest -redefstart -redefevent
+ *  @run driver ClassesByName2Test -redefstart -redefevent
+ *  @run driver DebuggerThreadTest -redefstart -redefevent
+ *  @run driver DeleteEventRequestsTest -redefstart -redefevent
+ *  @run driver ExceptionEvents -redefstart -redefevent N A StackOverflowCaughtTarg java.lang.Exception
+ *  @run driver ExceptionEvents -redefstart -redefevent C A StackOverflowCaughtTarg null
+ *  @run driver ExceptionEvents -redefstart -redefevent C A StackOverflowCaughtTarg java.lang.StackOverflowError
+ *  @run driver ExceptionEvents -redefstart -redefevent N A StackOverflowCaughtTarg java.lang.NullPointerException
+ *  @run driver ExceptionEvents -redefstart -redefevent C T StackOverflowCaughtTarg java.lang.Error
+ *  @run driver ExceptionEvents -redefstart -redefevent N T StackOverflowCaughtTarg java.lang.NullPointerException
+ *  @run driver ExceptionEvents -redefstart -redefevent N N StackOverflowCaughtTarg java.lang.Exception
+ *  @run driver ExceptionEvents -redefstart -redefevent C N StackOverflowCaughtTarg java.lang.Error
+ *  @run driver ExceptionEvents -redefstart -redefevent N A StackOverflowUncaughtTarg java.lang.Exception
+ *  @run driver ExpiredRequestDeletionTest -redefstart -redefevent
+ *  @run driver FieldWatchpoints -redefstart -redefevent
+ *  @run driver InstanceFilter -redefstart -redefevent
+ *  @run driver LocationTest -redefstart -redefevent
+ *  @run driver NewInstanceTest -redefstart -redefevent
+ *  @run driver RequestReflectionTest -redefstart -redefevent
  */

--- a/jdk/test/com/sun/jdi/RedefineCrossStart.java
+++ b/jdk/test/com/sun/jdi/RedefineCrossStart.java
@@ -37,13 +37,13 @@
  *  @run compile -g FramesTest.java
  *  @run compile -g InvokeTest.java
  *
- *  @run main CountEvent -redefstart
- *  @run main CountFilterTest -redefstart
- *  @run main FramesTest -redefstart
- *  @run main InvokeTest -redefstart
+ *  @run driver CountEvent -redefstart
+ *  @run driver CountFilterTest -redefstart
+ *  @run driver FramesTest -redefstart
+ *  @run driver InvokeTest -redefstart
  *
- *  @run main/othervm ExceptionEvents -redefstart U A StackOverflowUncaughtTarg null
- *  @run main/othervm ExceptionEvents -redefstart U A StackOverflowUncaughtTarg java.lang.Error
- *  @run main/othervm ExceptionEvents -redefstart U A StackOverflowUncaughtTarg java.lang.StackOverflowError
- *  @run main PopSynchronousTest -redefstart
+ *  @run driver ExceptionEvents -redefstart U A StackOverflowUncaughtTarg null
+ *  @run driver ExceptionEvents -redefstart U A StackOverflowUncaughtTarg java.lang.Error
+ *  @run driver ExceptionEvents -redefstart U A StackOverflowUncaughtTarg java.lang.StackOverflowError
+ *  @run driver PopSynchronousTest -redefstart
  */

--- a/jdk/test/com/sun/jdi/ReferrersTest.java
+++ b/jdk/test/com/sun/jdi/ReferrersTest.java
@@ -29,7 +29,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g ReferrersTest.java
- *  @run main ReferrersTest
+ *  @run driver ReferrersTest
  */
 
 /*

--- a/jdk/test/com/sun/jdi/RepStep.java
+++ b/jdk/test/com/sun/jdi/RepStep.java
@@ -29,7 +29,7 @@
  *  @run compile -g RepStepTarg.java
  *  @run build VMConnection RepStep
  *
- *  @run main/othervm RepStep
+ *  @run driver RepStep
  *
  * @summary RepStep detects missed step events due to lack of
  * frame pop events (in back-end).

--- a/jdk/test/com/sun/jdi/RequestReflectionTest.java
+++ b/jdk/test/com/sun/jdi/RequestReflectionTest.java
@@ -28,7 +28,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g RequestReflectionTest.java
- *  @run main RequestReflectionTest
+ *  @run driver RequestReflectionTest
  *
  *  @summary RequestReflectionTest checks to see that reflective
  *  accessors on EventRequests return what they are given.

--- a/jdk/test/com/sun/jdi/ResumeOneThreadTest.java
+++ b/jdk/test/com/sun/jdi/ResumeOneThreadTest.java
@@ -30,7 +30,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g ResumeOneThreadTest.java
- *  @run main ResumeOneThreadTest
+ *  @run driver ResumeOneThreadTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/RunToExit.java
+++ b/jdk/test/com/sun/jdi/RunToExit.java
@@ -26,7 +26,7 @@
  * @summary Test that with server=y, when VM runs to System.exit() no error happens
  *
  * @build VMConnection RunToExit Exit0
- * @run main/othervm RunToExit
+ * @run driver RunToExit
  */
 import java.io.InputStream;
 import java.io.IOException;

--- a/jdk/test/com/sun/jdi/SDENullTest.java
+++ b/jdk/test/com/sun/jdi/SDENullTest.java
@@ -30,7 +30,7 @@
  *
  *  @run build  TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g SDENullTest.java
- *  @run main SDENullTest
+ *  @run driver SDENullTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/SimulResumerTest.java
+++ b/jdk/test/com/sun/jdi/SimulResumerTest.java
@@ -30,7 +30,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g SimulResumerTest.java
- *  @run main/othervm SimulResumerTest
+ *  @run driver SimulResumerTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/SourceNameFilterTest.java
+++ b/jdk/test/com/sun/jdi/SourceNameFilterTest.java
@@ -30,9 +30,9 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g SourceNameFilterTest.java
- *  @run main SourceNameFilterTest
+ *  @run driver SourceNameFilterTest
  *  @run compile -g:none SourceNameFilterTest.java
- *  @run main SourceNameFilterTest
+ *  @run driver SourceNameFilterTest
  */
 // The compile -g:none suppresses the lineNumber table to trigger bug 6646613.
 

--- a/jdk/test/com/sun/jdi/StepTest.java
+++ b/jdk/test/com/sun/jdi/StepTest.java
@@ -51,15 +51,15 @@
  *                     |  |    |  +--- Debuggee command Line
  *                     V  V    V  V      Workaround-----+
  *                                                      V
- *  @run main StepTest 2 line  2 MethodCalls
- *  @run main StepTest 3 line 14 MethodCalls
+ *  @run driver StepTest 2 line  2 MethodCalls
+ *  @run driver StepTest 3 line 14 MethodCalls
  *
- *  @run main StepTest 2 line 18 MethodCallsReflection  12
+ *  @run driver StepTest 2 line 18 MethodCallsReflection  12
  *
- *  @run main StepTest 2 min   4 MethodCalls
- *  @run main StepTest 3 min  43 MethodCalls
+ *  @run driver StepTest 2 min   4 MethodCalls
+ *  @run driver StepTest 3 min  43 MethodCalls
  *
- *  @run main StepTest 2 line 65 ControlFlow            64
+ *  @run driver StepTest 2 line 65 ControlFlow            64
  */
 
 /*

--- a/jdk/test/com/sun/jdi/SuspendThreadTest.java
+++ b/jdk/test/com/sun/jdi/SuspendThreadTest.java
@@ -30,7 +30,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g SuspendThreadTest.java
- *  @run main SuspendThreadTest
+ *  @run driver SuspendThreadTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/TemplateTest.java
+++ b/jdk/test/com/sun/jdi/TemplateTest.java
@@ -33,7 +33,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g TemplateTest.java
- *  @run main TemplateTest
+ *  @run driver TemplateTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/ThreadGroupTest.java
+++ b/jdk/test/com/sun/jdi/ThreadGroupTest.java
@@ -30,7 +30,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile ThreadGroupTest.java
- *  @run main ThreadGroupTest
+ *  @run driver ThreadGroupTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.connect.*;

--- a/jdk/test/com/sun/jdi/TwoThreadsTest.java
+++ b/jdk/test/com/sun/jdi/TwoThreadsTest.java
@@ -30,7 +30,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g TwoThreadsTest.java
- *  @run main TwoThreadsTest
+ *  @run driver TwoThreadsTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/UTF8Test.java
+++ b/jdk/test/com/sun/jdi/UTF8Test.java
@@ -30,7 +30,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g UTF8Test.java
- *  @run main UTF8Test
+ *  @run driver UTF8Test
  */
 
 /*

--- a/jdk/test/com/sun/jdi/UnpreparedByName.java
+++ b/jdk/test/com/sun/jdi/UnpreparedByName.java
@@ -32,7 +32,7 @@
  *  @run compile -g InnerTarg.java
  *  @run build UnpreparedByName
  *
- *  @run main UnpreparedByName InnerTarg
+ *  @run driver UnpreparedByName InnerTarg
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/UnpreparedClasses.java
+++ b/jdk/test/com/sun/jdi/UnpreparedClasses.java
@@ -32,7 +32,7 @@
  *  @run compile -g InnerTarg.java
  *  @run build UnpreparedClasses
  *
- *  @run main UnpreparedClasses InnerTarg
+ *  @run driver UnpreparedClasses InnerTarg
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/VMConnection.java
+++ b/jdk/test/com/sun/jdi/VMConnection.java
@@ -52,61 +52,23 @@ class VMConnection {
 
         // When we run under jtreg, test.classes contains the pathname of
         // the dir in which the .class files will be placed.
-        BufferedReader reader;
         String testClasses = System.getProperty("test.classes");
         if (testClasses == null) {
             return retVal;
         }
-        retVal += "-classpath " + testClasses + " ";
-        File myFile = new File(testClasses, "@debuggeeVMOptions");
+        retVal += "-classpath " + testClasses;
 
-        if (!myFile.canRead()) {
-            // Not there - look in parent (in case we are in a subdir)
-            myFile = new File(testClasses);
-            String parentDir = myFile.getParent();
-            if (parentDir != null) {
-                myFile = new File(parentDir, "@debuggeeVMOptions");
-                if (!myFile.canRead()) {
-                    return retVal;
-                }
-            }
+        String vmOpts = System.getProperty("test.vm.opts");
+        System.out.println("vmOpts: "+vmOpts);
+        if (vmOpts != null) {
+            retVal += " " + vmOpts;
         }
-        String wholePath = myFile.getPath();
-        try {
-            reader = new BufferedReader(new FileReader(myFile));
-        } catch (FileNotFoundException ee) {
-            System.out.println("-- Error 2 trying to access file " +
-                               wholePath + ": " + ee);
-            return retVal;
+        String javaOpts = System.getProperty("test.java.opts");
+        System.out.println("javaOpts: "+javaOpts);
+        if (javaOpts != null) {
+            retVal += " " + javaOpts;
         }
 
-        String line;
-        while (true) {
-            try {
-                line = reader.readLine();
-            } catch (IOException ee) {
-                System.out.println("-- Error reading options from file " +
-                                   wholePath + ": " + ee);
-                break;
-            }
-            if (line == null) {
-                System.out.println("-- No debuggee VM options found in file " +
-                                   wholePath);
-                break;
-            }
-            line = line.trim();
-            if (line.length() != 0 && !line.startsWith("#")) {
-                System.out.println("-- Added debuggeeVM options from file " +
-                                   wholePath + ": " + line);
-                retVal += line;
-                break;
-            }
-            // Else, read he next line.
-        }
-        try {
-            reader.close();
-        } catch (IOException ee) {
-        }
         return retVal;
     }
 

--- a/jdk/test/com/sun/jdi/VMDeathLastTest.java
+++ b/jdk/test/com/sun/jdi/VMDeathLastTest.java
@@ -31,7 +31,7 @@
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g HelloWorld.java
  *  @run build VMDeathLastTest
- *  @run main VMDeathLastTest
+ *  @run driver VMDeathLastTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/VMDeathRequestTest.java
+++ b/jdk/test/com/sun/jdi/VMDeathRequestTest.java
@@ -29,7 +29,7 @@
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g HelloWorld.java
  *  @run build VMDeathRequestTest
- *  @run main VMDeathRequestTest
+ *  @run driver VMDeathRequestTest
  *
  * @summary VMDeathRequestTest checks to see that
  * VMDisconnectedException is never thrown before VMDisconnectEvent.

--- a/jdk/test/com/sun/jdi/VarargsTest.java
+++ b/jdk/test/com/sun/jdi/VarargsTest.java
@@ -30,7 +30,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g VarargsTest.java
- *  @run main VarargsTest
+ *  @run driver VarargsTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/Vars.java
+++ b/jdk/test/com/sun/jdi/Vars.java
@@ -29,7 +29,7 @@
  *
  *  @run build JDIScaffold VMConnection
  *  @run compile -g Vars.java
- *  @run main/othervm Vars
+ *  @run driver Vars
  */
 
 import com.sun.jdi.*;

--- a/jdk/test/com/sun/jdi/VisibleMethods.java
+++ b/jdk/test/com/sun/jdi/VisibleMethods.java
@@ -30,7 +30,7 @@
  *
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g VisibleMethods.java
- *  @run main VisibleMethods
+ *  @run driver VisibleMethods
  */
 import com.sun.jdi.Method;
 import com.sun.jdi.ReferenceType;

--- a/jdk/test/com/sun/jdi/redefine/RedefineTest.java
+++ b/jdk/test/com/sun/jdi/redefine/RedefineTest.java
@@ -34,7 +34,7 @@
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g RedefineTest.java
  *  @run shell RedefineSetUp.sh
- *  @run main/othervm RedefineTest
+ *  @run driver RedefineTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/redefineMethod/RedefineTest.java
+++ b/jdk/test/com/sun/jdi/redefineMethod/RedefineTest.java
@@ -32,8 +32,8 @@
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter
  *  @run compile -g RedefineTest.java
  *  @run shell RedefineSetUp.sh
- *  @run main RedefineTest -repeat 3
- *  @run main RedefineTest
+ *  @run driver RedefineTest -repeat 3
+ *  @run driver RedefineTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/sde/FilterMangleTest.java
+++ b/jdk/test/com/sun/jdi/sde/FilterMangleTest.java
@@ -9,21 +9,21 @@
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter InstallSDE
  *  @run compile FilterMangleTest.java
  *  @run compile -g onion/pickle/Mangle.java
- *  @run main FilterMangleTest
- *  @run main FilterMangleTest SDE-pMangle.java*
- *  @run main FilterMangleTest SDE-pMangle.jav*
- *  @run main FilterMangleTest SDE-pMangle.j*
- *  @run main FilterMangleTest SDE-p*Mangle.java
- *  @run main FilterMangleTest SDE-p*angle.java
- *  @run main FilterMangleTest SDE-p*java
- *  @run main FilterMangleTest SDE-pMangle.xyz
- *  @run main FilterMangleTest SDE-pIncl.rats*
- *  @run main FilterMangleTest SDE-pIncl.rat*
- *  @run main FilterMangleTest SDE-p*angle.rats
- *  @run main FilterMangleTest SDE-f*Incl.rat
- *  @run main FilterMangleTest SDE-ffred
- *  @run main FilterMangleTest SDE-f*ratsx
- *  @run main FilterMangleTest SDE-fMangle.javax*
+ *  @run driver FilterMangleTest
+ *  @run driver FilterMangleTest SDE-pMangle.java*
+ *  @run driver FilterMangleTest SDE-pMangle.jav*
+ *  @run driver FilterMangleTest SDE-pMangle.j*
+ *  @run driver FilterMangleTest SDE-p*Mangle.java
+ *  @run driver FilterMangleTest SDE-p*angle.java
+ *  @run driver FilterMangleTest SDE-p*java
+ *  @run driver FilterMangleTest SDE-pMangle.xyz
+ *  @run driver FilterMangleTest SDE-pIncl.rats*
+ *  @run driver FilterMangleTest SDE-pIncl.rat*
+ *  @run driver FilterMangleTest SDE-p*angle.rats
+ *  @run driver FilterMangleTest SDE-f*Incl.rat
+ *  @run driver FilterMangleTest SDE-ffred
+ *  @run driver FilterMangleTest SDE-f*ratsx
+ *  @run driver FilterMangleTest SDE-fMangle.javax*
  */
 
 /*

--- a/jdk/test/com/sun/jdi/sde/MangleStepTest.java
+++ b/jdk/test/com/sun/jdi/sde/MangleStepTest.java
@@ -10,11 +10,11 @@
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter InstallSDE
  *  @run compile MangleStepTest.java
  *  @run compile -g  onion/pickle/Mangle.java
- *  @run main/othervm MangleStepTest unset
- *  @run main/othervm MangleStepTest Java
- *  @run main/othervm MangleStepTest XYZ
- *  @run main/othervm MangleStepTest Rats
- *  @run main/othervm MangleStepTest bogus
+ *  @run driver MangleStepTest unset
+ *  @run driver MangleStepTest Java
+ *  @run driver MangleStepTest XYZ
+ *  @run driver MangleStepTest Rats
+ *  @run driver MangleStepTest bogus
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;
@@ -82,7 +82,6 @@ public class MangleStepTest extends TestScaffold {
         }
         BreakpointEvent bpe = resumeTo(targetName, "main",
                                        "([Ljava/lang/String;)V");
-        waitForInput();
 
         ThreadReference thread = bpe.thread();
 

--- a/jdk/test/com/sun/jdi/sde/MangleTest.java
+++ b/jdk/test/com/sun/jdi/sde/MangleTest.java
@@ -10,7 +10,7 @@
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter InstallSDE
  *  @run compile MangleTest.java
  *  @run compile -g onion/pickle/Mangle.java
- *  @run main MangleTest
+ *  @run driver MangleTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/sde/SourceDebugExtensionTest.java
+++ b/jdk/test/com/sun/jdi/sde/SourceDebugExtensionTest.java
@@ -10,7 +10,7 @@
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter InstallSDE
  *  @run compile SourceDebugExtensionTest.java
  *  @run compile -g SourceDebugExtensionTarg.java
- *  @run main SourceDebugExtensionTest
+ *  @run driver SourceDebugExtensionTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;

--- a/jdk/test/com/sun/jdi/sde/TemperatureTableTest.java
+++ b/jdk/test/com/sun/jdi/sde/TemperatureTableTest.java
@@ -10,7 +10,7 @@
  *  @run build TestScaffold VMConnection TargetListener TargetAdapter InstallSDE HelloWorld
  *  @run compile TemperatureTableTest.java
  *  @run compile -g TemperatureTableServlet.java
- *  @run main TemperatureTableTest
+ *  @run driver TemperatureTableTest
  */
 import com.sun.jdi.*;
 import com.sun.jdi.event.*;


### PR DESCRIPTION
Hi all,

I would like to backport this patch to improve test maintainability.
Currently, hotspot tests require jtreg 4.2 b13 or newer. Therefore, even if TEST.ROOT of the jdk test does not specify a required minimum jtreg version, it is unlikely that jdk tests will be run with a version of jtreg which does not support -vmoption.
Given this, the @debuggeeVMOptions mechanism can be safely removed.
The patch is almost clean. Only difference is that DoubleAgentTest.java is skipped because the fix is alreaday in another patch.

There is a related patch JDK-8048892, and I have proposed a separate backport for it. #493 
Additionally, when JDK-8054066 was backported, a @debuggeeVMOptions file was added to the original patch. I plan to propose an issue regarding the modification of that test once this fix is approved.

Testing: All tests under jdk/test/com/sun/jdi

Thank you.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-6622468](https://bugs.openjdk.org/browse/JDK-6622468) needs maintainer approval

### Issue
 * [JDK-6622468](https://bugs.openjdk.org/browse/JDK-6622468): TEST_BUG: Time to retire the @<!---->debuggeeVMOptions mechanism used in the com.sun.jdi infrastructure (**Bug** - P4 - Requested)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/492/head:pull/492` \
`$ git checkout pull/492`

Update a local copy of the PR: \
`$ git checkout pull/492` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/492/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 492`

View PR using the GUI difftool: \
`$ git pr show -t 492`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/492.diff">https://git.openjdk.org/jdk8u-dev/pull/492.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/492#issuecomment-2098302448)
</details>
