### PR TITLE
8228658: test GetTotalSafepointTime.java fails on fast Linux machines with Total safepoint time 0 ms

### DIFF
--- a/jdk/test/sun/management/HotspotRuntimeMBean/GetTotalSafepointTime.java
+++ b/jdk/test/sun/management/HotspotRuntimeMBean/GetTotalSafepointTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,47 +39,33 @@ public class GetTotalSafepointTime {
     private static HotspotRuntimeMBean mbean =
         (HotspotRuntimeMBean)ManagementFactoryHelper.getHotspotRuntimeMBean();
 
-    private static final long NUM_THREAD_DUMPS = 100;
-
     // Careful with these values.
     private static final long MIN_VALUE_FOR_PASS = 1;
-    private static final long MAX_VALUE_FOR_PASS = Long.MAX_VALUE;
 
-    private static boolean trace = false;
+    // Thread.getAllStackTraces() should cause safepoints.
+    // If this test is failing because it doesn't,
+    // MIN_VALUE_FOR_PASS should be reset to 0
+    public static long executeThreadDumps(long initial_value) {
+        long value;
+        do {
+            Thread.getAllStackTraces();
+            value = mbean.getTotalSafepointTime();
+        } while (value == initial_value);
+        return value;
+    }
 
     public static void main(String args[]) throws Exception {
-        if (args.length > 0 && args[0].equals("trace")) {
-            trace = true;
-        }
+        long value = executeThreadDumps(0);
+        System.out.println("Total safepoint time (ms): " + value);
 
-        // Thread.getAllStackTraces() should cause safepoints.
-        // If this test is failing because it doesn't,
-        // MIN_VALUE_FOR_PASS should be reset to 0
-        for (int i = 0; i < NUM_THREAD_DUMPS; i++) {
-             Thread.getAllStackTraces();
-        }
-
-        long value = mbean.getTotalSafepointTime();
-
-        if (trace) {
-            System.out.println("Total safepoint time (ms): " + value);
-        }
-
-        if (value < MIN_VALUE_FOR_PASS || value > MAX_VALUE_FOR_PASS) {
+        if (value < MIN_VALUE_FOR_PASS) {
             throw new RuntimeException("Total safepoint time " +
                                        "illegal value: " + value + " ms " +
-                                       "(MIN = " + MIN_VALUE_FOR_PASS + "; " +
-                                       "MAX = " + MAX_VALUE_FOR_PASS + ")");
+                                       "(MIN = " + MIN_VALUE_FOR_PASS + ")");
         }
 
-        for (int i = 0; i < 2 * NUM_THREAD_DUMPS; i++) {
-             Thread.getAllStackTraces();
-        }
-        long value2 = mbean.getTotalSafepointTime();
-
-        if (trace) {
-            System.out.println("Total safepoint time2 (ms): " + value2);
-        }
+        long value2 = executeThreadDumps(value);
+        System.out.println("Total safepoint time (ms): " + value2);
 
         if (value2 <= value) {
             throw new RuntimeException("Total safepoint time " +


### PR DESCRIPTION
Hi all,
  We observerd the test `sun/management/HotspotRuntimeMBean/GetTotalSafepointTime.java` intermittent fails on jdk8u-dev. The failure phenomenon same to [JDK-8228658](https://bugs.openjdk.org/browse/JDK-8228658). So I want to backport this PR from jdk11u-dev to jdk8u-dev.

Only the copyright year backported not cleanly, the copyright year modified by JDK-6719955 and JDK-6943119 in jdk8u-dev. Other parts are backport cleanly.

The change has been verified locally, make the test more robustness, test fix only, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8228658](https://bugs.openjdk.org/browse/JDK-8228658) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8228658](https://bugs.openjdk.org/browse/JDK-8228658): test GetTotalSafepointTime.java fails on fast Linux machines with Total safepoint time 0 ms (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/578/head:pull/578` \
`$ git checkout pull/578`

Update a local copy of the PR: \
`$ git checkout pull/578` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/578/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 578`

View PR using the GUI difftool: \
`$ git pr show -t 578`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/578.diff">https://git.openjdk.org/jdk8u-dev/pull/578.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/578#issuecomment-2350792531)
</details>
