### PR TITLE
8324723: GHA: Upgrade some actions to avoid deprecated Node 16

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -1621,7 +1621,7 @@ jobs:
           done
 
       - name: Upload a combined test results artifact
-        uses:  actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4
         with:
           name: test-results_${{ needs.prerequisites.outputs.bundle_id }}
           path: test-results

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -299,6 +299,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
+          name: linux-x64${{ matrix.artifact }}_testresults_${{ env.logsuffix }}
           path: ~/linux-x64${{ matrix.artifact }}_testresults_${{ env.logsuffix }}.zip
         continue-on-error: true
 
@@ -660,6 +661,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
+          name: linux-x86${{ matrix.artifact }}_testresults_${{ env.logsuffix }}
           path: ~/linux-x86${{ matrix.artifact }}_testresults_${{ env.logsuffix }}.zip
         continue-on-error: true
 
@@ -1169,6 +1171,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
+          name: windows-x64${{ matrix.artifact }}_testresults_${{ env.logsuffix }}
           path: ~/windows-x64${{ matrix.artifact }}_testresults_${{ env.logsuffix }}.zip
         continue-on-error: true
 
@@ -1326,6 +1329,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
+          name: windows-x86${{ matrix.artifact }}_testresults_${{ env.logsuffix }}
           path: ~/windows-x86${{ matrix.artifact }}_testresults_${{ env.logsuffix }}.zip
         continue-on-error: true
 
@@ -1556,6 +1560,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
+          name: macos-x64${{ matrix.artifact }}_testresults_${{ env.logsuffix }}
           path: ~/macos-x64${{ matrix.artifact }}_testresults_${{ env.logsuffix }}.zip
         continue-on-error: true
 

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -107,7 +107,7 @@ jobs:
         if: steps.check_submit.outputs.should_run != 'false' && steps.jtreg.outputs.cache-hit != 'true'
 
       - name: Store jtreg for use by later steps
-        uses:  actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4
         with:
           name: transient_jtreg_${{ steps.check_bundle_id.outputs.bundle_id }}
           path: ~/jtreg/
@@ -183,7 +183,7 @@ jobs:
           tar -czf jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin${{ matrix.artifact }}.tar.gz -C jdk/build/linux-x64/images j2sdk-image
 
       - name: Persist test bundles
-        uses:  actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4
         with:
           name: transient_jdk-linux-x64${{ matrix.artifact }}_${{ needs.prerequisites.outputs.bundle_id }}
           path: |
@@ -297,7 +297,7 @@ jobs:
 
       - name: Persist test results
         if: always()
-        uses:  actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4
         with:
           path: ~/linux-x64${{ matrix.artifact }}_testresults_${{ env.logsuffix }}.zip
         continue-on-error: true
@@ -535,7 +535,7 @@ jobs:
           tar -czf jdk-${{ env.JDK_VERSION }}-internal+0_linux-x86_bin${{ matrix.artifact }}.tar.gz -C jdk/build/linux-x86/images j2sdk-image
 
       - name: Persist test bundles
-        uses:  actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4
         with:
           name: transient_jdk-linux-x86${{ matrix.artifact }}_${{ needs.prerequisites.outputs.bundle_id }}
           path: |
@@ -658,7 +658,7 @@ jobs:
 
       - name: Persist test results
         if: always()
-        uses:  actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4
         with:
           path: ~/linux-x86${{ matrix.artifact }}_testresults_${{ env.logsuffix }}.zip
         continue-on-error: true
@@ -835,7 +835,7 @@ jobs:
         working-directory: jdk/build/windows-x64/images
 
       - name: Persist test bundles
-        uses:  actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4
         with:
           name: transient_jdk-windows-x64${{ matrix.artifact }}_${{ needs.prerequisites.outputs.bundle_id }}
           path: |
@@ -1009,7 +1009,7 @@ jobs:
         working-directory: jdk/build/windows-x86/images
 
       - name: Persist test bundles
-        uses:  actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4
         with:
           name: transient_jdk-windows-x86${{ matrix.artifact }}_${{ needs.prerequisites.outputs.bundle_id }}
           path: |
@@ -1167,7 +1167,7 @@ jobs:
 
       - name: Persist test results
         if: always()
-        uses:  actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4
         with:
           path: ~/windows-x64${{ matrix.artifact }}_testresults_${{ env.logsuffix }}.zip
         continue-on-error: true
@@ -1324,7 +1324,7 @@ jobs:
 
       - name: Persist test results
         if: always()
