### PR TITLE
8336928: GHA: Bundle artifacts removal broken

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -1579,49 +1579,38 @@ jobs:
       - macos_x64_test
 
     steps:
-      - name: Determine current artifacts endpoint
-        id: actions_runtime
-        uses: actions/github-script@v7
-        with:
-          script: "return { url: process.env['ACTIONS_RUNTIME_URL'], token: process.env['ACTIONS_RUNTIME_TOKEN'] }"
-
       - name: Display current artifacts
-        run: >
-          curl -s -H 'Accept: application/json;api-version=6.0-preview'
-          -H 'Authorization: Bearer ${{ fromJson(steps.actions_runtime.outputs.result).token }}'
-          '${{ fromJson(steps.actions_runtime.outputs.result).url }}_apis/pipelines/workflows/${{ github.run_id }}/artifacts?api-version=6.0-preview'
+        run: |
+          curl -sL \
+              -H 'Accept: application/vnd.github+json' \
+              -H 'Authorization: Bearer ${{ github.token }}' \
+              -H 'X-GitHub-Api-Version: 2022-11-28' \
+              '${{ github.api_url }}/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts'
 
       - name: Delete transient artifacts
-        run: >
-          for url in `
-          curl -s -H 'Accept: application/json;api-version=6.0-preview'
-          -H 'Authorization: Bearer ${{ fromJson(steps.actions_runtime.outputs.result).token }}'
-          '${{ fromJson(steps.actions_runtime.outputs.result).url }}_apis/pipelines/workflows/${{ github.run_id }}/artifacts?api-version=6.0-preview' |
-          jq -r -c '.value | map(select(.name|startswith("transient_"))) | .[].url'`; do
-          curl -s -H 'Accept: application/json;api-version=6.0-preview'
-          -H 'Authorization: Bearer ${{ fromJson(steps.actions_runtime.outputs.result).token }}'
-          -X DELETE "${url}";
-          done
-
-      - name: Fetch remaining artifacts (test results)
-        uses: actions/download-artifact@v4
-        with:
-          path: test-results
-
-      - name: Delete remaining artifacts
-        run: >
-          for url in `
-          curl -s -H 'Accept: application/json;api-version=6.0-preview'
-          -H 'Authorization: Bearer ${{ fromJson(steps.actions_runtime.outputs.result).token }}'
-          '${{ fromJson(steps.actions_runtime.outputs.result).url }}_apis/pipelines/workflows/${{ github.run_id }}/artifacts?api-version=6.0-preview' |
-          jq -r -c '.value | .[].url'`; do
-          curl -s -H 'Accept: application/json;api-version=6.0-preview'
-          -H 'Authorization: Bearer ${{ fromJson(steps.actions_runtime.outputs.result).token }}'
-          -X DELETE "${url}";
+        run: |
+          # Find and remove all transient artifacts
+          # See: https://docs.github.com/en/rest/actions/artifacts?apiVersion=2022-11-28
+          ALL_ARTIFACT_IDS="$(curl -sL \
+              -H 'Accept: application/vnd.github+json' \
+              -H 'Authorization: Bearer ${{ github.token }}' \
+              -H 'X-GitHub-Api-Version: 2022-11-28' \
+              '${{ github.api_url }}/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts')"
+          BUNDLE_ARTIFACT_IDS="$(echo "$ALL_ARTIFACT_IDS" | jq -r -c '.artifacts | map(select(.name|startswith("transient_"))) | .[].id')"
+          for id in $BUNDLE_ARTIFACT_IDS; do
+            echo "Removing $id"
+            curl -sL \
+                -X DELETE \
+                -H 'Accept: application/vnd.github+json' \
+                -H 'Authorization: Bearer ${{ github.token }}' \
+                -H 'X-GitHub-Api-Version: 2022-11-28' \
+                "${{ github.api_url }}/repos/${{ github.repository }}/actions/artifacts/$id" \
+            || echo "Failed to remove bundle"
           done
 
       - name: Upload a combined test results artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact/merge@v4
         with:
           name: test-results_${{ needs.prerequisites.outputs.bundle_id }}
-          path: test-results
+          separate-directories: false
+          delete-merged: true


### PR DESCRIPTION
Backport fixes code, which removes unnecessary artifacts (jdk builds), as it longer works after [JDK-8324723](https://bugs.openjdk.org/browse/JDK-8324723).

**Notes:**
- changeset is quite different form newer JDKs, because there are significant differences to GHA code
- in jdk 8 bundle artifacts use transient prefix instead of bundle
- `Display current artifacts`  and `Delete transient artifacts` steps were updated to use documented [REST API](https://docs.github.com/en/rest/actions/artifacts?apiVersion=2022-11-28)
- I switched last step to use new `actions/upload-artifact/merge@v4`, which allows to turn last 3 steps into one

**Testing:**
- GHA: OK
- only single artifacts with resulst of all ran tests (checked) is produced, as expected on 8 (see [artifacts in summary tab](https://github.com/zzambers/jdk8u-dev/actions/runs/10375295565#artifacts))
- windows x86 build failures are unrelated, see: https://github.com/openjdk/jdk8u-dev/pull/555
- macos test failures are unrelates, see: https://github.com/openjdk/jdk8u-dev/pull/544#issuecomment-2250636257

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8336928](https://bugs.openjdk.org/browse/JDK-8336928) needs maintainer approval

### Issue
 * [JDK-8336928](https://bugs.openjdk.org/browse/JDK-8336928): GHA: Bundle artifacts removal broken (**Bug** - P4 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/560/head:pull/560` \
`$ git checkout pull/560`

Update a local copy of the PR: \
`$ git checkout pull/560` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/560/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 560`

View PR using the GUI difftool: \
`$ git pr show -t 560`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/560.diff">https://git.openjdk.org/jdk8u-dev/pull/560.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/560#issuecomment-2288574626)