### PR TITLE
8342822: jdk8u432-b06 does not compile on AIX

### DIFF
--- a/hotspot/src/share/vm/opto/superword.hpp
+++ b/hotspot/src/share/vm/opto/superword.hpp
@@ -588,7 +588,8 @@ class SWPointer VALUE_OBJ_CLASS_SPEC {
         _scale == q._scale   &&
         _invar == q._invar   &&
         _negate_invar == q._negate_invar) {
-      jlong difference = llabs(java_subtract((jlong)_offset, (jlong)q._offset));
+      jlong output = java_subtract((jlong)_offset, (jlong)q._offset);
+      jlong difference = output >= 0 ? output : -1ll * output;
       jlong max_diff = (jlong)1 << 31;
       if (difference >= max_diff) {
         return NotComparable;

--- a/hotspot/src/share/vm/opto/superword.hpp
+++ b/hotspot/src/share/vm/opto/superword.hpp
@@ -30,7 +30,10 @@
 #include "opto/phaseX.hpp"
 #include "opto/vectornode.hpp"
 #include "utilities/growableArray.hpp"
+
+#ifdef AIX
 #include "cstdlib"
+#endif
 
 //
 //                  S U P E R W O R D   T R A N S F O R M

--- a/hotspot/src/share/vm/opto/superword.hpp
+++ b/hotspot/src/share/vm/opto/superword.hpp
@@ -588,7 +588,7 @@ class SWPointer VALUE_OBJ_CLASS_SPEC {
         _scale == q._scale   &&
         _invar == q._invar   &&
         _negate_invar == q._negate_invar) {
-      jlong difference = labs(java_subtract((jlong)_offset, (jlong)q._offset));
+      jlong difference = llabs(java_subtract((jlong)_offset, (jlong)q._offset));
       jlong max_diff = (jlong)1 << 31;
       if (difference >= max_diff) {
         return NotComparable;

--- a/hotspot/src/share/vm/opto/superword.hpp
+++ b/hotspot/src/share/vm/opto/superword.hpp
@@ -30,6 +30,7 @@
 #include "opto/phaseX.hpp"
 #include "opto/vectornode.hpp"
 #include "utilities/growableArray.hpp"
+#include "cstdlib"
 
 //
 //                  S U P E R W O R D   T R A N S F O R M
@@ -588,8 +589,7 @@ class SWPointer VALUE_OBJ_CLASS_SPEC {
         _scale == q._scale   &&
         _invar == q._invar   &&
         _negate_invar == q._negate_invar) {
-      jlong output = java_subtract((jlong)_offset, (jlong)q._offset);
-      jlong difference = output >= 0 ? output : -1ll * output;
+      jlong difference = abs(java_subtract((jlong)_offset, (jlong)q._offset));
       jlong max_diff = (jlong)1 << 31;
       if (difference >= max_diff) {
         return NotComparable;

--- a/hotspot/src/share/vm/opto/superword.hpp
+++ b/hotspot/src/share/vm/opto/superword.hpp
@@ -588,7 +588,7 @@ class SWPointer VALUE_OBJ_CLASS_SPEC {
         _scale == q._scale   &&
         _invar == q._invar   &&
         _negate_invar == q._negate_invar) {
-      jlong difference = abs(java_subtract((jlong)_offset, (jlong)q._offset));
+      jlong difference = labs(java_subtract((jlong)_offset, (jlong)q._offset));
       jlong max_diff = (jlong)1 << 31;
       if (difference >= max_diff) {
         return NotComparable;


### PR DESCRIPTION
Use of llabs() for jlong resolves the build error on AIX.
Performed jtreg testing for hotspot/test on both aix-ppc64 and linux-ppc64le and no related failures observed 

JBS : [JDK-8342822](https://bugs.openjdk.org/browse/JDK-8342822)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8342822](https://bugs.openjdk.org/browse/JDK-8342822) needs maintainer approval

### Issue
 * [JDK-8342822](https://bugs.openjdk.org/browse/JDK-8342822): jdk8u432-b06 does not compile on AIX (**Bug** - P2 - Requested) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewers
 * [Francisco Ferrari Bihurriet](https://openjdk.org/census#fferrari) (@franferrax - no project role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/600/head:pull/600` \
`$ git checkout pull/600`

Update a local copy of the PR: \
`$ git checkout pull/600` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/600/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 600`

View PR using the GUI difftool: \
`$ git pr show -t 600`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/600.diff">https://git.openjdk.org/jdk8u-dev/pull/600.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/600#issuecomment-2449513572)
</details>
