### PR TITLE
8279164: Disable TLS_ECDH_* cipher suites

### DIFF
--- a/jdk/src/share/lib/security/java.security-aix
+++ b/jdk/src/share/lib/security/java.security-aix
@@ -703,7 +703,8 @@ jdk.jar.disabledAlgorithms=MD2, MD5, RSA keySize < 1024, \
 # Example:
 #   jdk.tls.disabledAlgorithms=MD5, SSLv3, DSA, RSA keySize < 2048
 jdk.tls.disabledAlgorithms=SSLv3, TLSv1, TLSv1.1, RC4, DES, MD5withRSA, \
-    DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL, ECDH, \
+    DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL, \
+    ECDH, \
     include jdk.disabled.namedCurves
 
 # Legacy algorithms for Secure Socket Layer/Transport Layer Security (SSL/TLS)

--- a/jdk/src/share/lib/security/java.security-aix
+++ b/jdk/src/share/lib/security/java.security-aix
@@ -703,7 +703,7 @@ jdk.jar.disabledAlgorithms=MD2, MD5, RSA keySize < 1024, \
 # Example:
 #   jdk.tls.disabledAlgorithms=MD5, SSLv3, DSA, RSA keySize < 2048
 jdk.tls.disabledAlgorithms=SSLv3, TLSv1, TLSv1.1, RC4, DES, MD5withRSA, \
-    DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL, \
+    DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL, ECDH, \
     include jdk.disabled.namedCurves
 
 # Legacy algorithms for Secure Socket Layer/Transport Layer Security (SSL/TLS)

--- a/jdk/src/share/lib/security/java.security-linux
+++ b/jdk/src/share/lib/security/java.security-linux
@@ -703,7 +703,8 @@ jdk.jar.disabledAlgorithms=MD2, MD5, RSA keySize < 1024, \
 # Example:
 #   jdk.tls.disabledAlgorithms=MD5, SSLv3, DSA, RSA keySize < 2048
 jdk.tls.disabledAlgorithms=SSLv3, TLSv1, TLSv1.1, RC4, DES, MD5withRSA, \
-    DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL, ECDH, \
+    DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL, \
+    ECDH, \
     include jdk.disabled.namedCurves
 
 # Legacy algorithms for Secure Socket Layer/Transport Layer Security (SSL/TLS)

--- a/jdk/src/share/lib/security/java.security-linux
+++ b/jdk/src/share/lib/security/java.security-linux
@@ -703,7 +703,7 @@ jdk.jar.disabledAlgorithms=MD2, MD5, RSA keySize < 1024, \
 # Example:
 #   jdk.tls.disabledAlgorithms=MD5, SSLv3, DSA, RSA keySize < 2048
 jdk.tls.disabledAlgorithms=SSLv3, TLSv1, TLSv1.1, RC4, DES, MD5withRSA, \
-    DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL, \
+    DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL, ECDH, \
     include jdk.disabled.namedCurves
 
 # Legacy algorithms for Secure Socket Layer/Transport Layer Security (SSL/TLS)

--- a/jdk/src/share/lib/security/java.security-macosx
+++ b/jdk/src/share/lib/security/java.security-macosx
@@ -706,7 +706,7 @@ jdk.jar.disabledAlgorithms=MD2, MD5, RSA keySize < 1024, \
 # Example:
 #   jdk.tls.disabledAlgorithms=MD5, SSLv3, DSA, RSA keySize < 2048
 jdk.tls.disabledAlgorithms=SSLv3, TLSv1, TLSv1.1, RC4, DES, MD5withRSA, \
-    DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL, \
+    DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL, ECDH, \
     include jdk.disabled.namedCurves
 
 # Legacy algorithms for Secure Socket Layer/Transport Layer Security (SSL/TLS)

--- a/jdk/src/share/lib/security/java.security-macosx
+++ b/jdk/src/share/lib/security/java.security-macosx
@@ -706,7 +706,8 @@ jdk.jar.disabledAlgorithms=MD2, MD5, RSA keySize < 1024, \
 # Example:
 #   jdk.tls.disabledAlgorithms=MD5, SSLv3, DSA, RSA keySize < 2048
 jdk.tls.disabledAlgorithms=SSLv3, TLSv1, TLSv1.1, RC4, DES, MD5withRSA, \
