### PR TITLE
8327007: javax/swing/JSpinner/8008657/bug8008657.java fails

### DIFF
--- a/jdk/test/javax/swing/JSpinner/8008657/bug8008657.java
+++ b/jdk/test/javax/swing/JSpinner/8008657/bug8008657.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,6 @@ import javax.swing.SwingUtilities;
 /**
  * @test
  * @bug 8008657
- * @author Alexander Scherbatiy
  * @summary JSpinner setComponentOrientation doesn't affect on text orientation
  * @run main bug8008657
  */
@@ -122,6 +121,7 @@ public class bug8008657 {
         calendar.add(Calendar.YEAR, -1);
         Date earliestDate = calendar.getTime();
         calendar.add(Calendar.YEAR, 1);
+        calendar.add(Calendar.DAY_OF_MONTH, 1);
         Date latestDate = calendar.getTime();
         SpinnerModel dateModel = new SpinnerDateModel(initDate,
                 earliestDate,


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [b7540df6](https://github.com/openjdk/jdk/commit/b7540df6a4279c63e69d32b9d9834f7a427478d1) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Prasanta Sadhukhan on 5 Mar 2024 and was reviewed by Phil Race.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8327007](https://bugs.openjdk.org/browse/JDK-8327007) needs maintainer approval

### Issue
 * [JDK-8327007](https://bugs.openjdk.org/browse/JDK-8327007): javax/swing/JSpinner/8008657/bug8008657.java fails (**Bug** - P3 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/530/head:pull/530` \
`$ git checkout pull/530`

Update a local copy of the PR: \
`$ git checkout pull/530` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/530/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 530`

View PR using the GUI difftool: \
`$ git pr show -t 530`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/530.diff">https://git.openjdk.org/jdk8u-dev/pull/530.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/530#issuecomment-2197342328)