### PR TITLE
8331791: [8u] AIX build break from JDK-8320005 backport

### DIFF
--- a/hotspot/src/os/aix/vm/os_aix.cpp
+++ b/hotspot/src/os/aix/vm/os_aix.cpp
@@ -1497,7 +1497,7 @@ void *os::dll_load(const char *filename, char *ebuf, int ebuflen) {
     snprintf(pointer_to_dot, sizeof(old_extension), "%s", new_extension);
     result = dll_load_library(file_path, ebuf, ebuflen);
   }
-  FREE_C_HEAP_ARRAY(char, file_path);
+  FREE_C_HEAP_ARRAY(char, file_path, mtInternal);
   return result;
 }
 

--- a/hotspot/src/os/aix/vm/os_aix.cpp
+++ b/hotspot/src/os/aix/vm/os_aix.cpp
@@ -1452,7 +1452,7 @@ bool os::dll_address_to_library_name(address addr, char* buf,
 
 // Loads .dll/.so and in case of error it checks if .dll/.so was built
 // for the same architecture as Hotspot is running on.
-static void*  dll_load_library(const char *filename, char *ebuf, int ebuflen) {
+static void* dll_load_library(const char *filename, char *ebuf, int ebuflen) {
 
   if (ebuf && ebuflen > 0) {
     ebuf[0] = '\0';

--- a/hotspot/src/os/aix/vm/os_aix.cpp
+++ b/hotspot/src/os/aix/vm/os_aix.cpp
@@ -1452,7 +1452,7 @@ bool os::dll_address_to_library_name(address addr, char* buf,
 
 // Loads .dll/.so and in case of error it checks if .dll/.so was built
 // for the same architecture as Hotspot is running on.
-static void* dll_load_library(const char *filename, char *ebuf, int ebuflen) {
+static void*  dll_load_library(const char *filename, char *ebuf, int ebuflen) {
 
   if (ebuf && ebuflen > 0) {
     ebuf[0] = '\0';
@@ -1480,10 +1480,11 @@ static void* dll_load_library(const char *filename, char *ebuf, int ebuflen) {
   }
   return NULL;
 }
+
 // Load library named <filename>
 // If filename matches <name>.so, and loading fails, repeat with <name>.a.
 void *os::dll_load(const char *filename, char *ebuf, int ebuflen) {
-  void* result = nullptr;
+  void* result = NULL;
   char* const file_path = strdup(filename);
   char* const pointer_to_dot = strrchr(file_path, '.');
   const char old_extension[] = ".so";
@@ -1493,7 +1494,7 @@ void *os::dll_load(const char *filename, char *ebuf, int ebuflen) {
   result = dll_load_library(filename, ebuf, ebuflen);
   // If the load fails,we try to reload by changing the extension to .a for .so files only.
   // Shared object in .so format dont have braces, hence they get removed for archives with members.
-  if (result == nullptr && pointer_to_dot != nullptr && strcmp(pointer_to_dot, old_extension) == 0) {
+  if (result == NULL && pointer_to_dot != NULL && strcmp(pointer_to_dot, old_extension) == 0) {
     snprintf(pointer_to_dot, sizeof(old_extension), "%s", new_extension);
     result = dll_load_library(file_path, ebuf, ebuflen);
   }


### PR DESCRIPTION
c1c8064
introduces a new call to the macro FREE_C_HEAP_ARRAY
but is not using the correct number of arguments.
jdk8u FREE_C_HEAP_ARRAY takes 3 arguments
JBS-ISSUE: [JDK-8331791](https://bugs.openjdk.org/browse/JDK-8331791)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8331791](https://bugs.openjdk.org/browse/JDK-8331791) needs maintainer approval

### Issue
 * [JDK-8331791](https://bugs.openjdk.org/browse/JDK-8331791): [8u] AIX build break from JDK-8320005 backport (**Bug** - P1 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/494/head:pull/494` \
`$ git checkout pull/494`

Update a local copy of the PR: \
`$ git checkout pull/494` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/494/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 494`

View PR using the GUI difftool: \
`$ git pr show -t 494`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/494.diff">https://git.openjdk.org/jdk8u-dev/pull/494.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/494#issuecomment-2099961274)