-    DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL, ECDH, \
+    DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL, \
+    ECDH, \
     include jdk.disabled.namedCurves
 
 # Legacy algorithms for Secure Socket Layer/Transport Layer Security (SSL/TLS)

--- a/jdk/src/share/lib/security/java.security-solaris
+++ b/jdk/src/share/lib/security/java.security-solaris
@@ -704,7 +704,7 @@ jdk.jar.disabledAlgorithms=MD2, MD5, RSA keySize < 1024, \
 # Example:
 #   jdk.tls.disabledAlgorithms=MD5, SSLv3, DSA, RSA keySize < 2048
 jdk.tls.disabledAlgorithms=SSLv3, TLSv1, TLSv1.1, RC4, DES, MD5withRSA, \
-    DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL, \
+    DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL, ECDH, \
     include jdk.disabled.namedCurves
 
 # Legacy algorithms for Secure Socket Layer/Transport Layer Security (SSL/TLS)

--- a/jdk/src/share/lib/security/java.security-solaris
+++ b/jdk/src/share/lib/security/java.security-solaris
@@ -704,7 +704,8 @@ jdk.jar.disabledAlgorithms=MD2, MD5, RSA keySize < 1024, \
 # Example:
 #   jdk.tls.disabledAlgorithms=MD5, SSLv3, DSA, RSA keySize < 2048
 jdk.tls.disabledAlgorithms=SSLv3, TLSv1, TLSv1.1, RC4, DES, MD5withRSA, \
-    DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL, ECDH, \
+    DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL, \
+    ECDH, \
     include jdk.disabled.namedCurves
 
 # Legacy algorithms for Secure Socket Layer/Transport Layer Security (SSL/TLS)

--- a/jdk/src/share/lib/security/java.security-windows
+++ b/jdk/src/share/lib/security/java.security-windows
@@ -706,7 +706,7 @@ jdk.jar.disabledAlgorithms=MD2, MD5, RSA keySize < 1024, \
 # Example:
 #   jdk.tls.disabledAlgorithms=MD5, SSLv3, DSA, RSA keySize < 2048
 jdk.tls.disabledAlgorithms=SSLv3, TLSv1, TLSv1.1, RC4, DES, MD5withRSA, \
-    DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL, \
+    DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL, ECDH, \
     include jdk.disabled.namedCurves
 
 # Legacy algorithms for Secure Socket Layer/Transport Layer Security (SSL/TLS)

--- a/jdk/src/share/lib/security/java.security-windows
+++ b/jdk/src/share/lib/security/java.security-windows
@@ -706,7 +706,8 @@ jdk.jar.disabledAlgorithms=MD2, MD5, RSA keySize < 1024, \
 # Example:
 #   jdk.tls.disabledAlgorithms=MD5, SSLv3, DSA, RSA keySize < 2048
 jdk.tls.disabledAlgorithms=SSLv3, TLSv1, TLSv1.1, RC4, DES, MD5withRSA, \
-    DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL, ECDH, \
+    DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL, \
+    ECDH, \
     include jdk.disabled.namedCurves
 
 # Legacy algorithms for Secure Socket Layer/Transport Layer Security (SSL/TLS)

--- a/jdk/test/javax/net/ssl/sanity/ciphersuites/CheckCipherSuites.java
+++ b/jdk/test/javax/net/ssl/sanity/ciphersuites/CheckCipherSuites.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 4750141 4895631 8217579 8163326
+ * @bug 4750141 4895631 8217579 8163326 8279164
  * @summary Check enabled and supported ciphersuites are correct
  * @run main/othervm CheckCipherSuites default
  * @run main/othervm CheckCipherSuites limited
