### PR TITLE
6544871: java/awt/event/KeyEvent/KeyTyped/CtrlASCII.html fails from jdk b09 on windows.

### DIFF
--- a/jdk/test/java/awt/event/KeyEvent/KeyTyped/CtrlASCII.java
+++ b/jdk/test/java/awt/event/KeyEvent/KeyTyped/CtrlASCII.java
@@ -257,8 +257,12 @@ public class CtrlASCII extends Applet implements KeyListener
     }// start()
     public void punchCtrlKey( Robot ro, int keyCode ) {
         ro.keyPress(KeyEvent.VK_CONTROL);
-        ro.keyPress(keyCode);
-        ro.keyRelease(keyCode);
+        try {
+            ro.keyPress(keyCode);
+            ro.keyRelease(keyCode);
+        }catch(IllegalArgumentException iae) {
+            System.err.println("skip probably invalid keyCode "+keyCode);
+        }
         ro.keyRelease(KeyEvent.VK_CONTROL);
         ro.delay(200);
     }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [791267a0](https://github.com/openjdk/jdk/commit/791267a0961353693ad6a92d888675b2e2837edc) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Yuri Nesterenko on 31 Jul 2015 and was reviewed by Sergey Bylokhov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-6544871](https://bugs.openjdk.org/browse/JDK-6544871) needs maintainer approval

### Issue
 * [JDK-6544871](https://bugs.openjdk.org/browse/JDK-6544871): java/awt/event/KeyEvent/KeyTyped/CtrlASCII.html fails from jdk b09 on windows. (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/524/head:pull/524` \
`$ git checkout pull/524`

Update a local copy of the PR: \
`$ git checkout pull/524` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/524/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 524`

View PR using the GUI difftool: \
`$ git pr show -t 524`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/524.diff">https://git.openjdk.org/jdk8u-dev/pull/524.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/524#issuecomment-2191184456)