### PR TITLE
8152207: Perform array bound checks while getting a length of bytecode instructions

### DIFF
--- a/hotspot/src/share/vm/interpreter/bytecodes.hpp
+++ b/hotspot/src/share/vm/interpreter/bytecodes.hpp
@@ -394,15 +394,16 @@ class Bytecodes: AllStatic {
   static Code       non_breakpoint_code_at(const Method* method, address bcp);
 
   // Bytecode attributes
-  static bool        is_defined     (int  code)    { return 0 <= code && code < number_of_codes && flags(code, false) != 0; }
+  static bool        is_valid       (int  code)    { return 0 <= code && code < number_of_codes; }
+  static bool        is_defined     (int  code)    { return is_valid(code) && flags(code, false) != 0; }
   static bool        wide_is_defined(int  code)    { return is_defined(code) && flags(code, true) != 0; }
   static const char* name           (Code code)    { check(code);      return _name          [code]; }
   static BasicType   result_type    (Code code)    { check(code);      return _result_type   [code]; }
   static int         depth          (Code code)    { check(code);      return _depth         [code]; }
   // Note: Length functions must return <=0 for invalid bytecodes.
   // Calling check(code) in length functions would throw an unwanted assert.
-  static int         length_for     (Code code)    { /*no check*/      return _lengths       [code] & 0xF; }
-  static int         wide_length_for(Code code)    { /*no check*/      return _lengths       [code] >> 4; }
+  static int         length_for     (Code code)    { return is_valid(code) ? _lengths[code] & 0xF : -1; }
+  static int         wide_length_for(Code code)    { return is_valid(code) ? _lengths[code]  >> 4 : -1; }
   static bool        can_trap       (Code code)    { check(code);      return has_all_flags(code, _bc_can_trap, false); }
   static Code        java_code      (Code code)    { check(code);      return _java_code     [code]; }
   static bool        can_rewrite    (Code code)    { check(code);      return has_all_flags(code, _bc_can_rewrite, false); }

--- a/jdk/src/share/native/common/check_code.c
+++ b/jdk/src/share/native/common/check_code.c
@@ -1731,9 +1731,14 @@ static int instruction_length(unsigned char *iptr, unsigned char *end)
             }
 
         default: {
+            if (instruction < 0 || instruction > JVM_OPC_MAX)
+                return -1;
+
             /* A length of 0 indicates an error. */
-            int length = opcode_length[instruction];
-            return (length <= 0) ? -1 : length;
+            if (opcode_length[instruction] <= 0)
+                return -1;
+
+            return opcode_length[instruction];
         }
     }
 }


### PR DESCRIPTION
Hi,

I'd like to propose a backport of 8152207 for 8u as this release is affected. The JDK main line patch applies almost cleanly, except for the file path and the copyright date.

Thanks,
Martin.-

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8152207](https://bugs.openjdk.org/browse/JDK-8152207) needs maintainer approval

### Issue
 * [JDK-8152207](https://bugs.openjdk.org/browse/JDK-8152207): Perform array bound checks while getting a length of bytecode instructions (**Bug** - P4 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/527/head:pull/527` \
`$ git checkout pull/527`

Update a local copy of the PR: \
`$ git checkout pull/527` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/527/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 527`

View PR using the GUI difftool: \
`$ git pr show -t 527`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/527.diff">https://git.openjdk.org/jdk8u-dev/pull/527.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/527#issuecomment-2190376167)