@@ -46,51 +46,35 @@ public class CheckCipherSuites {
         "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
         "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
 
-        // AES_256(GCM) - ECDHE - forward screcy
+        // AES_256(GCM) - ECDHE - forward secrecy
         "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
 
-        // AES_128(GCM) - ECDHE - forward screcy
+        // AES_128(GCM) - ECDHE - forward secrecy
         "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
 
-        // AES_256(GCM) - DHE - forward screcy
+        // AES_256(GCM) - DHE - forward secrecy
         "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
         "TLS_DHE_DSS_WITH_AES_256_GCM_SHA384",
 
-        // AES_128(GCM) - DHE - forward screcy
+        // AES_128(GCM) - DHE - forward secrecy
         "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
         "TLS_DHE_DSS_WITH_AES_128_GCM_SHA256",
 
-        // AES_256(CBC) - ECDHE - forward screcy
+        // AES_256(CBC) - ECDHE - forward secrecy
         "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
         "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
 
-        // AES_256(CBC) - ECDHE - forward screcy
+        // AES_256(CBC) - ECDHE - forward secrecy
         "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
         "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
 
-        // AES_256(CBC) - DHE - forward screcy
+        // AES_256(CBC) - DHE - forward secrecy
         "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256",
         "TLS_DHE_DSS_WITH_AES_256_CBC_SHA256",
 
-        // AES_128(CBC) - DHE - forward screcy
+        // AES_128(CBC) - DHE - forward secrecy
         "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256",
         "TLS_DHE_DSS_WITH_AES_128_CBC_SHA256",
-
-        // AES_256(GCM) - not forward screcy
-        "TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384",
-
-        // AES_128(GCM) - not forward screcy
-        "TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256",
-
-        // AES_256(CBC) - not forward screcy
-        "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384",
-        "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384",
-
-        // AES_128(CBC) - not forward screcy
-        "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256",
-        "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256",
 
         // AES_256(CBC) - ECDHE - using SHA
         "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
@@ -107,14 +91,6 @@ public class CheckCipherSuites {
         // AES_128(CBC) - DHE - using SHA
         "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
         "TLS_DHE_DSS_WITH_AES_128_CBC_SHA",
-
-        // AES_256(CBC) - using SHA, not forward screcy
-        "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA",
-        "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA",
-
-        // AES_128(CBC) - using SHA, not forward screcy
-        "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA",
-        "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA",
 
         // deprecated
         "TLS_RSA_WITH_AES_256_GCM_SHA384",
@@ -138,16 +114,10 @@ public class CheckCipherSuites {
         "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
         "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256",
         "TLS_DHE_DSS_WITH_AES_128_CBC_SHA256",
-        "TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256",
-        "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256",
         "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
         "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
         "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
         "TLS_DHE_DSS_WITH_AES_128_CBC_SHA",
-        "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA",
-        "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA",
         "TLS_RSA_WITH_AES_128_GCM_SHA256",
         "TLS_RSA_WITH_AES_128_CBC_SHA256",
         "TLS_RSA_WITH_AES_128_CBC_SHA",
@@ -165,51 +135,35 @@ public class CheckCipherSuites {
         "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
         "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
 
-        // AES_256(GCM) - ECDHE - forward screcy
+        // AES_256(GCM) - ECDHE - forward secrecy
         "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
 
-        // AES_128(GCM) - ECDHE - forward screcy
+        // AES_128(GCM) - ECDHE - forward secrecy
         "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
 
-        // AES_256(GCM) - DHE - forward screcy
+        // AES_256(GCM) - DHE - forward secrecy
         "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
         "TLS_DHE_DSS_WITH_AES_256_GCM_SHA384",
 
-        // AES_128(GCM) - DHE - forward screcy
+        // AES_128(GCM) - DHE - forward secrecy
         "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
         "TLS_DHE_DSS_WITH_AES_128_GCM_SHA256",
 
-        // AES_256(CBC) - ECDHE - forward screcy
+        // AES_256(CBC) - ECDHE - forward secrecy
         "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
         "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
 
-        // AES_256(CBC) - ECDHE - forward screcy
+        // AES_256(CBC) - ECDHE - forward secrecy
         "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
         "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
 
-        // AES_256(CBC) - DHE - forward screcy
+        // AES_256(CBC) - DHE - forward secrecy
         "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256",
         "TLS_DHE_DSS_WITH_AES_256_CBC_SHA256",
 
-        // AES_128(CBC) - DHE - forward screcy
+        // AES_128(CBC) - DHE - forward secrecy
         "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256",
         "TLS_DHE_DSS_WITH_AES_128_CBC_SHA256",
-
-        // AES_256(GCM) - not forward screcy
-        "TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384",
-
-        // AES_128(GCM) - not forward screcy
-        "TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256",
-
-        // AES_256(CBC) - not forward screcy
-        "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384",
-        "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384",
-
-        // AES_128(CBC) - not forward screcy
-        "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256",
-        "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256",
 
         // AES_256(CBC) - ECDHE - using SHA
         "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
@@ -226,14 +180,6 @@ public class CheckCipherSuites {
         // AES_128(CBC) - DHE - using SHA
         "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
         "TLS_DHE_DSS_WITH_AES_128_CBC_SHA",
-
-        // AES_256(CBC) - using SHA, not forward screcy
-        "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA",
-        "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA",
-
-        // AES_128(CBC) - using SHA, not forward screcy
-        "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA",
-        "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA",
 
         // deprecated
         "TLS_RSA_WITH_AES_256_GCM_SHA384",
@@ -257,16 +203,10 @@ public class CheckCipherSuites {
         "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
         "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256",
         "TLS_DHE_DSS_WITH_AES_128_CBC_SHA256",
-        "TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256",
-        "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256",
         "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
         "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
         "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
         "TLS_DHE_DSS_WITH_AES_128_CBC_SHA",
-        "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA",
-        "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA",
         "TLS_RSA_WITH_AES_128_GCM_SHA256",
         "TLS_RSA_WITH_AES_128_CBC_SHA256",
         "TLS_RSA_WITH_AES_128_CBC_SHA",


### PR DESCRIPTION
Backport disables `TLS_ECDH_*` cipher suites.

Not clean. Differences:
- there is more than one `java.security` file on 8u (one per system), because it does not have [JDK-6997010](https://bugs.openjdk.org/browse/JDK-6997010) (Consolidate java.security files into one file with modifications)
- changeset to `test/jdk/javax/net/ssl/DTLS/CipherSuite.java` is excluded, as there is no equivalent test on 8u, support for DTLS was only added in 9 by [JDK-8043758](https://bugs.openjdk.org/browse/JDK-8043758) (JEP 219: Datagram Transport Layer Security (DTLS))
- Parts of changeset to remaining files had to be done by hand, because of some context differences, as there are some intermediate changes not backported to 8u. (e.g. [JDK-8163327](https://bugs.openjdk.org/browse/JDK-8163327) (Remove 3DES from the default enabled cipher suites list)) 

Testing:
tier1: OK (only [known](https://bugs.openjdk.org/browse/JDK-8333788) CAInterop failures)
jdk_security: [OK](https://github.com/zzambers/jdk8u-dev/actions/runs/9466037907) (tested with modified GHA on top, modified security tests (by backport) passed, no regressions to [master](https://github.com/zzambers/jdk8u-dev/actions/runs/9467711902))

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8279164](https://bugs.openjdk.org/browse/JDK-8279164) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8332812](https://bugs.openjdk.org/browse/JDK-8332812) to be approved

### Issues
 * [JDK-8279164](https://bugs.openjdk.org/browse/JDK-8279164): Disable TLS_ECDH_* cipher suites (**Enhancement** - P3 - Approved)
 * [JDK-8332812](https://bugs.openjdk.org/browse/JDK-8332812): Disable TLS_ECDH_* cipher suites (**CSR**)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)
 * [Martin Balao](https://openjdk.org/census#mbalao) (@martinuy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/519/head:pull/519` \
`$ git checkout pull/519`

Update a local copy of the PR: \
`$ git checkout pull/519` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/519/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 519`

View PR using the GUI difftool: \
`$ git pr show -t 519`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/519.diff">https://git.openjdk.org/jdk8u-dev/pull/519.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/519#issuecomment-2161237022)