### PR TITLE
8075511: Enable -Woverloaded-virtual C++ warning for HotSpot build

### DIFF
--- a/hotspot/make/linux/makefiles/gcc.make
+++ b/hotspot/make/linux/makefiles/gcc.make
@@ -212,7 +212,7 @@ ifeq ($(USE_CLANG), true)
   WARNINGS_ARE_ERRORS += -Wno-return-type -Wno-empty-body
 endif
 
-WARNING_FLAGS = -Wpointer-arith -Wsign-compare -Wundef -Wunused-function -Wunused-value -Wformat=2 -Wreturn-type
+WARNING_FLAGS = -Wpointer-arith -Wsign-compare -Wundef -Wunused-function -Wunused-value -Wformat=2 -Wreturn-type -Woverloaded-virtual
 
 ifeq ($(USE_CLANG),)
   # Since GCC 4.3, -Wconversion has changed its meanings to warn these implicit


### PR DESCRIPTION
Hi, this backport PR has been split apart from #532. The `-Woverloaded-virtual` GCC flag, in addition to the fact that warnings are treated as errors, should ensure an issue like #532 is caught next time.

In fact, the GitHub Actions' Linux builds should fail, since #532 is not yet integrated. Build log excerpt with the expected failure:

```
/usr/bin/g++ -DLINUX -D_GNU_SOURCE -DAMD64 -DPRODUCT -I. -I/home/runner/work/jdk8u-dev/jdk8u-dev/jdk/hotspot/src/share/vm/prims -I/home/runner/work/jdk8u-dev/jdk8u-dev/jdk/hotspot/src/share/vm -I/home/runner/work/jdk8u-dev/jdk8u-dev/jdk/hotspot/src/share/vm/precompiled -I/home/runner/work/jdk8u-dev/jdk8u-dev/jdk/hotspot/src/cpu/x86/vm -I/home/runner/work/jdk8u-dev/jdk8u-dev/jdk/hotspot/src/os_cpu/linux_x86/vm -I/home/runner/work/jdk8u-dev/jdk8u-dev/jdk/hotspot/src/os/linux/vm -I/home/runner/work/jdk8u-dev/jdk8u-dev/jdk/hotspot/src/os/posix/vm -I../generated -DHOTSPOT_RELEASE_VERSION="\"25.432-b00\"" -DHOTSPOT_BUILD_TARGET="\"product\"" -DHOTSPOT_BUILD_USER="\"runner\"" -DHOTSPOT_LIB_ARCH=\"amd64\" -DHOTSPOT_VM_DISTRO="\"OpenJDK\""  -DTARGET_OS_FAMILY_linux -DTARGET_ARCH_x86 -DTARGET_ARCH_MODEL_x86_64 -DTARGET_OS_ARCH_linux_x86 -DTARGET_OS_ARCH_MODEL_linux_x86_64 -DTARGET_COMPILER_gcc -DINCLUDE_JFR=1 -DCOMPILER2 -DCOMPILER1 -fPIC -fno-rtti -fno-exceptions -D_REENTRANT -fcheck-new -fvisibility=hidden -m64  -pipe -fno-strict-aliasing  -fno-omit-frame-pointer -O3  -g -DVM_LITTLE_ENDIAN -D_LP64=1 -Werror -Wpointer-arith -Wsign-compare -Wundef -Wunused-function -Wunused-value -Wformat=2 -Wreturn-type -Woverloaded-virtual   -fstack-protector  -fno-delete-null-pointer-checks -fno-lifetime-dse -std=gnu++98 -c -MMD -MP -MF ../generated/dependencies/precompiled.hpp.gch.d -fpch-deps -x c++-header /home/runner/work/jdk8u-dev/jdk8u-dev/jdk/hotspot/src/share/vm/precompiled/precompiled.hpp -o precompiled.hpp.gch 
In file included from /home/runner/work/jdk8u-dev/jdk8u-dev/jdk/hotspot/src/share/vm/precompiled/precompiled.hpp:262:
/home/runner/work/jdk8u-dev/jdk8u-dev/jdk/hotspot/src/share/vm/opto/addnode.hpp:50:17: error: ‘virtual Node* AddNode::Identity(PhaseTransform*)’ was hidden [-Werror=overloaded-virtual]
   50 |   virtual Node *Identity( PhaseTransform *phase );
      |                 ^~~~~~~~
/home/runner/work/jdk8u-dev/jdk8u-dev/jdk/hotspot/src/share/vm/opto/addnode.hpp:295:17: error:   by ‘virtual Node* MaxLNode::Identity(PhaseGVN*)’ [-Werror=overloaded-virtual]
  295 |   virtual Node* Identity(PhaseGVN* phase);
      |                 ^~~~~~~~
/home/runner/work/jdk8u-dev/jdk8u-dev/jdk/hotspot/src/share/vm/opto/addnode.hpp:50:17: error: ‘virtual Node* AddNode::Identity(PhaseTransform*)’ was hidden [-Werror=overloaded-virtual]
   50 |   virtual Node *Identity( PhaseTransform *phase );
      |                 ^~~~~~~~
/home/runner/work/jdk8u-dev/jdk8u-dev/jdk/hotspot/src/share/vm/opto/addnode.hpp:312:17: error:   by ‘virtual Node* MinLNode::Identity(PhaseGVN*)’ [-Werror=overloaded-virtual]
  312 |   virtual Node* Identity(PhaseGVN* phase);
      |                 ^~~~~~~~
In file included from /home/runner/work/jdk8u-dev/jdk8u-dev/jdk/hotspot/src/share/vm/opto/addnode.hpp:28,
                 from /home/runner/work/jdk8u-dev/jdk8u-dev/jdk/hotspot/src/share/vm/precompiled/precompiled.hpp:262:
/home/runner/work/jdk8u-dev/jdk8u-dev/jdk/hotspot/src/share/vm/opto/node.hpp:904:17: error: ‘virtual Node* Node::Identity(PhaseTransform*)’ was hidden [-Werror=overloaded-virtual]
  904 |   virtual Node *Identity( PhaseTransform *phase );
      |                 ^~~~~~~~
In file included from /home/runner/work/jdk8u-dev/jdk8u-dev/jdk/hotspot/src/share/vm/opto/callnode.hpp:28,
                 from /home/runner/work/jdk8u-dev/jdk8u-dev/jdk/hotspot/src/share/vm/precompiled/precompiled.hpp:266:
/home/runner/work/jdk8u-dev/jdk8u-dev/jdk/hotspot/src/share/vm/opto/connode.hpp:516:17: error:   by ‘virtual Node* ConvI2LNode::Identity(PhaseGVN*)’ [-Werror=overloaded-virtual]
  516 |   virtual Node* Identity(PhaseGVN* phase);
      |                 ^~~~~~~~
cc1plus: all warnings being treated as errors
make[6]: *** [/home/runner/work/jdk8u-dev/jdk8u-dev/jdk/hotspot/make/linux/makefiles/vm.make:310: precompiled.hpp.gch] Error 1
make[6]: Leaving directory '/home/runner/work/jdk8u-dev/jdk8u-dev/jdk/build/linux-x64/hotspot/linux_amd64_compiler2/product'
make[5]: *** [/home/runner/work/jdk8u-dev/jdk8u-dev/jdk/hotspot/make/linux/makefiles/top.make:119: the_vm] Error 2
make[5]: Leaving directory '/home/runner/work/jdk8u-dev/jdk8u-dev/jdk/build/linux-x64/hotspot/linux_amd64_compiler2/product'
make[4]: *** [/home/runner/work/jdk8u-dev/jdk8u-dev/jdk/hotspot/make/linux/Makefile:284: product] Error 2
make[4]: Leaving directory '/home/runner/work/jdk8u-dev/jdk8u-dev/jdk/build/linux-x64/hotspot'
make[3]: *** [Makefile:231: generic_build2] Error 2
make[3]: Leaving directory '/home/runner/work/jdk8u-dev/jdk8u-dev/jdk/hotspot/make'
make[2]: *** [Makefile:177: product] Error 2
make[2]: Leaving directory '/home/runner/work/jdk8u-dev/jdk8u-dev/jdk/hotspot/make'
make[1]: *** [HotspotWrapper.gmk:45: /home/runner/work/jdk8u-dev/jdk8u-dev/jdk/build/linux-x64/hotspot/_hotspot.timestamp] Error 2
make[1]: Leaving directory '/home/runner/work/jdk8u-dev/jdk8u-dev/jdk/make'
make: *** [/home/runner/work/jdk8u-dev/jdk8u-dev/jdk//make/Main.gmk:110: hotspot-only] Error 2
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8075511](https://bugs.openjdk.org/browse/JDK-8075511) needs maintainer approval

### Issue
 * [JDK-8075511](https://bugs.openjdk.org/browse/JDK-8075511): Enable -Woverloaded-virtual C++ warning for HotSpot build (**Enhancement** - P4 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/534/head:pull/534` \
`$ git checkout pull/534`

Update a local copy of the PR: \
`$ git checkout pull/534` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/534/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 534`

View PR using the GUI difftool: \
`$ git pr show -t 534`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/534.diff">https://git.openjdk.org/jdk8u-dev/pull/534.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/534#issuecomment-2206730145)