### PR TITLE
8318039: GHA: Bump macOS and Xcode versions

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -1331,7 +1331,7 @@ jobs:
 
   macos_x64_build:
     name: macOS x64
-    runs-on: "macos-11"
+    runs-on: "macos-13"
     needs: prerequisites
     if: needs.prerequisites.outputs.should_run != 'false' && needs.prerequisites.outputs.platform_macos_x64 != 'false'
 
@@ -1395,10 +1395,10 @@ jobs:
         run: chmod -R a+rx ${HOME}/jtreg/
 
       - name: Install dependencies
-        run: brew install make
+        run: brew install make gawk
 
       - name: Select Xcode version
-        run: sudo xcode-select --switch /Applications/Xcode_11.7.app/Contents/Developer
+        run: sudo xcode-select --switch /Applications/Xcode_14.3.1.app/Contents/Developer
 
       - name: Configure
         run: >
@@ -1429,7 +1429,7 @@ jobs:
 
   macos_x64_test:
     name: macOS x64
-    runs-on: "macos-11"
+    runs-on: "macos-13"
     needs:
       - prerequisites
       - macos_x64_build
@@ -1512,10 +1512,10 @@ jobs:
           tar -xzf "${HOME}/jdk-macos-x64${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_osx-x64_bin${{ matrix.artifact }}.tar.gz" -C "${HOME}/jdk-macos-x64${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_osx-x64_bin${{ matrix.artifact }}"
 
       - name: Install dependencies
-        run: brew install make
+        run: brew install make gawk
 
       - name: Select Xcode version
-        run: sudo xcode-select --switch /Applications/Xcode_11.7.app/Contents/Developer
+        run: sudo xcode-select --switch /Applications/Xcode_14.3.1.app/Contents/Developer
 
       - name: Run tests
         run: >


### PR DESCRIPTION
This backport is written from scratch, as GHA workflows in jdk8u differ significantly from newer jdk versions.

Notes:
- additionally installed `gawk` to prevent build error on newer macos (see my [comment](https://github.com/openjdk/jdk17u-dev/pull/2206#issuecomment-2217722646))
- interestingly, unlike for newer jdks (11, 17), additional backports do not seem necessary to pass the build, probably build system of jdk8 is more relaxed, when it comes to warnings as errors
- fixes problem of stuck macos jobs in GHA (caused by dropping of macos-11 by GitHub)

Testing:
- macos builds pass
- there are some test failures on updated macos, probably problem in test environment, seem to be hostname related -> to be fixed (either here, or in separate PR)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8318039](https://bugs.openjdk.org/browse/JDK-8318039) needs maintainer approval

### Issue
 * [JDK-8318039](https://bugs.openjdk.org/browse/JDK-8318039): GHA: Bump macOS and Xcode versions (**Enhancement** - P4 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/544/head:pull/544` \
`$ git checkout pull/544`

Update a local copy of the PR: \
`$ git checkout pull/544` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/544/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 544`

View PR using the GUI difftool: \
`$ git pr show -t 544`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/544.diff">https://git.openjdk.org/jdk8u-dev/pull/544.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/544#issuecomment-2217972185)