### PR TITLE
8335552: [8u] JDK-8303466 backport to 8u requires 3 ::Identity signature fixes

### DIFF
--- a/hotspot/make/linux/makefiles/gcc.make
+++ b/hotspot/make/linux/makefiles/gcc.make
@@ -212,7 +212,7 @@ ifeq ($(USE_CLANG), true)
   WARNINGS_ARE_ERRORS += -Wno-return-type -Wno-empty-body
 endif
 
-WARNING_FLAGS = -Wpointer-arith -Wsign-compare -Wundef -Wunused-function -Wunused-value -Wformat=2 -Wreturn-type
+WARNING_FLAGS = -Wpointer-arith -Wsign-compare -Wundef -Wunused-function -Wunused-value -Wformat=2 -Wreturn-type -Woverloaded-virtual
 
 ifeq ($(USE_CLANG),)
   # Since GCC 4.3, -Wconversion has changed its meanings to warn these implicit

--- a/hotspot/make/linux/makefiles/gcc.make
+++ b/hotspot/make/linux/makefiles/gcc.make
@@ -212,7 +212,7 @@ ifeq ($(USE_CLANG), true)
   WARNINGS_ARE_ERRORS += -Wno-return-type -Wno-empty-body
 endif
 
-WARNING_FLAGS = -Wpointer-arith -Wsign-compare -Wundef -Wunused-function -Wunused-value -Wformat=2 -Wreturn-type -Woverloaded-virtual
+WARNING_FLAGS = -Wpointer-arith -Wsign-compare -Wundef -Wunused-function -Wunused-value -Wformat=2 -Wreturn-type
 
 ifeq ($(USE_CLANG),)
   # Since GCC 4.3, -Wconversion has changed its meanings to warn these implicit

--- a/hotspot/src/share/vm/opto/addnode.cpp
+++ b/hotspot/src/share/vm/opto/addnode.cpp
@@ -1101,7 +1101,7 @@ const Type* MaxLNode::add_ring(const Type* t0, const Type* t1) const {
   return TypeLong::make(MAX2(r0->_lo, r1->_lo), MAX2(r0->_hi, r1->_hi), MAX2(r0->_widen, r1->_widen));
 }
 
-Node* MaxLNode::Identity(PhaseGVN* phase) {
+Node* MaxLNode::Identity(PhaseTransform* phase) {
   const TypeLong* t1 = phase->type(in(1))->is_long();
   const TypeLong* t2 = phase->type(in(2))->is_long();
 
@@ -1133,7 +1133,7 @@ const Type* MinLNode::add_ring(const Type* t0, const Type* t1) const {
   return TypeLong::make(MIN2(r0->_lo, r1->_lo), MIN2(r0->_hi, r1->_hi), MIN2(r0->_widen, r1->_widen));
 }
 
-Node* MinLNode::Identity(PhaseGVN* phase) {
+Node* MinLNode::Identity(PhaseTransform* phase) {
   const TypeLong* t1 = phase->type(in(1))->is_long();
   const TypeLong* t2 = phase->type(in(2))->is_long();
 

--- a/hotspot/src/share/vm/opto/addnode.hpp
+++ b/hotspot/src/share/vm/opto/addnode.hpp
@@ -292,7 +292,7 @@ public:
   virtual const Type* add_id() const { return TypeLong::make(min_jlong); }
   virtual const Type* bottom_type() const { return TypeLong::LONG; }
   virtual uint ideal_reg() const { return Op_RegL; }
-  virtual Node* Identity(PhaseGVN* phase);
+  virtual Node* Identity(PhaseTransform* phase);
   virtual Node* Ideal(PhaseGVN *phase, bool can_reshape);
 };
 
@@ -309,7 +309,7 @@ public:
   virtual const Type* add_id() const { return TypeLong::make(max_jlong); }
   virtual const Type* bottom_type() const { return TypeLong::LONG; }
   virtual uint ideal_reg() const { return Op_RegL; }
-  virtual Node* Identity(PhaseGVN* phase);
+  virtual Node* Identity(PhaseTransform* phase);
   virtual Node* Ideal(PhaseGVN* phase, bool can_reshape);
 };
 

--- a/hotspot/src/share/vm/opto/connode.cpp
+++ b/hotspot/src/share/vm/opto/connode.cpp
@@ -942,7 +942,7 @@ const Type *ConvI2LNode::Value( PhaseTransform *phase ) const {
   return tl;
 }
 
-Node* ConvI2LNode::Identity(PhaseGVN* phase) {
+Node* ConvI2LNode::Identity(PhaseTransform* phase) {
   // If type is in "int" sub-range, we can
   // convert I2L(L2I(x)) => x
   // since the conversions have no effect.

--- a/hotspot/src/share/vm/opto/connode.hpp
+++ b/hotspot/src/share/vm/opto/connode.hpp
@@ -513,7 +513,7 @@ public:
   virtual int Opcode() const;
   virtual const Type *Value( PhaseTransform *phase ) const;
   virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
-  virtual Node* Identity(PhaseGVN* phase);
+  virtual Node* Identity(PhaseTransform* phase);
   virtual uint  ideal_reg() const { return Op_RegL; }
 };
 


### PR DESCRIPTION
Hi, here is a followup fix for #529, where @wkia has noted a problem with the `MaxLNode::Identity`, `MinLNode::Identity` and `ConvI2LNode::Identity` signatures: https://github.com/openjdk/jdk8u-dev/pull/529#discussion_r1661486052.

A complimentary [JDK-8075511](https://bugs.openjdk.org/browse/JDK-8075511 "Enable -Woverloaded-virtual C++ warning for HotSpot build") backport can be found in #534.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8335552](https://bugs.openjdk.org/browse/JDK-8335552) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (3 reviews required, with at least 3 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8335552](https://bugs.openjdk.org/browse/JDK-8335552): [8u] JDK-8303466 backport to 8u requires 3 ::Identity signature fixes (**Bug** - P4 - Approved)


### Reviewers
 * [Martin Balao](https://openjdk.org/census#mbalao) (@martinuy - **Reviewer**) ⚠️ Review applies to [85db200c](https://git.openjdk.org/jdk8u-dev/pull/532/files/85db200c448580e26361cee2e91b3e580a40c70c)
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - **Reviewer**) ⚠️ Review applies to [85db200c](https://git.openjdk.org/jdk8u-dev/pull/532/files/85db200c448580e26361cee2e91b3e580a40c70c)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/532/head:pull/532` \
`$ git checkout pull/532`

Update a local copy of the PR: \
`$ git checkout pull/532` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/532/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 532`

View PR using the GUI difftool: \
`$ git pr show -t 532`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/532.diff">https://git.openjdk.org/jdk8u-dev/pull/532.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/532#issuecomment-2204289054)