### PR TITLE
Backport b3cf0cf9fcaa25f11f8b5fb8658ecb383d19fc17

### DIFF
--- a/hotspot/test/compiler/6891750/Test6891750.java
+++ b/hotspot/test/compiler/6891750/Test6891750.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @bug 6891750
  * @summary deopt blob kills values in O5
  *
- * @run main Test6891750
+ * @run main/othervm Test6891750
  */
 
 abstract class Base6891750 extends Thread {


### PR DESCRIPTION
Arm test runs of `Test6891750` on adoptium infra [fails](https://github.com/adoptium/aqa-tests/pull/5646#issuecomment-2383302408):
```
JavaTest Message: Problem cleaning up the following threads:
Thread-10
  at Test6891750.test(Test6891750.java:69)
  at Test6891750.run(Test6891750.java:88)
 ```
 
This simple backport ([JDK-8209023](https://bugs.openjdk.org/browse/JDK-8209023)) should fix that. Backport is not entirely clean because test was [moved / put into java package](https://github.com/openjdk-bots/jdk11u-dev/commit/a0381422ddb56f6cf8fc2fd1a7f111e11925a7d1#diff-b549ddee629b86e132f95ac3eac281c38135208eae656326860a4ab904784e9b) in newer jdk (affecting `@run` line).
 
**Testing:**
GHA: OK (test passes, failures unrelated)