### PR TITLE
8333669: [8u] GHA: Dead VS2010 download link

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -867,6 +867,8 @@ jobs:
       VS2010_DIR: "${{ fromJson(needs.prerequisites.outputs.dependencies).VS2010_DIR }}"
       VS2010_FILENAME: "${{ fromJson(needs.prerequisites.outputs.dependencies).VS2010_FILENAME }}"
       VS2010_URL: "${{ fromJson(needs.prerequisites.outputs.dependencies).VS2010_URL }}"
+      VS2010_TORRENT_URL: "${{ fromJson(needs.prerequisites.outputs.dependencies).VS2010_TORRENT_URL }}"
+      VS2010_TORRENT_DIR: "${{ fromJson(needs.prerequisites.outputs.dependencies).VS2010_TORRENT_DIR }}"
       VS2010_SHA256: "${{ fromJson(needs.prerequisites.outputs.dependencies).VS2010_SHA256 }}"
 
     steps:
@@ -933,10 +935,11 @@ jobs:
       - name: Download and unpack Visual Studio 2010
         run: |
           mkdir "$HOME\$env:VS2010_DIR"
-          & curl -L "$env:VS2010_URL" -o "$HOME/$env:VS2010_FILENAME"
-          $FileHash = Get-FileHash -Algorithm SHA256 "$HOME/$env:VS2010_FILENAME"
+          $ImagePath = "$HOME/$env:VS2010_TORRENT_DIR/$env:VS2010_FILENAME"
+          & aria2c -d "$HOME" --seed-time=0 --bt-stop-timeout=300 "$env:VS2010_TORRENT_URL" || & curl -L "$env:VS2010_URL" -o "$ImagePath" --create-dirs
+          $FileHash = Get-FileHash -Algorithm SHA256 "$ImagePath"
           $FileHash.Hash -eq $env:VS2010_SHA256
-          & 7z x -o"$HOME/$env:VS2010_DIR" "$HOME/$env:VS2010_FILENAME"
+          & 7z x -o"$HOME/$env:VS2010_DIR" "$ImagePath"
           & dir "$HOME/$env:VS2010_DIR"
         if: steps.vs2010.outputs.cache-hit != 'true'
 

--- a/make/conf/test-dependencies
+++ b/make/conf/test-dependencies
@@ -31,7 +31,9 @@ JTREG_BUILD=b01
 
 VS2010_FILENAME=VS2010Express1.iso
 VS2010_DIR=VS2010Express1
-VS2010_URL=https://debian.fmi.uni-sofia.bg/~aangelov/VS2010Express1.iso
+VS2010_URL=https://archive.org/download/vs-2010-express-1/VS2010Express1.iso
+VS2010_TORRENT_URL=https://archive.org/download/vs-2010-express-1/vs-2010-express-1_archive.torrent
+VS2010_TORRENT_DIR=vs-2010-express-1
 VS2010_SHA256=a9d5dcdf55e539a06547a8ebbc63d55dc167113e09ee9e42096ab9098313039b
 
 VS2017_FILENAME=vs2017.exe


### PR DESCRIPTION
Switches VS2010 download link back to `archive.org`, as currently used link no longer works. ( I currently don't know about better mirror. ) Http download from archive.org is slow, but I have found [they also offer torrent](https://archive.org/details/vs-2010-express-1), which is much faster. So torrent, with fallback to http, is used.

Affects GHA testing only. Fixes windows x86 builds.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8333669](https://bugs.openjdk.org/browse/JDK-8333669) needs maintainer approval

### Issue
 * [JDK-8333669](https://bugs.openjdk.org/browse/JDK-8333669): [8u] GHA: Dead VS2010 download link (**Bug** - P4 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/513/head:pull/513` \
`$ git checkout pull/513`

Update a local copy of the PR: \
`$ git checkout pull/513` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/513/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 513`

View PR using the GUI difftool: \
`$ git pr show -t 513`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/513.diff">https://git.openjdk.org/jdk8u-dev/pull/513.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/513#issuecomment-2150657652)