### PR TITLE
8223482: Unsupported ciphersuites may be offered by a TLS client

### DIFF
--- a/jdk/test/sun/security/pkcs11/fips/TestTLS12.java
+++ b/jdk/test/sun/security/pkcs11/fips/TestTLS12.java
@@ -372,15 +372,20 @@ public final class TestTLS12 extends SecmodTest {
 
         private static SSLEngine[][] getSSLEnginesToTest() throws Exception {
             SSLEngine[][] enginesToTest = new SSLEngine[2][2];
+            // TLS_RSA_WITH_AES_128_GCM_SHA256 ciphersuite is available but
+            // must not be chosen for the TLS connection if not supported.
+            // See JDK-8222937.
             String[][] preferredSuites = new String[][]{ new String[] {
+                    "TLS_RSA_WITH_AES_128_GCM_SHA256",
                     "TLS_RSA_WITH_AES_128_CBC_SHA256"
             },  new String[] {
+                    "TLS_RSA_WITH_AES_128_GCM_SHA256",
                     "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256"
             }};
             for (int i = 0; i < enginesToTest.length; i++) {
                 enginesToTest[i][0] = createSSLEngine(true);
                 enginesToTest[i][1] = createSSLEngine(false);
-                enginesToTest[i][0].setEnabledCipherSuites(preferredSuites[i]);
+                // All CipherSuites enabled for the client.
                 enginesToTest[i][1].setEnabledCipherSuites(preferredSuites[i]);
             }
             return enginesToTest;


### PR DESCRIPTION
Hi all,
This PR is backport of [JDK-8223482](https://bugs.openjdk.org/browse/JDK-8223482), backport parity with 8u261 and emb-8u261.

The change of  [JDK-8223482](https://bugs.openjdk.org/browse/JDK-8223482) of two files`src/java.base/share/classes/sun/security/ssl/SSLCipher.java` and `src/java.base/share/classes/sun/security/ssl/SSLContextImpl.java` has already in jdk8u-dev, make this backport clean.
The file `test/jdk/sun/security/pkcs11/fips/TestTLS12.java` is backported cleanly.

The test `test/jdk/sun/security/pkcs11/fips/TestTLS12.java` run failed before this PR, run passed after this PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] [JDK-8223482](https://bugs.openjdk.org/browse/JDK-8223482) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8223482](https://bugs.openjdk.org/browse/JDK-8223482): Unsupported ciphersuites may be offered by a TLS client (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/566/head:pull/566` \
`$ git checkout pull/566`

Update a local copy of the PR: \
`$ git checkout pull/566` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/566/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 566`

View PR using the GUI difftool: \
`$ git pr show -t 566`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/566.diff">https://git.openjdk.org/jdk8u-dev/pull/566.diff</a>

</details>
