### PR TITLE
8334905: [8u] The test java/awt/Mixing/AWT_Mixing/JButtonOverlapping.java started to fail after 8159690

### DIFF
--- a/jdk/test/java/awt/Mixing/AWT_Mixing/JButtonOverlapping.java
+++ b/jdk/test/java/awt/Mixing/AWT_Mixing/JButtonOverlapping.java
@@ -33,6 +33,7 @@ import javax.swing.*;
  * @key headful
  * @summary Simple Overlapping test for javax.swing.JButton
  * @author sergey.grinev@oracle.com: area=awt.mixing
+ * @library ../../regtesthelpers
  * @build Util
  * @run main JButtonOverlapping
  */


### PR DESCRIPTION
The missed line in the test is restored.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8334905](https://bugs.openjdk.org/browse/JDK-8334905) needs maintainer approval

### Issue
 * [JDK-8334905](https://bugs.openjdk.org/browse/JDK-8334905): [8u] The test java/awt/Mixing/AWT_Mixing/JButtonOverlapping.java started to fail after 8159690 (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/525/head:pull/525` \
`$ git checkout pull/525`

Update a local copy of the PR: \
`$ git checkout pull/525` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/525/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 525`

View PR using the GUI difftool: \
`$ git pr show -t 525`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/525.diff">https://git.openjdk.org/jdk8u-dev/pull/525.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/525#issuecomment-2187680779)