-        uses:  actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4
         with:
           path: ~/windows-x86${{ matrix.artifact }}_testresults_${{ env.logsuffix }}.zip
         continue-on-error: true
@@ -1421,7 +1421,7 @@ jobs:
           tar -czf jdk-${{ env.JDK_VERSION }}-internal+0_osx-x64_bin${{ matrix.artifact }}.tar.gz -C jdk/build/macos-x64/images j2sdk-image
 
       - name: Persist test bundles
-        uses:  actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4
         with:
           name: transient_jdk-macos-x64${{ matrix.artifact }}_${{ needs.prerequisites.outputs.bundle_id }}
           path: |
@@ -1554,7 +1554,7 @@ jobs:
 
       - name: Persist test results
         if: always()
-        uses:  actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4
         with:
           path: ~/macos-x64${{ matrix.artifact }}_testresults_${{ env.logsuffix }}.zip
         continue-on-error: true

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -53,7 +53,7 @@ jobs:
         if: steps.check_submit.outputs.should_run != 'false'
 
       - name: Checkout the source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: jdk
         if: steps.check_submit.outputs.should_run != 'false'
@@ -82,14 +82,14 @@ jobs:
 
       - name: Check if a jtreg image is present in the cache
         id: jtreg
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/jtreg/
           key: jtreg-${{ env.JTREG_REF }}-v1
         if: steps.check_submit.outputs.should_run != 'false'
 
       - name: Checkout the jtreg source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: "openjdk/jtreg"
           ref: ${{ env.JTREG_REF }}
@@ -107,7 +107,7 @@ jobs:
         if: steps.check_submit.outputs.should_run != 'false' && steps.jtreg.outputs.cache-hit != 'true'
 
       - name: Store jtreg for use by later steps
-        uses: actions/upload-artifact@v3
+        uses:  actions/upload-artifact@v4
         with:
           name: transient_jtreg_${{ steps.check_bundle_id.outputs.bundle_id }}
           path: ~/jtreg/
@@ -135,20 +135,20 @@ jobs:
 
     steps:
       - name: Checkout the source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: jdk
 
       - name: Restore jtreg artifact
         id: jtreg_restore
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: transient_jtreg_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jtreg/
         continue-on-error: true
 
       - name: Restore jtreg artifact (retry)
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: transient_jtreg_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jtreg/
@@ -183,7 +183,7 @@ jobs:
           tar -czf jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin${{ matrix.artifact }}.tar.gz -C jdk/build/linux-x64/images j2sdk-image
 
       - name: Persist test bundles
-        uses: actions/upload-artifact@v3
+        uses:  actions/upload-artifact@v4
         with:
           name: transient_jdk-linux-x64${{ matrix.artifact }}_${{ needs.prerequisites.outputs.bundle_id }}
           path: |
@@ -217,18 +217,18 @@ jobs:
 
     steps:
       - name: Checkout the source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Restore jtreg artifact
         id: jtreg_restore
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: transient_jtreg_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jtreg/
         continue-on-error: true
 
       - name: Restore jtreg artifact (retry)
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: transient_jtreg_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jtreg/
@@ -236,14 +236,14 @@ jobs:
 
       - name: Restore build artifacts
         id: build_restore
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: transient_jdk-linux-x64${{ matrix.artifact }}_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jdk-linux-x64${{ matrix.artifact }}
         continue-on-error: true
 
       - name: Restore build artifacts (retry)
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: transient_jdk-linux-x64${{ matrix.artifact }}_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jdk-linux-x64${{ matrix.artifact }}
@@ -297,7 +297,7 @@ jobs:
 
       - name: Persist test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses:  actions/upload-artifact@v4
         with:
           path: ~/linux-x64${{ matrix.artifact }}_testresults_${{ env.logsuffix }}.zip
         continue-on-error: true
@@ -356,7 +356,7 @@ jobs:
 
     steps:
       - name: Checkout the source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: jdk
 
@@ -384,7 +384,7 @@ jobs:
 
       - name: Cache sysroot
         id: cache-sysroot
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/sysroot-${{ matrix.debian-arch }}/
           key: sysroot-${{ matrix.debian-arch }}-${{ hashFiles('jdk/.github/workflows/submit.yml') }}
