### PR TITLE
8341946: [8u] sun/security/pkcs11/ec/ tests fail on RHEL9

### DIFF
--- a/jdk/test/sun/security/pkcs11/PKCS11Test.java
+++ b/jdk/test/sun/security/pkcs11/PKCS11Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/jdk/test/sun/security/pkcs11/PKCS11Test.java
+++ b/jdk/test/sun/security/pkcs11/PKCS11Test.java
@@ -90,7 +90,7 @@ public abstract class PKCS11Test {
     // NSS version info
     public static enum ECCState { None, Basic, Extended };
     static double nss_version = -1;
-    static ECCState nss_ecc_status = ECCState.Extended;
+    static ECCState nss_ecc_status = ECCState.Basic;
 
     // The NSS library we need to search for in getNSSLibDir()
     // Default is "libsoftokn3.so", listed as "softokn3"


### PR DESCRIPTION
The following tests fail when they cannot find the NSS version information, because the initial value of nss_ecc_status is ECCState.Extended and tries to use the EC algorithm not supported in ECCState.Basic,

sun/security/pkcs11/ec/TestECDH.java
sun/security/pkcs11/ec/TestECDSA.java
sun/security/pkcs11/ec/TestECGenSpec.java

To resolve these failures, change the initial value of nss_ecc_status from ECCState.Extended to ECCState.Basic.

Similar fix was made in [JDK-8253637](https://bugs.openjdk.org/browse/JDK-8253637) for jdk16 and later, and [JDK-8328889](https://bugs.openjdk.org/browse/JDK-8328889) for jdk11.

JDK-8253637 and JDK-8313206 were done with versions higher than jdk8. For this reason, it is normal to do a backport, but do not backport to jdk11 or jdk8 because:

JDK-8253637
About jdk11
・The ECDHKeyAgreement.java diff contains enhancements that have not been applied to jdk11 and cannot be backported to jdk11.
・Since TestEC.java is now passed in jdk11 and has been removed from the ProblemList, there is no need to modify Problemlist.txt and TestEC.java.
・The fix for PKCS11Test.java has already been made in JDK-8313206.
About jdk8
・For the same reason as jdk11, the ECDHKeyAgreement.java diff is not applicable, and the TestEC.java and Problemlist.txt diffs need not be applied.
・All we need is a PKCS11Test.java fix to resolve 3 failures (TestECDH.java, TestECDSA.java and TestECGenSpec.java). It is appropriate to issue a new bug ID this time because the test to be solved is different from JDK-8253637.

JDK-8313206
In JDK-8313206, only jdk11 has the fix to the initial value of nss_ecc_status in PKCS11Test.java.
Since JDK-8313206 is a different topic than the one I want to solve this time, I think it is inappropriate to backport to solve 3 failures(TestECDH.java, TestECDSA.java and TestECGenSpec.java).

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8341946](https://bugs.openjdk.org/browse/JDK-8341946) needs maintainer approval

### Issue
 * [JDK-8341946](https://bugs.openjdk.org/browse/JDK-8341946): [8u] sun/security/pkcs11/ec/ tests fail on RHEL9 (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/594/head:pull/594` \
`$ git checkout pull/594`

Update a local copy of the PR: \
`$ git checkout pull/594` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/594/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 594`

View PR using the GUI difftool: \
`$ git pr show -t 594`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/594.diff">https://git.openjdk.org/jdk8u-dev/pull/594.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/594#issuecomment-2406959943)
</details>
