### PR TITLE
8266881: Enable debug log for SSLEngineExplorerMatchedSNI.java

### DIFF
--- a/jdk/test/javax/net/ssl/SSLEngine/LargePacket.java
+++ b/jdk/test/javax/net/ssl/SSLEngine/LargePacket.java
@@ -38,6 +38,7 @@
  */
 
 import javax.net.ssl.*;
+import java.nio.ByteBuffer;
 import java.nio.channels.*;
 import java.net.*;
 
@@ -93,10 +94,10 @@ public class LargePacket extends SSLEngineService {
         }
 
         // handshaking
-        handshaking(ssle, sc, null);
+        ByteBuffer peerNetData = handshaking(ssle, sc, null);
 
         // receive application data
-        receive(ssle, sc);
+        receive(ssle, sc, peerNetData);
 
         // send out application data
         deliver(ssle, sc);
@@ -136,13 +137,13 @@ public class LargePacket extends SSLEngineService {
         }
 
         // handshaking
-        handshaking(ssle, sc, null);
+        ByteBuffer peerNetData = handshaking(ssle, sc, null);
 
         // send out application data
         deliver(ssle, sc);
 
         // receive application data
-        receive(ssle, sc);
+        receive(ssle, sc, peerNetData);
 
         // close the socket channel.
         sc.close();

--- a/jdk/test/javax/net/ssl/ServerName/SSLEngineExplorer.java
+++ b/jdk/test/javax/net/ssl/ServerName/SSLEngineExplorer.java
@@ -142,10 +142,10 @@ public class SSLEngineExplorer extends SSLEngineService {
         }
 
         // handshaking
-        handshaking(ssle, sc, buffer);
+        ByteBuffer peerNetData = handshaking(ssle, sc, buffer);
 
         // receive application data
-        receive(ssle, sc);
+        receive(ssle, sc, peerNetData);
 
         // send out application data
         deliver(ssle, sc);
