### PR TITLE
8340660: [8u] Test com/sun/jdi/PrivateTransportTest.sh fails on MacOS

### DIFF
--- a/jdk/test/com/sun/jdi/PrivateTransportTest.sh
+++ b/jdk/test/com/sun/jdi/PrivateTransportTest.sh
@@ -148,13 +148,13 @@ elif [ -f ${libloc}/libdt_socket.dylib ]; then
     echo cp ${libloc}/libdt_socket.dylib ${fullpath}
     cp ${libloc}/libdt_socket.dylib ${fullpath}
     # make sure we can find libraries in current directory
-    if [ "${LD_LIBRARY_PATH}" = "" ] ; then
-        LD_LIBRARY_PATH=${libdir}
+    if [ "${DYLD_LIBRARY_PATH}" = "" ] ; then
+        DYLD_LIBRARY_PATH=${libdir}
     else
-        LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${libdir}
+        DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}:${libdir}
     fi
-    export LD_LIBRARY_PATH
-    echo LD_LIBRARY_PATH=${LD_LIBRARY_PATH}
+    export DYLD_LIBRARY_PATH
+    echo DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}
 elif [ -f ${libloc}/libdt_socket.so ] ; then
     fullpath=${libdir}/lib${private_transport}.so
     rm -f ${fullpath}


### PR DESCRIPTION
Turns out there is still one failing jdi test on MacOS (after DNS issue with macos-13 image was fixed):
`com/sun/jdi/PrivateTransportTest.sh`

**Error:**
```
STDOUT:
JDK under test is: /Users/runner/jdk-macos-x64/jdk-1.8.0-internal+0_osx-x64_bin/j2sdk-image
Setup private transport library by copying an existing one and renaming
cp /Users/runner/jdk-macos-x64/jdk-1.8.0-internal+0_osx-x64_bin/j2sdk-image/jre/lib/libdt_socket.dylib /Users/runner/work/jdk8u-dev/jdk8u-dev/test-results/testoutput/jdk_tier1/JTwork/classes/com/sun/jdi/libprivate_dt_socket.dylib
LD_LIBRARY_PATH=/Users/runner/work/jdk8u-dev/jdk8u-dev/test-results/testoutput/jdk_tier1/JTwork/classes/com/sun/jdi
/Users/runner/jdk-macos-x64/jdk-1.8.0-internal+0_osx-x64_bin/j2sdk-image/bin/java -agentlib:jdwp=transport=private_dt_socket,server=y,suspend=n -classpath "/Users/runner/work/jdk8u-dev/jdk8u-dev/test-results/testoutput/jdk_tier1/JTwork/classes/com/sun/jdi" HelloWorld
FATAL ERROR in native method: JDWP No transports initialized, jvmtiError=AGENT_ERROR_TRANSPORT_LOAD(196)
test status for  was: 134
The test failed :-(
exit status was 134
STDERR:
ERROR: transport library not found: private_dt_socket
ERROR: JDWP Transport private_dt_socket failed to initialize, TRANSPORT_LOAD(509)
JDWP exit error AGENT_ERROR_TRANSPORT_LOAD(196): No transports initialized [debugInit.c:750]
/Users/runner/work/jdk8u-dev/jdk8u-dev/jdk/test/com/sun/jdi/PrivateTransportTest.sh: line 203: 16866 Abort trap: 6           /Users/runner/jdk-macos-x64/jdk-1.8.0-internal+0_osx-x64_bin/j2sdk-image/bin/java -agentlib:jdwp=transport=private_dt_socket,server=y,suspend=n -classpath "/Users/runner/work/jdk8u-dev/jdk8u-dev/test-results/testoutput/jdk_tier1/JTwork/classes/com/sun/jdi" HelloWorld
unspecified test failure
```

**Details:**
Test fails to load native library. Issue is, that `LD_LIBRARY_PATH` env. var is [no longer supported by newer versions MacOS](https://forums.developer.apple.com/forums/thread/705308). Fix is to use `DYLD_LIBRARY_PATH` env. var instead. Fix is specific to 8u, because jdi tests were rewritten to java in later JDKs in [series of changes](https://bugs.openjdk.org/browse/JDK-8201652). I believe, in rewritten test , issue was then fixed as part of [JDK-8216265](https://bugs.openjdk.org/browse/JDK-8216265). Backporting all of that just to fix this, seems like overkill, so I made fix to shell test.

**Testing:**
Tier1: OK (test passes, other failures unrelated)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] [JDK-8340660](https://bugs.openjdk.org/browse/JDK-8340660) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340660](https://bugs.openjdk.org/browse/JDK-8340660): [8u] Test com/sun/jdi/PrivateTransportTest.sh fails on MacOS (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/580/head:pull/580` \
`$ git checkout pull/580`

Update a local copy of the PR: \
`$ git checkout pull/580` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/580/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 580`

View PR using the GUI difftool: \
`$ git pr show -t 580`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/580.diff">https://git.openjdk.org/jdk8u-dev/pull/580.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/580#issuecomment-2368732803)
</details>
