### PR TITLE
Backport e03ca73dc122af84d4a5456120e5cf5fac7aed31

### DIFF
--- a/hotspot/src/share/vm/opto/type.cpp
+++ b/hotspot/src/share/vm/opto/type.cpp
@@ -2540,7 +2540,7 @@ TypeOopPtr::TypeOopPtr(TYPES t, PTR ptr, ciKlass* k, bool xk, ciObject* o, int o
       } else if (_offset == OffsetBot || _offset == OffsetTop) {
         // unsafe access
         _is_ptr_to_narrowoop = UseCompressedOops;
-      } else { // exclude unsafe ops
+      } else {
         assert(this->isa_instptr(), "must be an instance ptr.");
 
         if (klass() == ciEnv::current()->Class_klass() &&
@@ -2555,10 +2555,14 @@ TypeOopPtr::TypeOopPtr(TYPES t, PTR ptr, ciKlass* k, bool xk, ciObject* o, int o
           assert(o != NULL, "must be constant");
           ciInstanceKlass* k = o->as_instance()->java_lang_Class_klass()->as_instance_klass();
           ciField* field = k->get_field_by_offset(_offset, true);
-          assert(field != NULL, "missing field");
-          BasicType basic_elem_type = field->layout_type();
-          _is_ptr_to_narrowoop = UseCompressedOops && (basic_elem_type == T_OBJECT ||
+          if (field != NULL) {
+            BasicType basic_elem_type = field->layout_type();
+            _is_ptr_to_narrowoop = UseCompressedOops && (basic_elem_type == T_OBJECT ||
                                                        basic_elem_type == T_ARRAY);
+          } else {
+            // unsafe access
+            _is_ptr_to_narrowoop = UseCompressedOops;
+          }
         } else {
           // Instance fields which contains a compressed oop references.
           field = ik->get_field_by_offset(_offset, false);

--- a/hotspot/test/compiler/unsafe/TestMisalignedUnsafeAccess.java
+++ b/hotspot/test/compiler/unsafe/TestMisalignedUnsafeAccess.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2020 THL A29 Limited, a Tencent company. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8250825
+ * @summary "assert(field != __null) failed: missing field" in TypeOopPtr::TypeOopPt(...) with misaligned unsafe accesses
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ * @run main/othervm -XX:-TieredCompilation -Xcomp
+ *                   -XX:CompileCommand=compileonly,TestMisalignedUnsafeAccess::test* TestMisalignedUnsafeAccess
+ */
+
+import java.lang.reflect.Field;
+import jdk.internal.misc.Unsafe;
+import jdk.test.lib.Asserts;
+
+public class TestMisalignedUnsafeAccess {
+
+    private static final Unsafe UNSAFE = Unsafe.getUnsafe();;
+
+    private static short onHeapStaticMemory; // For static field testing
+    private static final Object onHeapStaticMemoryBase;
+    private static final long onHeapStaticMemoryOffset;
+
+    private short onHeapInstanceMemory; // For instance field testing
+    private static final long onHeapInstanceMemoryOffset;
+
+    static {
+        try {
+            Field staticField = TestMisalignedUnsafeAccess.class.getDeclaredField("onHeapStaticMemory");
+            onHeapStaticMemoryBase = UNSAFE.staticFieldBase(staticField);
+            onHeapStaticMemoryOffset = UNSAFE.staticFieldOffset(staticField);
+
+            Field instanceField = TestMisalignedUnsafeAccess.class.getDeclaredField("onHeapInstanceMemory");
+            onHeapInstanceMemoryOffset = UNSAFE.objectFieldOffset(instanceField);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void testStaticField() {
+        byte b1 = 0x01;
+        byte b2 = 0x02;
+
+        UNSAFE.putByte(onHeapStaticMemoryBase, onHeapStaticMemoryOffset, b1);
+        UNSAFE.putByte(onHeapStaticMemoryBase, onHeapStaticMemoryOffset + 1, b2);
+
+        Asserts.assertEquals(b1, UNSAFE.getByte(onHeapStaticMemoryBase, onHeapStaticMemoryOffset));
+        Asserts.assertEquals(b2, UNSAFE.getByte(onHeapStaticMemoryBase, onHeapStaticMemoryOffset + 1));
+    }
+
+    public static void testInstanceField() {
+        byte b1 = 0x03;
+        byte b2 = 0x04;
+        TestMisalignedUnsafeAccess obj = new TestMisalignedUnsafeAccess();
+
+        UNSAFE.putByte(obj, onHeapInstanceMemoryOffset, b1);
+        UNSAFE.putByte(obj, onHeapInstanceMemoryOffset + 1, b2);
+
+        Asserts.assertEquals(b1, UNSAFE.getByte(obj, onHeapInstanceMemoryOffset));
+        Asserts.assertEquals(b2, UNSAFE.getByte(obj, onHeapInstanceMemoryOffset + 1));
+    }
+
+    public static void main(String[] args) {
+        testStaticField();
+        testInstanceField();
+    }
+}


### PR DESCRIPTION
Hi all,
This is backport of [JDK-8250825](https://bugs.openjdk.org/browse/JDK-8250825).
Patch does not apply cleanly due to different context, before [JDK-8250825](https://bugs.openjdk.org/browse/JDK-8250825)  the  PR [JDK-8230505](https://bugs.openjdk.org/browse/JDK-8230505) change these lines, and I think [JDK-8230505](https://bugs.openjdk.org/browse/JDK-8230505) do not needed backport to jdk8u-dev.

New test fails without the patch, passes with it.

Additional testing:

- [] linux x64 tier1/2/3 jtreg test
- [] linux aarch64 tier1/2/3 jtreg test