@@ -479,20 +479,20 @@ jobs:
 
     steps:
       - name: Checkout the source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: jdk
 
       - name: Restore jtreg artifact
         id: jtreg_restore
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: transient_jtreg_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jtreg/
         continue-on-error: true
 
       - name: Restore jtreg artifact (retry)
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: transient_jtreg_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jtreg/
@@ -535,7 +535,7 @@ jobs:
           tar -czf jdk-${{ env.JDK_VERSION }}-internal+0_linux-x86_bin${{ matrix.artifact }}.tar.gz -C jdk/build/linux-x86/images j2sdk-image
 
       - name: Persist test bundles
-        uses: actions/upload-artifact@v3
+        uses:  actions/upload-artifact@v4
         with:
           name: transient_jdk-linux-x86${{ matrix.artifact }}_${{ needs.prerequisites.outputs.bundle_id }}
           path: |
@@ -570,18 +570,18 @@ jobs:
 
     steps:
       - name: Checkout the source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Restore jtreg artifact
         id: jtreg_restore
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: transient_jtreg_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jtreg/
         continue-on-error: true
 
       - name: Restore jtreg artifact (retry)
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: transient_jtreg_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jtreg/
@@ -589,14 +589,14 @@ jobs:
 
       - name: Restore build artifacts
         id: build_restore
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: transient_jdk-linux-x86${{ matrix.artifact }}_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jdk-linux-x86${{ matrix.artifact }}
         continue-on-error: true
 
       - name: Restore build artifacts (retry)
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: transient_jdk-linux-x86${{ matrix.artifact }}_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jdk-linux-x86${{ matrix.artifact }}
@@ -658,7 +658,7 @@ jobs:
 
       - name: Persist test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses:  actions/upload-artifact@v4
         with:
           path: ~/linux-x86${{ matrix.artifact }}_testresults_${{ env.logsuffix }}.zip
         continue-on-error: true
@@ -693,7 +693,7 @@ jobs:
     steps:
       - name: Restore cygwin installer from cache
         id: cygwin-installer
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/cygwin/setup-x86_64.exe
           key: cygwin-installer
@@ -706,7 +706,7 @@ jobs:
 
       - name: Restore cygwin packages from cache
         id: cygwin
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/cygwin/packages
           key: cygwin-packages-${{ runner.os }}-v1
@@ -716,12 +716,12 @@ jobs:
           Start-Process -FilePath "$HOME\cygwin\setup-x86_64.exe" -ArgumentList "--quiet-mode --packages autoconf,make,zip,unzip --root $HOME\cygwin\cygwin64 --local-package-dir $HOME\cygwin\packages --site http://mirrors.kernel.org/sourceware/cygwin --no-desktop --no-shortcuts --no-startmenu --no-admin" -Wait -NoNewWindow
 
       - name: Checkout the source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: jdk
 
       - name: Checkout the FreeType source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: "freetype/freetype"
           ref: VER-2-8-1
@@ -729,7 +729,7 @@ jobs:
 
       - name: Restore boot JDK from cache
         id: bootjdk
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
           key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-${{ env.BOOT_JDK_SHA256 }}-v1
@@ -746,21 +746,21 @@ jobs:
 
       - name: Restore Visual Studio 2017 from cache
         id: vs2017
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/${{ env.VS2017_FILENAME }}
           key: vs2017
 
       - name: Restore jtreg artifact
         id: jtreg_restore
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: transient_jtreg_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jtreg/
         continue-on-error: true
 
       - name: Restore jtreg artifact (retry)
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: transient_jtreg_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jtreg/
@@ -835,7 +835,7 @@ jobs:
         working-directory: jdk/build/windows-x64/images
 
       - name: Persist test bundles
-        uses: actions/upload-artifact@v3
+        uses:  actions/upload-artifact@v4
         with:
           name: transient_jdk-windows-x64${{ matrix.artifact }}_${{ needs.prerequisites.outputs.bundle_id }}
           path: |
@@ -874,7 +874,7 @@ jobs:
     steps:
       - name: Restore cygwin installer from cache
         id: cygwin-installer
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/cygwin/setup-x86_64.exe
           key: cygwin-installer
@@ -887,7 +887,7 @@ jobs:
 
       - name: Restore cygwin packages from cache
         id: cygwin
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/cygwin/packages
           key: cygwin-packages-${{ runner.os }}-v1
@@ -897,12 +897,12 @@ jobs:
           Start-Process -FilePath "$HOME\cygwin\setup-x86_64.exe" -ArgumentList "--quiet-mode --packages autoconf,make,zip,unzip --root $HOME\cygwin\cygwin64 --local-package-dir $HOME\cygwin\packages --site http://mirrors.kernel.org/sourceware/cygwin --no-desktop --no-shortcuts --no-startmenu --no-admin" -Wait -NoNewWindow
 
       - name: Checkout the source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: jdk
 
       - name: Checkout the FreeType source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: "freetype/freetype"
           ref: VER-2-8-1
