### PR TITLE
Backport b4d4c8a3922f6563013d4e997e149bd0198222d2

### DIFF
--- a/hotspot/test/compiler/8009761/Test8009761.java
+++ b/hotspot/test/compiler/8009761/Test8009761.java
@@ -21,11 +21,7 @@
  * questions.
  */
 
-import com.sun.management.HotSpotDiagnosticMXBean;
-import com.sun.management.VMOption;
 import sun.hotspot.WhiteBox;
-import sun.management.ManagementFactoryHelper;
-
 import java.lang.reflect.Method;
 
 /*
@@ -41,6 +37,7 @@ import java.lang.reflect.Method;
 public class Test8009761 {
 
     private static final WhiteBox WHITE_BOX = WhiteBox.getWhiteBox();
+    private static int COMP_LEVEL_SIMPLE = 1;
     private static int COMP_LEVEL_FULL_OPTIMIZATION = 4;
     private static Method m3 = null;
 
@@ -237,7 +234,7 @@ public class Test8009761 {
 
     static public void main(String[] args) {
         // Make sure background compilation is disabled
-        if (backgroundCompilationEnabled()) {
+        if (WHITE_BOX.getBooleanVMFlag("BackgroundCompilation")) {
             throw new RuntimeException("Background compilation enabled");
         }
 
@@ -257,7 +254,11 @@ public class Test8009761 {
         c1 = count;
 
         // Force the compilation of m3() that will inline m1()
-        WHITE_BOX.enqueueMethodForCompilation(m3, COMP_LEVEL_FULL_OPTIMIZATION);
+        if(!WHITE_BOX.enqueueMethodForCompilation(m3, COMP_LEVEL_FULL_OPTIMIZATION)) {
+            // C2 compiler not available, compile with C1
+            WHITE_BOX.enqueueMethodForCompilation(m3, COMP_LEVEL_SIMPLE);
+        }
+
         // Because background compilation is disabled, method should now be compiled
         if(!WHITE_BOX.isMethodCompiled(m3)) {
             throw new RuntimeException(m3 + " not compiled");
@@ -278,20 +279,5 @@ public class Test8009761 {
         } else {
             System.out.println("PASSED " + c1);
         }
-    }
-
-    /**
-     * Checks if background compilation (-XX:+BackgroundCompilation) is enabled.
-     * @return True if background compilation is enabled, false otherwise
-     */
-    private static boolean backgroundCompilationEnabled() {
-      HotSpotDiagnosticMXBean diagnostic = ManagementFactoryHelper.getDiagnosticMXBean();
-      VMOption backgroundCompilation;
-      try {
-          backgroundCompilation = diagnostic.getVMOption("BackgroundCompilation");
-      } catch (IllegalArgumentException e) {
-          return false;
-      }
-      return Boolean.valueOf(backgroundCompilation.getValue());
     }
 }


### PR DESCRIPTION
Backport to fix failure on Client VM, [seen on adoptium infra](https://github.com/adoptium/aqa-tests/pull/5646#issuecomment-2377058006) on win32 and arm:
```
10:24:53  STDOUT:
10:24:53  CompilerOracle: exclude Test8009761.m2
10:24:53  WB error: invalid compilation level 4
10:24:53  STDERR:
10:24:53  java.lang.RuntimeException: static java.lang.Object Test8009761.m3(boolean,boolean) not compiled
10:24:53  	at Test8009761.main(Test8009761.java:263)
10:24:53  	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
10:24:53  	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
10:24:53  	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
10:24:53  	at java.lang.reflect.Method.invoke(Method.java:498)
10:24:53  	at com.sun.javatest.regtest.agent.MainWrapper$MainThread.run(MainWrapper.java:127)
10:24:53  	at java.lang.Thread.run(Thread.java:750)
```

Interestingly test passes on win32 in GHA. I checked jtr, it tests correct jdk, but seems Server VM is built even on win32 (I thought Client VM was default [on win32](https://github.com/openjdk/jdk8u-dev/blob/6acc668a6cfd0c0ab3c05560fe3b45ee44bf76a4/.github/workflows/submit.yml#L986), but probably not):
```
JDK under test: C:\\Users\\runneradmin\\jdk-windows-x86\\jdk-1.8.0-internal+0_windows-x86_bin\\j2sdk-image
openjdk version "1.8.0_442-internal"
OpenJDK Runtime Environment (build 1.8.0_442-internal-zzambers-25ceefc7a16f31558ec7e92b7504f328a78d8091-b00)
OpenJDK Server VM (build 25.442-b00, mixed mode)
```

**Testing:**
GHA: OK (test passes, failures unrelated)