### PR TITLE
8244966: Add .vscode to .hgignore and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /build/
 /dist/
 /.idea/
+/.vscode/
 nbproject/private/
 /webrev
 /.src-rev


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [95c0b97b](https://github.com/openjdk/jdk11u-dev/commit/95c0b97bc2bfcb686dfabc6d74424772f0f866a1) from the [openjdk/jdk11u-dev](https://git.openjdk.org/jdk11u-dev) repository.

The commit being backported was authored by SendaoYan on 30 Jul 2024 and was reviewed by Paul Hohensee.

Trivial fix but useful, no risk.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8244966](https://bugs.openjdk.org/browse/JDK-8244966) needs maintainer approval

### Issue
 * [JDK-8244966](https://bugs.openjdk.org/browse/JDK-8244966): Add .vscode to .hgignore and .gitignore (**Enhancement** - P5 - Approved)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/556/head:pull/556` \
`$ git checkout pull/556`

Update a local copy of the PR: \
`$ git checkout pull/556` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/556/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 556`

View PR using the GUI difftool: \
`$ git pr show -t 556`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/556.diff">https://git.openjdk.org/jdk8u-dev/pull/556.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/556#issuecomment-2258607662)
</details>
