### PR TITLE
8339882: Replace ThreadLocalStorage::thread with Thread::current_or_null in jdk8 backport of JDK-8183925

### DIFF
--- a/hotspot/src/os/posix/vm/os_posix.cpp
+++ b/hotspot/src/os/posix/vm/os_posix.cpp
@@ -876,7 +876,7 @@ bool os::ThreadCrashProtection::call(os::CrashProtectionCallback& cb) {
 
   Thread::muxAcquire(&_crash_mux, "CrashProtection");
 
-  _protected_thread = ThreadLocalStorage::thread();
+  _protected_thread = Thread::current_or_null();
   assert(_protected_thread != NULL, "Cannot crash protect a NULL thread");
 
   // we cannot rely on sigsetjmp/siglongjmp to save/restore the signal mask

--- a/hotspot/src/os/windows/vm/os_windows.cpp
+++ b/hotspot/src/os/windows/vm/os_windows.cpp
@@ -4890,7 +4890,7 @@ bool os::ThreadCrashProtection::call(os::CrashProtectionCallback& cb) {
 
   Thread::muxAcquire(&_crash_mux, "CrashProtection");
 
-  _protected_thread = ThreadLocalStorage::thread();
+  _protected_thread = Thread::current_or_null();
   assert(_protected_thread != NULL, "Cannot crash protect a NULL thread");
 
   bool success = true;

--- a/hotspot/src/share/vm/runtime/os.cpp
+++ b/hotspot/src/share/vm/runtime/os.cpp
@@ -619,7 +619,7 @@ void* os::malloc(size_t size, MEMFLAGS memflags, const NativeCallStack& stack) {
 
   // Since os::malloc can be called when the libjvm.{dll,so} is
   // first loaded and we don't have a thread yet we must accept NULL also here.
-  assert(!os::ThreadCrashProtection::is_crash_protected(ThreadLocalStorage::thread()),
+  assert(!os::ThreadCrashProtection::is_crash_protected(Thread::current_or_null()),
          "malloc() not allowed when crash protection is set");
 
   if (size == 0) {


### PR DESCRIPTION
This change replaces 3 instances of `ThreadLocalStorage::thread` with `Thread::current_or_null` to ensure that `ThreadLocalStorage::is_initialized` is checked before attempting to get the current thread.

Change passes all tier1 tests locally on Linux x86_64 and Windows x86_64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8339882](https://bugs.openjdk.org/browse/JDK-8339882) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339882](https://bugs.openjdk.org/browse/JDK-8339882): Replace ThreadLocalStorage::thread with Thread::current_or_null in jdk8 backport of JDK-8183925 (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/576/head:pull/576` \
`$ git checkout pull/576`

Update a local copy of the PR: \
`$ git checkout pull/576` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/576/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 576`

View PR using the GUI difftool: \
`$ git pr show -t 576`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/576.diff">https://git.openjdk.org/jdk8u-dev/pull/576.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/576#issuecomment-2342360187)
</details>
