### PR TITLE
8336480: [8u] Incorrect comment in bytecodeInterpreter_aarch64.inline.hpp

### DIFF
--- a/hotspot/src/cpu/aarch64/vm/bytecodeInterpreter_aarch64.inline.hpp
+++ b/hotspot/src/cpu/aarch64/vm/bytecodeInterpreter_aarch64.inline.hpp
@@ -27,7 +27,7 @@
 #ifndef CPU_AARCH64_VM_BYTECODEINTERPRETER_AARCH64_INLINE_HPP
 #define CPU_AARCH64_VM_BYTECODEINTERPRETER_AARCH64_INLINE_HPP
 
-// Inline interpreter functions for IA32
+// Inline interpreter functions for aarch64
 
 inline jfloat BytecodeInterpreter::VMfloatAdd(jfloat op1, jfloat op2) { return op1 + op2; }
 inline jfloat BytecodeInterpreter::VMfloatSub(jfloat op1, jfloat op2) { return op1 - op2; }
@@ -46,11 +46,11 @@ inline int32_t BytecodeInterpreter::VMfloatCompare(jfloat op1, jfloat op2, int32
 }
 
 inline void BytecodeInterpreter::VMmemCopy64(uint32_t to[2], const uint32_t from[2]) {
-  // x86 can do unaligned copies but not 64bits at a time
+  // aarch64 can do unaligned copies but not 64bits at a time?
   to[0] = from[0]; to[1] = from[1];
 }
 
-// The long operations depend on compiler support for "long long" on x86
+// The long operations depend on compiler support for "long long" on aarch64?
 
 inline jlong BytecodeInterpreter::VMlongAdd(jlong op1, jlong op2) {
   return op1 + op2;


### PR DESCRIPTION
Hi all,
Modify inaccurate comments in the file `hotspot/src/cpu/aarch64/vm/bytecodeInterpreter_aarch64.inline.hpp`. This file has been deleted by [JDK-8074457](https://bugs.openjdk.org/browse/JDK-8074457) in jdk9, so this incorrect comments only exists in jdk8u.
Trivial fix, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8336480](https://bugs.openjdk.org/browse/JDK-8336480) needs maintainer approval

### Issue
 * [JDK-8336480](https://bugs.openjdk.org/browse/JDK-8336480): [8u] Incorrect comment in bytecodeInterpreter_aarch64.inline.hpp (**Bug** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/550/head:pull/550` \
`$ git checkout pull/550`

Update a local copy of the PR: \
`$ git checkout pull/550` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/550/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 550`

View PR using the GUI difftool: \
`$ git pr show -t 550`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/550.diff">https://git.openjdk.org/jdk8u-dev/pull/550.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/550#issuecomment-2232126166)