### PR TITLE
8328825: Google CAInterop test failures

### DIFF
--- a/jdk/test/ProblemList.txt
+++ b/jdk/test/ProblemList.txt
@@ -390,9 +390,4 @@ sample/chatserver/ChatTest.java					8178912 generic-all
 
 ############################################################################
 security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#certignarootca         8331883 generic-all
-security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#globalsigneccrootcar4  8328825 generic-all
-security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#gtsrootcar1            8328825 generic-all
-security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#gtsrootcar2            8328825 generic-all
-security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#gtsrootecccar3         8328825 generic-all
-security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#gtsrootecccar4         8328825 generic-all
 security/infra/java/security/cert/CertPathValidator/certification/LuxTrustCA.java                       8314509 generic-all

--- a/jdk/test/security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java
+++ b/jdk/test/security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java
@@ -207,8 +207,7 @@
  * @summary Interoperability tests with Google's GlobalSign R4 and GTS Root certificates
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop globalsigneccrootcar4 OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop globalsigneccrootcar4 CRL
+ * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop globalsigneccrootcar4 DEFAULT
  */
 
 /*
@@ -217,8 +216,7 @@
  * @summary Interoperability tests with Google's GlobalSign R4 and GTS Root certificates
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop gtsrootcar1 OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop gtsrootcar1 CRL
+ * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop gtsrootcar1 DEFAULT
  */
 
 /*
@@ -227,8 +225,7 @@
  * @summary Interoperability tests with Google's GlobalSign R4 and GTS Root certificates
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop gtsrootcar2 OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop gtsrootcar2 CRL
+ * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop gtsrootcar2 DEFAULT
  */
 
 /*
@@ -237,8 +234,7 @@
  * @summary Interoperability tests with Google's GlobalSign R4 and GTS Root certificates
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop gtsrootecccar3 OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop gtsrootecccar3 CRL
+ * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop gtsrootecccar3 DEFAULT
  */
 
 /*
@@ -247,8 +243,7 @@
  * @summary Interoperability tests with Google's GlobalSign R4 and GTS Root certificates
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop gtsrootecccar4 OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop gtsrootecccar4 CRL
+ * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop gtsrootecccar4 DEFAULT
  */
 
 /*


### PR DESCRIPTION
Backport fixes Google cert failures in CAInterop test. Only updates test. Changeset applied cleanly (with fixed file path). It additionally removes appropriate entries from ProblemList.txt (these are JDK8 only).

Testing:
Relevant tests pass testing. (other ones are not regressions to master, see also: https://github.com/openjdk/jdk8u-dev/pull/502)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8328825](https://bugs.openjdk.org/browse/JDK-8328825) needs maintainer approval

### Issue
 * [JDK-8328825](https://bugs.openjdk.org/browse/JDK-8328825): Google CAInterop test failures (**Bug** - P3 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/503/head:pull/503` \
`$ git checkout pull/503`

Update a local copy of the PR: \
`$ git checkout pull/503` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/503/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 503`

View PR using the GUI difftool: \
`$ git pr show -t 503`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/503.diff">https://git.openjdk.org/jdk8u-dev/pull/503.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/503#issuecomment-2122876940)