### PR TITLE
8339133: [8u] Profiler crashes at guarantee(is_result_safe || is_in_asgct()): unsafe access to zombie method

### DIFF
--- a/hotspot/src/share/vm/prims/forte.cpp
+++ b/hotspot/src/share/vm/prims/forte.cpp
@@ -553,7 +553,8 @@ void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
     return;
   }
 
-  // !important! make sure all to call thread->set_in_asgct(false) before every return
+  // !important! make sure all to call thread->set_in_asgct(saved_in_asgct) before every return
+  bool saved_in_asgct = thread->in_asgct();
   thread->set_in_asgct(true);
 
   switch (thread->thread_state()) {
@@ -613,7 +614,7 @@ void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
     trace->num_frames = ticks_unknown_state; // -7
     break;
   }
-  thread->set_in_asgct(false);
+  thread->set_in_asgct(saved_in_asgct);
 }
 
 


### PR DESCRIPTION
When running AsyncGetCallTrace based profiler, JVM occasionally crashes on the guarantee at codeCache.cpp:287:
```
guarantee(is_result_safe || is_in_asgct(), "unsafe access to zombie method");
```
According to the stack trace, a thread is inside `AsyncGetCallTrace` at the moment of crash, but `is_in_asgct() == false`.

Current implementation of `AsyncGetCallTrace` is not reentrant, since it incorrectly resets `in_asgct` flag of the current thread. The fix is similar to [JDK-8329103](https://bugs.openjdk.org/browse/JDK-8329103): `in_asgct` should be reset to previous value instead of `false`.

The fix is trivial and safe: it affects only `AsyncGetCallTrace`.

Testing: tier1, renaissance suite with async-profiler enabled

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8339133](https://bugs.openjdk.org/browse/JDK-8339133) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339133](https://bugs.openjdk.org/browse/JDK-8339133): [8u] Profiler crashes at guarantee(is_result_safe || is_in_asgct()): unsafe access to zombie method (**Bug** - P4 - Approved)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/568/head:pull/568` \
`$ git checkout pull/568`

Update a local copy of the PR: \
`$ git checkout pull/568` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/568/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 568`

View PR using the GUI difftool: \
`$ git pr show -t 568`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/568.diff">https://git.openjdk.org/jdk8u-dev/pull/568.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/568#issuecomment-2313959218)