### PR TITLE
8335851: [8u] Test JMXStartStopTest.java fails after JDK-8334415

### DIFF
--- a/jdk/test/sun/management/jmxremote/startstop/JMXStartStopTest.java
+++ b/jdk/test/sun/management/jmxremote/startstop/JMXStartStopTest.java
@@ -765,7 +765,7 @@ public class JMXStartStopTest {
                 "jmxremote.ssl=false",
                 "jmxremote.port=" + pa.getPort1()
             );
-            testConnect(port1);
+            testConnect(pa.getPort1());
 
             jcmd(CMD_STOP);
             jcmd(CMD_START,


### PR DESCRIPTION
Hi all,
The testcase `sun/management/jmxremote/startstop/JMXStartStopTest.java` compile error after [JDK-8334415](https://bugs.openjdk.org/browse/JDK-8334415). This PR fix the testcase bug, the change has been verified, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8335851](https://bugs.openjdk.org/browse/JDK-8335851) needs maintainer approval

### Issue
 * [JDK-8335851](https://bugs.openjdk.org/browse/JDK-8335851): [8u] Test JMXStartStopTest.java fails after JDK-8334415 (**Bug** - P4 - Approved)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/541/head:pull/541` \
`$ git checkout pull/541`

Update a local copy of the PR: \
`$ git checkout pull/541` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/541/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 541`

View PR using the GUI difftool: \
`$ git pr show -t 541`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/541.diff">https://git.openjdk.org/jdk8u-dev/pull/541.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/541#issuecomment-2213485834)