### PR TITLE
8313626: C2 crash due to unexpected exception control flow

### DIFF
--- a/hotspot/src/share/vm/opto/doCall.cpp
+++ b/hotspot/src/share/vm/opto/doCall.cpp
@@ -892,6 +892,8 @@ void Parse::catch_inline_exceptions(SafePointNode* ex_map) {
         tty->print_cr("  Catching every inline exception bci:%d -> handler_bci:%d", bci(), handler_bci);
       }
 #endif
+      // If this is a backwards branch in the bytecodes, add safepoint
+      maybe_add_safepoint(handler_bci);
       merge_exception(handler_bci); // jump to handler
       return;                   // No more handling to be done here!
     }
@@ -925,6 +927,8 @@ void Parse::catch_inline_exceptions(SafePointNode* ex_map) {
         tty->cr();
       }
 #endif
+      // If this is a backwards branch in the bytecodes, add safepoint
+      maybe_add_safepoint(handler_bci);
       merge_exception(handler_bci);
     }
     set_control(not_subtype_ctrl);

--- a/hotspot/test/compiler/parsing/MissingSafepointOnTryCatch.jasm
+++ b/hotspot/test/compiler/parsing/MissingSafepointOnTryCatch.jasm
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+public class MissingSafepointOnTryCatch version 52:0 {
+
+    static Method m:"()V" {
+        return;
+    }
+
+    static Method test1:"()V" stack 1 {
+        try t;
+            invokestatic m:"()V";
+            return;
+
+            catch t java/lang/Throwable;
+            stack_map class java/lang/Throwable;
+            athrow;
+        endtry t;
+    }
+
+    static Method test2:"()V" stack 1 {
+        try t0;
+            try t1;
+                invokestatic m:"()V";
+            endtry t1;
+            return;
+
+            catch t1 java/lang/Exception;
+            stack_map class java/lang/Exception;
+            return;
+
+            catch t0 java/lang/Throwable;
+            stack_map class java/lang/Throwable;
+            athrow;
+        endtry t0;
+    }
+
+    public static Method th:"()V"
+      throws java/lang/Exception
+      stack 2 locals 0
+    {
+          new	class java/lang/Exception;
+          dup;
+          invokespecial	Method java/lang/Exception."<init>":"()V";
+          athrow;
+    }
+
+    static Method test3:"()V" stack 1 locals 2 {
+        try t;
+            invokestatic m:"()V";
+            iconst_1;
+            istore_0;
+    		iconst_0;
+    		istore_1;
+            return;
+            catch t java/lang/Throwable;
+            stack_map class java/lang/Throwable;
+            invokestatic th:"()V";
+            return;
+        endtry t;
+    }
+
+    static Method test4:"()V" stack 2 locals 2 {
+        try t;
+            invokestatic m:"()V";
+            iconst_1;
+            istore_0;
+            iconst_0;
+            istore_1;
+            return;
+            catch t java/lang/Throwable;
+            stack_map class java/lang/Throwable;
+            iconst_1;
+            istore_0;
+            invokestatic th:"()V";
+            return;
+        endtry t;
+    }
+
+    static Method testInfinite:"()V" stack 1 {
+        try t;
+            invokestatic th:"()V";
+            return;
+
+            catch t java/lang/Throwable;
+            stack_map class java/lang/Throwable;
+            athrow;
+        endtry t;
+    }
+
+} // end Class MissingSafepointOnTryCatch

--- a/hotspot/test/compiler/parsing/TestMissingSafepointOnTryCatch.java
+++ b/hotspot/test/compiler/parsing/TestMissingSafepointOnTryCatch.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8313626
+ * @summary  assert(false) failed: malformed control flow to missing safepoint on backedge of a try-catch
+ * @library /test/lib
+ * @compile MissingSafepointOnTryCatch.jasm
+ * @run main/othervm -XX:CompileCommand=quiet
+ *      -XX:CompileCommand=compileonly,MissingSafepointOnTryCatch::test*
+ *      -XX:CompileCommand=dontinline,MissingSafepointOnTryCatch::m
+ *      -XX:CompileCommand=inline,MissingSafepointOnTryCatch::th
+ *      -XX:-TieredCompilation -Xcomp TestMissingSafepointOnTryCatch
+ */
+
+import jdk.test.lib.Utils;
+
+public class TestMissingSafepointOnTryCatch {
+
+    public static void infiniteLoop() {
+        try {
+            Thread thread = new Thread() {
+                public void run() {
+                    MissingSafepointOnTryCatch.testInfinite();
+                }
+            };
+            thread.setDaemon(true);
+            thread.start();
+            Thread.sleep(Utils.adjustTimeout(500));
+        } catch (Exception e) {}
+    }
+
+    public static void main(String[] args) {
+        try {
+            // to make sure java/lang/Exception class is resolved
+            MissingSafepointOnTryCatch.th();
+        } catch (Exception e) {}
+        MissingSafepointOnTryCatch.test1();
+        MissingSafepointOnTryCatch.test2();
+        MissingSafepointOnTryCatch.test3();
+        MissingSafepointOnTryCatch.test4();
+        infiniteLoop();
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [f8203cb2](https://github.com/openjdk/jdk/commit/f8203cb272e6136b784e5c43a500f6a0bfb19c8b) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Tobias Holenstein on 23 Aug 2023 and was reviewed by Tobias Hartmann and Christian Hagedorn.

The patch is mostly clean. The jdk8u still widely uses "#ifndef PRODUCT/#endif" in the context. The usage of that macro was deleted by the next patch in jdk9: https://github.com/openjdk/jdk/commit/6896030b9620e89546527fbfd19369366b5ad3d5#diff-2797e2c78bff502b5d98cab2383791529d267cfd3099575872c756fcd715e143L858

- No new issues were found by the tier1 and tier2 tests. 
- The new test passes before and after the patch, same as for jdk11u, see:
 
https://bugs.openjdk.org/browse/JDK-8313626?focusedId=14608649&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-14608649


Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8313626](https://bugs.openjdk.org/browse/JDK-8313626) needs maintainer approval

### Issue
 * [JDK-8313626](https://bugs.openjdk.org/browse/JDK-8313626): C2 crash due to unexpected exception control flow (**Bug** - P3 - Approved)


### Reviewers
 * [Yuri Nesterenko](https://openjdk.org/census#yan) (@yan-too - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/581/head:pull/581` \
`$ git checkout pull/581`

Update a local copy of the PR: \
`$ git checkout pull/581` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/581/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 581`

View PR using the GUI difftool: \
`$ git pr show -t 581`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/581.diff">https://git.openjdk.org/jdk8u-dev/pull/581.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/581#issuecomment-2376415519)