@@ -910,7 +910,7 @@ jobs:
 
       - name: Restore boot JDK from cache
         id: bootjdk
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
           key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-${{ env.BOOT_JDK_SHA256 }}-v1
@@ -927,7 +927,7 @@ jobs:
 
       - name: Restore Visual Studio 2010 from cache
         id: vs2010
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/${{ env.VS2010_DIR }}
           key: vs2010
@@ -949,14 +949,14 @@ jobs:
 
       - name: Restore jtreg artifact
         id: jtreg_restore
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: transient_jtreg_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jtreg/
         continue-on-error: true
 
       - name: Restore jtreg artifact (retry)
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: transient_jtreg_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jtreg/
@@ -1009,7 +1009,7 @@ jobs:
         working-directory: jdk/build/windows-x86/images
 
       - name: Persist test bundles
-        uses: actions/upload-artifact@v3
+        uses:  actions/upload-artifact@v4
         with:
           name: transient_jdk-windows-x86${{ matrix.artifact }}_${{ needs.prerequisites.outputs.bundle_id }}
           path: |
@@ -1046,11 +1046,11 @@ jobs:
 
     steps:
       - name: Checkout the source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Restore boot JDK from cache
         id: bootjdk
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
           key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-${{ env.BOOT_JDK_SHA256 }}-v1
@@ -1067,7 +1067,7 @@ jobs:
 
       - name: Restore cygwin installer from cache
         id: cygwin-installer
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/cygwin/setup-x86_64.exe
           key: cygwin-installer
@@ -1080,7 +1080,7 @@ jobs:
 
       - name: Restore cygwin packages from cache
         id: cygwin
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/cygwin/packages
           key: cygwin-packages-${{ runner.os }}-v1
@@ -1091,14 +1091,14 @@ jobs:
 
       - name: Restore jtreg artifact
         id: jtreg_restore
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: transient_jtreg_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jtreg/
         continue-on-error: true
 
       - name: Restore jtreg artifact (retry)
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: transient_jtreg_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jtreg/
@@ -1106,14 +1106,14 @@ jobs:
 
       - name: Restore build artifacts
         id: build_restore
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: transient_jdk-windows-x64${{ matrix.artifact }}_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jdk-windows-x64${{ matrix.artifact }}
         continue-on-error: true
 
       - name: Restore build artifacts (retry)
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: transient_jdk-windows-x64${{ matrix.artifact }}_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jdk-windows-x64${{ matrix.artifact }}
@@ -1167,7 +1167,7 @@ jobs:
 
       - name: Persist test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses:  actions/upload-artifact@v4
         with:
           path: ~/windows-x64${{ matrix.artifact }}_testresults_${{ env.logsuffix }}.zip
         continue-on-error: true
@@ -1203,11 +1203,11 @@ jobs:
 
     steps:
       - name: Checkout the source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Restore boot JDK from cache
         id: bootjdk
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
           key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-${{ env.BOOT_JDK_SHA256 }}-v1
@@ -1224,7 +1224,7 @@ jobs:
 
       - name: Restore cygwin installer from cache
         id: cygwin-installer
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/cygwin/setup-x86_64.exe
           key: cygwin-installer
@@ -1237,7 +1237,7 @@ jobs:
 
       - name: Restore cygwin packages from cache
         id: cygwin
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/cygwin/packages
           key: cygwin-packages-${{ runner.os }}-v1
@@ -1248,14 +1248,14 @@ jobs:
 
       - name: Restore jtreg artifact
         id: jtreg_restore
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: transient_jtreg_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jtreg/
         continue-on-error: true
 
       - name: Restore jtreg artifact (retry)
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: transient_jtreg_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jtreg/
@@ -1263,14 +1263,14 @@ jobs:
 
       - name: Restore build artifacts
         id: build_restore
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: transient_jdk-windows-x86${{ matrix.artifact }}_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jdk-windows-x86${{ matrix.artifact }}
         continue-on-error: true
 
       - name: Restore build artifacts (retry)
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: transient_jdk-windows-x86${{ matrix.artifact }}_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jdk-windows-x86${{ matrix.artifact }}
@@ -1324,7 +1324,7 @@ jobs:
 
       - name: Persist test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses:  actions/upload-artifact@v4
         with:
           path: ~/windows-x86${{ matrix.artifact }}_testresults_${{ env.logsuffix }}.zip
         continue-on-error: true
