### PR TITLE
8335845: [8u] Fix hotspot/test/runtime/containers tests for jdks with symlinked conf dir

### DIFF
--- a/hotspot/test/testlibrary/com/oracle/java/testlibrary/DockerTestUtils.java
+++ b/hotspot/test/testlibrary/com/oracle/java/testlibrary/DockerTestUtils.java
@@ -30,12 +30,14 @@ import java.nio.file.Files;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.FileVisitOption;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.EnumSet;
 
 import com.oracle.java.testlibrary.Utils;
 import com.oracle.java.testlibrary.Container;
@@ -144,7 +146,7 @@ public class DockerTestUtils {
 
         // Copy JDK-under-test tree to the docker build directory.
         // This step is required for building a docker image.
-        Files.walkFileTree(jdkSrcDir, new CopyFileVisitor(jdkSrcDir, jdkDstDir));
+        Files.walkFileTree(jdkSrcDir, EnumSet.of(FileVisitOption.FOLLOW_LINKS), Integer.MAX_VALUE, new CopyFileVisitor(jdkSrcDir, jdkDstDir));
         buildDockerImage(imageName, Paths.get(Utils.TEST_SRC, dockerfile), buildDir);
     }
 


### PR DESCRIPTION
Hi all,
Fix the testcase bug, which if the tested jdk directory is symlinked, symlinks are followed when copying tested jdk.
Only change the testcase lib file, the risk is low.
This is similar to [JDK-8309138](https://bugs.openjdk.org/browse/JDK-8309138), but in jdk8u-dev repository, there is a separated DockerTestUtils.java in hotspot/test directory.

Additional testing:

- [x] hotspot/test/runtime/containers/docker

[docker-tests.log](https://github.com/user-attachments/files/16124421/docker-tests.log)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8335845](https://bugs.openjdk.org/browse/JDK-8335845) needs maintainer approval

### Issue
 * [JDK-8335845](https://bugs.openjdk.org/browse/JDK-8335845): [8u] Fix hotspot/test/runtime/containers tests for jdks with symlinked conf dir (**Bug** - P4 - Rejected)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/539/head:pull/539` \
`$ git checkout pull/539`

Update a local copy of the PR: \
`$ git checkout pull/539` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/539/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 539`

View PR using the GUI difftool: \
`$ git pr show -t 539`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/539.diff">https://git.openjdk.org/jdk8u-dev/pull/539.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/539#issuecomment-2213294993)