### PR TITLE
8287113: JFR: Periodic task thread uses period for method sampling events

### DIFF
--- a/jdk/src/share/classes/jdk/jfr/internal/MetadataRepository.java
+++ b/jdk/src/share/classes/jdk/jfr/internal/MetadataRepository.java
@@ -78,7 +78,7 @@ public final class MetadataRepository {
                 // annotations, such as Period and Threshold.
                 if (pEventType.hasPeriod()) {
                     pEventType.setEventHook(true);
-                    if (!(Type.EVENT_NAME_PREFIX + "ExecutionSample").equals(type.getName())) {
+                    if (!pEventType.isMethodSampling()) {
                         requestHooks.add(new RequestHook(pEventType));
                     }
                 }

--- a/jdk/src/share/classes/jdk/jfr/internal/PlatformEventType.java
+++ b/jdk/src/share/classes/jdk/jfr/internal/PlatformEventType.java
@@ -278,4 +278,8 @@ public final class PlatformEventType extends Type {
     public int getStackTraceOffset() {
         return stackTraceOffset;
     }
+
+    public boolean isMethodSampling() {
+        return isMethodSampling;
+    }
 }


### PR DESCRIPTION
Clean backport from JDK11
I'd like to backport it to improve resource usage when running an application with the JFR default profile.

All JFR-related JTREG tests passed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8287113](https://bugs.openjdk.org/browse/JDK-8287113) needs maintainer approval

### Issue
 * [JDK-8287113](https://bugs.openjdk.org/browse/JDK-8287113): JFR: Periodic task thread uses period for method sampling events (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/601/head:pull/601` \
`$ git checkout pull/601`

Update a local copy of the PR: \
`$ git checkout pull/601` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/601/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 601`

View PR using the GUI difftool: \
`$ git pr show -t 601`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/601.diff">https://git.openjdk.org/jdk8u-dev/pull/601.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/601#issuecomment-2458465060)
</details>
