### PR TITLE
8342841: [8u] Separate jdk_security_infra tests from jdk_tier1

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -203,6 +203,7 @@ jobs:
           - jdk/tier1
           - langtools/tier1
           - hotspot/tier1
+          - jdk/security_infra
         include:
           - test: jdk/tier1
             suites: jdk_tier1
@@ -210,6 +211,8 @@ jobs:
             suites: langtools_tier1
           - test: hotspot/tier1
             suites: hotspot_tier1
+          - test: jdk/security_infra
+            suites: jdk_security_infra
 
     env:
       JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).JDK_MAJOR_VERSION }}.${{ fromJson(needs.prerequisites.outputs.dependencies).JDK_MINOR_VERSION }}.${{ fromJson(needs.prerequisites.outputs.dependencies).JDK_MICRO_VERSION }}"
@@ -559,6 +562,7 @@ jobs:
           - jdk/tier1
           - langtools/tier1
           - hotspot/tier1
+          - jdk/security_infra
         include:
           - test: jdk/tier1
             suites: jdk_tier1
@@ -566,6 +570,8 @@ jobs:
             suites: langtools_tier1
           - test: hotspot/tier1
             suites: hotspot_tier1
+          - test: jdk/security_infra
+            suites: jdk_security_infra
 
     # Reduced 32-bit build uses the same boot JDK as 64-bit build
     env:
@@ -1034,6 +1040,7 @@ jobs:
           - jdk/tier1
           - langtools/tier1
           - hotspot/tier1
+          - jdk/security_infra
         include:
           - test: jdk/tier1
             suites: jdk_tier1
@@ -1041,6 +1048,8 @@ jobs:
             suites: langtools_tier1
           - test: hotspot/tier1
             suites: hotspot_tier1
+          - test: jdk/security_infra
+            suites: jdk_security_infra
 
     env:
       JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).JDK_MAJOR_VERSION }}.${{ fromJson(needs.prerequisites.outputs.dependencies).JDK_MINOR_VERSION }}.${{ fromJson(needs.prerequisites.outputs.dependencies).JDK_MICRO_VERSION }}"
@@ -1192,6 +1201,7 @@ jobs:
           - jdk/tier1
           - langtools/tier1
           - hotspot/tier1
+          - jdk/security_infra
         include:
           - test: jdk/tier1
             suites: jdk_tier1
@@ -1199,6 +1209,8 @@ jobs:
             suites: langtools_tier1
           - test: hotspot/tier1
             suites: hotspot_tier1
+          - test: jdk/security_infra
+            suites: jdk_security_infra
 
     env:
       JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).JDK_MAJOR_VERSION }}.${{ fromJson(needs.prerequisites.outputs.dependencies).JDK_MINOR_VERSION }}.${{ fromJson(needs.prerequisites.outputs.dependencies).JDK_MICRO_VERSION }}"
@@ -1448,6 +1460,7 @@ jobs:
           - jdk/tier1
           - langtools/tier1
           - hotspot/tier1
+          - jdk/security_infra
         include:
           - test: jdk/tier1
             suites: jdk_tier1
@@ -1455,6 +1468,8 @@ jobs:
             suites: langtools_tier1
           - test: hotspot/tier1
             suites: hotspot_tier1
+          - test: jdk/security_infra
+            suites: jdk_security_infra
 
     env:
       JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).JDK_MAJOR_VERSION }}.${{ fromJson(needs.prerequisites.outputs.dependencies).JDK_MINOR_VERSION }}.${{ fromJson(needs.prerequisites.outputs.dependencies).JDK_MICRO_VERSION }}"

--- a/jdk/test/TEST.groups
+++ b/jdk/test/TEST.groups
@@ -29,8 +29,7 @@ jdk_tier1 = \
     :jdk_lang \
     :jdk_util \
     :jdk_math \
-    :jdk_jdi \
-    :jdk_security_infra
+    :jdk_jdi
 
 jdk_tier2 = \
     :jdk_io \


### PR DESCRIPTION
After [JDK-8315757](https://bugs.openjdk.org/browse/JDK-8315757),  `jdk_security_infra` is included in `jdk_tier1` (jdk 8 only). I would like to exclude it from `jdk_tier1` and instead add new configurations to GHA workflow.

**Motivations:**
- `jdk_security_infra` has not proven to be very stable/reliable set of tests.
- being able to quickly distinguish `jdk_security_infra` test failures from other tests failures in results would be helpful
- tests in `jdk_security_infra` are created to work with internal cacerts, but vendors usually replace cacerts with their own (e.g. [temurin](https://github.com/adoptium/temurin-build/commit/9cb3ddcb8f3550aa904f086146be0cdd242d7e8a)). It then complicates running `jdk_tier1` group on jdk with custom cacerts (needs custom excludes etc..).
- jdk 8 is currently only jdk including `jdk_security_infra` in `jdk_tier1`

**Testing:**
GHA: OK (all test failures should be unrelated to this change)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8342841](https://bugs.openjdk.org/browse/JDK-8342841) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342841](https://bugs.openjdk.org/browse/JDK-8342841): [8u] Separate jdk_security_infra tests from jdk_tier1 (**Bug** - P4 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/596/head:pull/596` \
`$ git checkout pull/596`

Update a local copy of the PR: \
`$ git checkout pull/596` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/596/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 596`

View PR using the GUI difftool: \
`$ git pr show -t 596`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/596.diff">https://git.openjdk.org/jdk8u-dev/pull/596.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/596#issuecomment-2429673988)
</details>
