### PR TITLE
8335894: [8u] Fix SupplementalJapaneseEraTest.java for jdks with symlinked conf dir

### DIFF
--- a/jdk/test/java/util/Calendar/SupplementalJapaneseEraTest.java
+++ b/jdk/test/java/util/Calendar/SupplementalJapaneseEraTest.java
@@ -39,6 +39,7 @@ import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.FileVisitOption;
 import java.text.SimpleDateFormat;
 import java.time.chrono.JapaneseChronology;
 import java.time.chrono.JapaneseDate;
@@ -52,6 +53,7 @@ import static java.util.GregorianCalendar.*;
 import java.util.Locale;
 import java.util.Properties;
 import java.util.TimeZone;
+import java.util.EnumSet;
 
 import jdk.testlibrary.ProcessTools;
 import org.testng.annotations.BeforeTest;
@@ -71,7 +73,7 @@ public class SupplementalJapaneseEraTest {
     public void prepareTestJDK() throws IOException {
         Path src = Paths.get(System.getProperty("test.jdk")).toAbsolutePath();
         Path dst = Paths.get("testjava").toAbsolutePath();
-        Files.walkFileTree(src, new CopyFileVisitor(src, dst));
+        Files.walkFileTree(src, EnumSet.of(FileVisitOption.FOLLOW_LINKS), Integer.MAX_VALUE, new CopyFileVisitor(src, dst));
     }
 
     @Test


### PR DESCRIPTION
Hi all,
Fix the testcase bug, which if the tested jdk directory is symlinked, symlinks are followed when copying tested jdk.
This is similar to [JDK-8309138](https://bugs.openjdk.org/browse/JDK-8309138).
Only change the testcase, the change has been verified, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8335894](https://bugs.openjdk.org/browse/JDK-8335894) needs maintainer approval

### Issue
 * [JDK-8335894](https://bugs.openjdk.org/browse/JDK-8335894): [8u] Fix SupplementalJapaneseEraTest.java for jdks with symlinked conf dir (**Bug** - P4 - Approved)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/542/head:pull/542` \
`$ git checkout pull/542`

Update a local copy of the PR: \
`$ git checkout pull/542` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/542/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 542`

View PR using the GUI difftool: \
`$ git pr show -t 542`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/542.diff">https://git.openjdk.org/jdk8u-dev/pull/542.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/542#issuecomment-2214465527)