### PR TITLE
8343334: JFR crash in JfrEmergencyDump::build_dump_path

### DIFF
--- a/hotspot/src/share/vm/jfr/recorder/repository/jfrEmergencyDump.cpp
+++ b/hotspot/src/share/vm/jfr/recorder/repository/jfrEmergencyDump.cpp
@@ -306,7 +306,7 @@ static const char* create_emergency_chunk_path(const char* repository_path) {
     return NULL;
   }
   // append the individual substrings
-  jio_snprintf(chunk_path, chunkname_max_len, "%s%s%s%s", repository_path_len, os::file_separator(), date_time_buffer, chunk_file_jfr_ext);
+  jio_snprintf(chunk_path, chunkname_max_len, "%s%s%s%s", repository_path, os::file_separator(), date_time_buffer, chunk_file_jfr_ext);
   return chunk_path;
 }
 


### PR DESCRIPTION
Expect a string value but actually pass an integer value to `jio_snprintf` which could lead to undefined behavior.
The minor result is the error JFR file path, the major result is JVM crash.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] [JDK-8343334](https://bugs.openjdk.org/browse/JDK-8343334) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343334](https://bugs.openjdk.org/browse/JDK-8343334): JFR crash in JfrEmergencyDump::build_dump_path (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/599/head:pull/599` \
`$ git checkout pull/599`

Update a local copy of the PR: \
`$ git checkout pull/599` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/599/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 599`

View PR using the GUI difftool: \
`$ git pr show -t 599`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/599.diff">https://git.openjdk.org/jdk8u-dev/pull/599.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/599#issuecomment-2448943026)
</details>
