### PR TITLE
8330415: Update system property for Java SE specification maintenance version

### DIFF
--- a/jdk/src/share/native/java/lang/System.c
+++ b/jdk/src/share/native/java/lang/System.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -215,7 +215,7 @@ Java_java_lang_System_initProperties(JNIEnv *env, jclass cla, jobject props)
     PUTPROP(props, "java.specification.version",
             JDK_MAJOR_VERSION "." JDK_MINOR_VERSION);
     PUTPROP(props, "java.specification.maintenance.version",
-            "5");
+            "6");
     PUTPROP(props, "java.specification.name",
             "Java Platform API Specification");
     PUTPROP(props, "java.specification.vendor",


### PR DESCRIPTION
Please review this PR which is a backport of https://github.com/openjdk/jdk8u-ri/commit/bda97a28e0d0830b3c07b33482c4d6a99524af99.
This is a trivial increment of the `"java.specification.maintenance.version"` system property value from 5 to 6.
Associated GHA run: https://github.com/justin-curtis-lu/jdk8u-dev/actions/runs/9354657529.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8330415](https://bugs.openjdk.org/browse/JDK-8330415) needs maintainer approval

### Issue
 * [JDK-8330415](https://bugs.openjdk.org/browse/JDK-8330415): Update system property for Java SE specification maintenance version (**Enhancement** - P4 - Approved)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/521/head:pull/521` \
`$ git checkout pull/521`

Update a local copy of the PR: \
`$ git checkout pull/521` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/521/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 521`

View PR using the GUI difftool: \
`$ git pr show -t 521`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/521.diff">https://git.openjdk.org/jdk8u-dev/pull/521.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/521#issuecomment-2174382781)