@@ -1356,13 +1356,13 @@ jobs:
 
     steps:
       - name: Checkout the source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: jdk
 
       - name: Restore boot JDK from cache
         id: bootjdk
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
           key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-${{ env.BOOT_JDK_SHA256 }}-v1
@@ -1378,14 +1378,14 @@ jobs:
 
       - name: Restore jtreg artifact
         id: jtreg_restore
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: transient_jtreg_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jtreg/
         continue-on-error: true
 
       - name: Restore jtreg artifact (retry)
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: transient_jtreg_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jtreg/
@@ -1421,7 +1421,7 @@ jobs:
           tar -czf jdk-${{ env.JDK_VERSION }}-internal+0_osx-x64_bin${{ matrix.artifact }}.tar.gz -C jdk/build/macos-x64/images j2sdk-image
 
       - name: Persist test bundles
-        uses: actions/upload-artifact@v3
+        uses:  actions/upload-artifact@v4
         with:
           name: transient_jdk-macos-x64${{ matrix.artifact }}_${{ needs.prerequisites.outputs.bundle_id }}
           path: |
@@ -1458,11 +1458,11 @@ jobs:
 
     steps:
       - name: Checkout the source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Restore boot JDK from cache
         id: bootjdk
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
           key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-${{ env.BOOT_JDK_SHA256 }}-v1
@@ -1478,14 +1478,14 @@ jobs:
 
       - name: Restore jtreg artifact
         id: jtreg_restore
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: transient_jtreg_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jtreg/
         continue-on-error: true
 
       - name: Restore jtreg artifact (retry)
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: transient_jtreg_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jtreg/
@@ -1493,14 +1493,14 @@ jobs:
 
       - name: Restore build artifacts
         id: build_restore
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: transient_jdk-macos-x64${{ matrix.artifact }}_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jdk-macos-x64${{ matrix.artifact }}
         continue-on-error: true
 
       - name: Restore build artifacts (retry)
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: transient_jdk-macos-x64${{ matrix.artifact }}_${{ needs.prerequisites.outputs.bundle_id }}
           path: ~/jdk-macos-x64${{ matrix.artifact }}
@@ -1554,7 +1554,7 @@ jobs:
 
       - name: Persist test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses:  actions/upload-artifact@v4
         with:
           path: ~/macos-x64${{ matrix.artifact }}_testresults_${{ env.logsuffix }}.zip
         continue-on-error: true
@@ -1576,7 +1576,7 @@ jobs:
     steps:
       - name: Determine current artifacts endpoint
         id: actions_runtime
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: "return { url: process.env['ACTIONS_RUNTIME_URL'], token: process.env['ACTIONS_RUNTIME_TOKEN'] }"
 
@@ -1599,7 +1599,7 @@ jobs:
           done
 
       - name: Fetch remaining artifacts (test results)
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: test-results
 
@@ -1616,7 +1616,7 @@ jobs:
           done
 
       - name: Upload a combined test results artifact
-        uses: actions/upload-artifact@v3
+        uses:  actions/upload-artifact@v4
         with:
           name: test-results_${{ needs.prerequisites.outputs.bundle_id }}
           path: test-results


### PR DESCRIPTION
This backport is written from scratch, as GHA workflows in jdk8u differ significantly from newer jdk versions.

This will remove all warnings about deprecated Node.js versions

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8324723](https://bugs.openjdk.org/browse/JDK-8324723) needs maintainer approval
- [x] [JDK-8315863](https://bugs.openjdk.org/browse/JDK-8315863) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8324723](https://bugs.openjdk.org/browse/JDK-8324723): GHA: Upgrade some actions to avoid deprecated Node 16 (**Enhancement** - P4 - Approved)
 * [JDK-8315863](https://bugs.openjdk.org/browse/JDK-8315863): [GHA] Update checkout action to use v4 (**Enhancement** - P4 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Zdenek Zambersky](https://openjdk.org/census#zzambers) (@zzambers - Committer) 🔄 Re-review required (review applies to [ec96589f](https://git.openjdk.org/jdk8u-dev/pull/546/files/ec96589f7246d5ca7a48d3b351791a578ebb1db0))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/546/head:pull/546` \
`$ git checkout pull/546`

Update a local copy of the PR: \
`$ git checkout pull/546` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/546/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 546`

View PR using the GUI difftool: \
`$ git pr show -t 546`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/546.diff">https://git.openjdk.org/jdk8u-dev/pull/546.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/546#issuecomment-2225328149)