### PR TITLE
8239965: XMLEncoder/Test4625418.java fails due to "Error: Cp943 - can't read properly"

### DIFF
--- a/jdk/test/java/beans/XMLEncoder/Test4625418.java
+++ b/jdk/test/java/beans/XMLEncoder/Test4625418.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 4625418
+ * @bug 4625418 8239965
  * @summary Tests XML <a href="http://download.java.net/jdk6/docs/technotes/guides/intl/encoding.doc.html">encoding</a>
  * @author Sergey Malenkov
  * @run main/timeout=360 Test4625418
@@ -126,7 +126,7 @@ public final class Test4625418 implements ExceptionListener {
         //"Cp939",
         //"Cp942",
         //"Cp942C",
-        "Cp943",
+        //"Cp943",
         //"Cp943C",
         "Cp948",
         "Cp949",
@@ -307,7 +307,7 @@ public final class Test4625418 implements ExceptionListener {
         //"x-IBM939",
         //"x-IBM942",
         //"x-IBM942C",
-        "x-IBM943",
+        //"x-IBM943",
         //"x-IBM943C",
         "x-IBM948",
         "x-IBM949",


### PR DESCRIPTION
This is a backport PR which needs to go along [JDK-8235834](https://bugs.openjdk.org/browse/JDK-8235834). As I'm backporting JDK-8235834, so need to backport this change as well [JDK-8239965](https://bugs.openjdk.org/browse/JDK-8239965).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8239965](https://bugs.openjdk.org/browse/JDK-8239965) needs maintainer approval

### Issue
 * [JDK-8239965](https://bugs.openjdk.org/browse/JDK-8239965): XMLEncoder/Test4625418.java fails due to "Error: Cp943 - can't read properly" (**Bug** - P4 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/500/head:pull/500` \
`$ git checkout pull/500`

Update a local copy of the PR: \
`$ git checkout pull/500` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/500/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 500`

View PR using the GUI difftool: \
`$ git pr show -t 500`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/500.diff">https://git.openjdk.org/jdk8u-dev/pull/500.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/500#issuecomment-2115188419)