### PR TITLE
8058322: Zero name_index item of MethodParameters attribute cause MalformedParameterException.

### DIFF
--- a/hotspot/src/share/vm/runtime/reflection.cpp
+++ b/hotspot/src/share/vm/runtime/reflection.cpp
@@ -867,17 +867,16 @@ oop Reflection::new_field(fieldDescriptor* fd, bool intern_name, TRAPS) {
 
 oop Reflection::new_parameter(Handle method, int index, Symbol* sym,
                               int flags, TRAPS) {
-  Handle name;
-
-  // A null symbol here translates to the empty string
-  if(NULL != sym) {
-    name = java_lang_String::create_from_symbol(sym, CHECK_NULL);
-  } else {
-    name = java_lang_String::create_from_str("", CHECK_NULL);
-  }
 
   Handle rh = java_lang_reflect_Parameter::create(CHECK_NULL);
-  java_lang_reflect_Parameter::set_name(rh(), name());
+
+  if(NULL != sym) {
+    Handle name = java_lang_String::create_from_symbol(sym, CHECK_NULL);
+    java_lang_reflect_Parameter::set_name(rh(), name());
+  } else {
+    java_lang_reflect_Parameter::set_name(rh(), NULL);
+  }
+
   java_lang_reflect_Parameter::set_modifiers(rh(), flags);
   java_lang_reflect_Parameter::set_executable(rh(), method());
   java_lang_reflect_Parameter::set_index(rh(), index);


### PR DESCRIPTION
An out-of-spec behavior of core reflection causes it to fail when it encounters class files that conform to JVMS for release 8. In [JVMS § 4.7.24](https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.24) parameters are allowed to have `null` (CP reference 0) names, but core reflection didn't accept it.

This problem was relatively obscure, but it has been exacerbated when javac for release 21 and later starts generating such parameters in `MethodParameters` attribute. Since this is a problem with Java 8, I propose to backport this related fix onto 8 instead of changing latest releases.

This pull request contains a backport of commit [cba5bd26](https://github.com/openjdk/jdk/commit/cba5bd26387dc2ecb31ac8d6bea21bcc01da0cd5) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository. The commit being backported was authored by Eric McCorkle on 11 Nov 2014 and was reviewed by Coleen Phillimore and David Holmes.

A backport request is included in the latest comment in the original JBS issue.

An original pull request openjdk/jdk8u#63 was made against the wrong repository.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8058322](https://bugs.openjdk.org/browse/JDK-8058322) needs maintainer approval

### Issue
 * [JDK-8058322](https://bugs.openjdk.org/browse/JDK-8058322): Zero name_index item of MethodParameters attribute cause MalformedParameterException. (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/592/head:pull/592` \
`$ git checkout pull/592`

Update a local copy of the PR: \
`$ git checkout pull/592` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/592/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 592`

View PR using the GUI difftool: \
`$ git pr show -t 592`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/592.diff">https://git.openjdk.org/jdk8u-dev/pull/592.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/592#issuecomment-2400417543)