@@ -192,13 +192,13 @@ public class SSLEngineExplorer extends SSLEngineService {
         ssle.setEnabledProtocols(supportedProtocols);
 
         // handshaking
-        handshaking(ssle, sc, null);
+        ByteBuffer peerNetData = handshaking(ssle, sc, null);
 
         // send out application data
         deliver(ssle, sc);
 
         // receive application data
-        receive(ssle, sc);
+        receive(ssle, sc, peerNetData);
 
         // close the socket channel.
         sc.close();

--- a/jdk/test/javax/net/ssl/ServerName/SSLEngineExplorerMatchedSNI.java
+++ b/jdk/test/javax/net/ssl/ServerName/SSLEngineExplorerMatchedSNI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,7 +71,7 @@ public class SSLEngineExplorerMatchedSNI extends SSLEngineService {
     /*
      * Turn on SSL debugging?
      */
-    static boolean debug = false;
+    static boolean debug = true;
 
     /*
      * Define the server side of the test.

--- a/jdk/test/javax/net/ssl/ServerName/SSLEngineExplorerMatchedSNI.java
+++ b/jdk/test/javax/net/ssl/ServerName/SSLEngineExplorerMatchedSNI.java
@@ -154,10 +154,10 @@ public class SSLEngineExplorerMatchedSNI extends SSLEngineService {
         ssle.setSSLParameters(params);
 
         // handshaking
-        handshaking(ssle, sc, buffer);
+        ByteBuffer peerNetData = handshaking(ssle, sc, buffer);
 
         // receive application data
-        receive(ssle, sc);
+        receive(ssle, sc, peerNetData);
 
         // send out application data
         deliver(ssle, sc);
@@ -209,13 +209,13 @@ public class SSLEngineExplorerMatchedSNI extends SSLEngineService {
         ssle.setSSLParameters(params);
 
         // handshaking
-        handshaking(ssle, sc, null);
+        ByteBuffer peerNetData = handshaking(ssle, sc, null);
 
         // send out application data
         deliver(ssle, sc);
 
         // receive application data
-        receive(ssle, sc);
+        receive(ssle, sc, peerNetData);
 
         // check server name indication
         ExtendedSSLSession session = (ExtendedSSLSession)ssle.getSession();

--- a/jdk/test/javax/net/ssl/ServerName/SSLEngineExplorerUnmatchedSNI.java
+++ b/jdk/test/javax/net/ssl/ServerName/SSLEngineExplorerUnmatchedSNI.java
@@ -148,10 +148,10 @@ public class SSLEngineExplorerUnmatchedSNI extends SSLEngineService {
 
         try {
             // handshaking
-            handshaking(ssle, sc, buffer);
+            ByteBuffer peerNetData = handshaking(ssle, sc, buffer);
 
             // receive application data
-            receive(ssle, sc);
+            receive(ssle, sc, peerNetData);
 
             // send out application data
             deliver(ssle, sc);
@@ -213,13 +213,13 @@ public class SSLEngineExplorerUnmatchedSNI extends SSLEngineService {
 
         try {
             // handshaking
-            handshaking(ssle, sc, null);
+            ByteBuffer peerNetData = handshaking(ssle, sc, null);
 
             // send out application data
             deliver(ssle, sc);
 
             // receive application data
-            receive(ssle, sc);
+            receive(ssle, sc, peerNetData);
 
             // check server name indication
             ExtendedSSLSession session = (ExtendedSSLSession)ssle.getSession();

--- a/jdk/test/javax/net/ssl/ServerName/SSLEngineExplorerWithCli.java
+++ b/jdk/test/javax/net/ssl/ServerName/SSLEngineExplorerWithCli.java
@@ -136,10 +136,10 @@ public class SSLEngineExplorerWithCli extends SSLEngineService {
         }
 
         // handshaking
-        handshaking(ssle, sc, buffer);
+        ByteBuffer peerNetData = handshaking(ssle, sc, buffer);
 
         // receive application data
-        receive(ssle, sc);
+        receive(ssle, sc, peerNetData);
 
         // send out application data
         deliver(ssle, sc);
@@ -190,13 +190,13 @@ public class SSLEngineExplorerWithCli extends SSLEngineService {
         ssle.setSSLParameters(params);
 
         // handshaking
-        handshaking(ssle, sc, null);
+        ByteBuffer peerNetData = handshaking(ssle, sc, null);
 
         // send out application data
         deliver(ssle, sc);
 
         // receive application data
-        receive(ssle, sc);
+        receive(ssle, sc, peerNetData);
 
         // check server name indication
         ExtendedSSLSession session = (ExtendedSSLSession)ssle.getSession();

--- a/jdk/test/javax/net/ssl/ServerName/SSLEngineExplorerWithSrv.java
+++ b/jdk/test/javax/net/ssl/ServerName/SSLEngineExplorerWithSrv.java
@@ -145,10 +145,10 @@ public class SSLEngineExplorerWithSrv extends SSLEngineService {
         ssle.setSSLParameters(params);
 
         // handshaking
-        handshaking(ssle, sc, buffer);
+        ByteBuffer peerNetData = handshaking(ssle, sc, buffer);
 
         // receive application data
-        receive(ssle, sc);
+        receive(ssle, sc, peerNetData);
 
         // send out application data
         deliver(ssle, sc);
@@ -193,13 +193,13 @@ public class SSLEngineExplorerWithSrv extends SSLEngineService {
         }
 
         // handshaking
-        handshaking(ssle, sc, null);
+        ByteBuffer peerNetData = handshaking(ssle, sc, null);
 
         // send out application data
         deliver(ssle, sc);
 
         // receive application data
-        receive(ssle, sc);
+        receive(ssle, sc, peerNetData);
 
         // check server name indication
         ExtendedSSLSession session = (ExtendedSSLSession)ssle.getSession();


### PR DESCRIPTION
Hi all,
  This PR contains two backports [JDK-8266881](https://github.com/openjdk/jdk11u-dev/commit/8138382780b16f4184ad5bbfe07ab2468afe71a8) and [JDK-8227651](https://github.com/openjdk/jdk11u-dev/commit/e8b7e77c8b71946eaee952443e001105b48fe73e) from jdk11u-dev.
We observed `javax/net/ssl/ServerName/SSLEngineExplorerMatchedSNI.java failed intermittently due to SSLException: Tag mismatch` by ours nightly CI, so we want to backport these two PRs to fix the test bugs which cause intermittent fails.

The change in `test/jdk/ProblemList.txt` was not needed deal with in jdk8u-dev, all other files are backported cleanly.

Changes(total 6 releated testcases) has been verified locally. Test fix only, no risk.

Additional testing:

- [x] full jtreg tests on linux x64
- [x] full jtreg tests on linux aarch64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8266881](https://bugs.openjdk.org/browse/JDK-8266881) needs maintainer approval
- [x] [JDK-8212096](https://bugs.openjdk.org/browse/JDK-8212096) needs maintainer approval
- [x] [JDK-8227651](https://bugs.openjdk.org/browse/JDK-8227651) needs maintainer approval

### Issues
 * [JDK-8266881](https://bugs.openjdk.org/browse/JDK-8266881): Enable debug log for SSLEngineExplorerMatchedSNI.java (**Bug** - P4 - Approved)
 * [JDK-8212096](https://bugs.openjdk.org/browse/JDK-8212096): javax/net/ssl/ServerName/SSLEngineExplorerMatchedSNI.java failed intermittently due to SSLException: Tag mismatch (**Bug** - P3 - Approved)
 * [JDK-8227651](https://bugs.openjdk.org/browse/JDK-8227651): Tests fail with SSLProtocolException: Input record too big (**Bug** - P3 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/567/head:pull/567` \
`$ git checkout pull/567`

Update a local copy of the PR: \
`$ git checkout pull/567` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/567/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 567`

View PR using the GUI difftool: \
`$ git pr show -t 567`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/567.diff">https://git.openjdk.org/jdk8u-dev/pull/567.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/567#issuecomment-2309610026)
</details>
