### PR TITLE
Backport bb3f1238cb12c45ed85936d3b06eced0730d588f

### DIFF
--- a/hotspot/src/share/vm/opto/type.cpp
+++ b/hotspot/src/share/vm/opto/type.cpp
@@ -2552,13 +2552,19 @@ TypeOopPtr::TypeOopPtr(TYPES t, PTR ptr, ciKlass* k, bool xk, ciObject* o, int o
         } else if (klass() == ciEnv::current()->Class_klass() &&
                    _offset >= InstanceMirrorKlass::offset_of_static_fields()) {
           // Static fields
-          assert(o != NULL, "must be constant");
-          ciInstanceKlass* k = o->as_instance()->java_lang_Class_klass()->as_instance_klass();
-          ciField* field = k->get_field_by_offset(_offset, true);
-          assert(field != NULL, "missing field");
-          BasicType basic_elem_type = field->layout_type();
-          _is_ptr_to_narrowoop = UseCompressedOops && (basic_elem_type == T_OBJECT ||
-                                                       basic_elem_type == T_ARRAY);
+          ciField* field = NULL;
+          if (const_oop() != NULL) {
+            ciInstanceKlass* k = const_oop()->as_instance()->java_lang_Class_klass()->as_instance_klass();
+            field = k->get_field_by_offset(_offset, true);
+          }
+          if (field != NULL) {
+            BasicType basic_elem_type = field->layout_type();
+            _is_ptr_to_narrowoop = UseCompressedOops && (basic_elem_type == T_OBJECT ||
+                                                         basic_elem_type == T_ARRAY);
+          } else {
+            // unsafe access
+            _is_ptr_to_narrowoop = UseCompressedOops;
+          }
         } else {
           // Instance fields which contains a compressed oop references.
           field = ik->get_field_by_offset(_offset, false);

--- a/hotspot/test/compiler/unsafe/TestUnsafeStaticFieldAccess.java
+++ b/hotspot/test/compiler/unsafe/TestUnsafeStaticFieldAccess.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8255466
+ * @summary unsafe access to static field causes crash
+ *
+ * @run main/bootclasspath/othervm -Xcomp -XX:CompileCommand=compileonly,TestUnsafeStaticFieldAccess::* TestUnsafeStaticFieldAccess
+ *
+ */
+
+import sun.misc.Unsafe;
+import java.lang.reflect.Field;
+
+public class TestUnsafeStaticFieldAccess {
+    private static final Unsafe UNSAFE = Unsafe.getUnsafe();
+    private static final long offset;
+    private static volatile Class<?> clazz;
+
+    private static int field;
+
+    static {
+        long o = 0;
+        for (Field f : TestUnsafeStaticFieldAccess.class.getDeclaredFields()) {
+            if (f.getName().equals("field")) {
+                o = UNSAFE.staticFieldOffset(f);
+                break;
+            }
+        }
+        offset = o;
+        clazz = TestUnsafeStaticFieldAccess.class;
+    }
+
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 12000; i++) {
+            UNSAFE.getInt(clazz, offset);
+        }
+    }
+}


### PR DESCRIPTION
Hi all
This is backport of JDK-8255466, to fixes the corner case in C2.
Patch does not apply cleanly due to in jdk8u, the jtreg tag @run main need add `bootclasspath`.
New test fails without the patch, passes with it.

Additional testing:

- [ ] linux x64 tier1/2/3 jtreg test
- [ ] linux aarch64 tier1/2/3 jtreg test