### PR TITLE
8062938: [TEST_BUG] sun/jvmstat/monitor/MonitoredVm/CR6672135.java: java.lang.IllegalArgumentException: Could not map vmid to user name

### DIFF
--- a/jdk/test/sun/jvmstat/monitor/MonitoredVm/TestPollingInterval.java
+++ b/jdk/test/sun/jvmstat/monitor/MonitoredVm/TestPollingInterval.java
@@ -21,11 +21,18 @@
  * questions.
  */
 
+import java.io.IOException;
 import java.net.URISyntaxException;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
+
+import jdk.testlibrary.Asserts;
+import jdk.testlibrary.Utils;
+import jdk.test.lib.apps.LingeredApp;
 import sun.jvmstat.monitor.MonitorException;
 import sun.jvmstat.monitor.MonitoredHost;
 import sun.jvmstat.monitor.MonitoredVm;
+import sun.jvmstat.monitor.MonitoredVmUtil;
 import sun.jvmstat.monitor.VmIdentifier;
 
 /**
@@ -33,40 +40,41 @@ import sun.jvmstat.monitor.VmIdentifier;
  * @test
  * @bug 6672135
  * @summary setInterval() for local MonitoredHost and local MonitoredVm
- * @author Tomas Hurka
- * @run main/othervm -XX:+UsePerfData CR6672135
+ * @modules jdk.jvmstat/sun.jvmstat.monitor
+ * @library /lib/testlibrary
+ * @library /../../test/lib/share/classes
+ * @build jdk.testlibrary.*
+ * @build jdk.test.lib.apps.*
+ * @run main TestPollingInterval
  */
-public class CR6672135 {
+public class TestPollingInterval {
 
     private static final int INTERVAL = 2000;
 
-    public static void main(String[] args) {
-        int vmInterval;
-        int hostInterval;
-
+    public static void main(String[] args) throws IOException,
+            MonitorException, URISyntaxException {
+        LingeredApp app = null;
         try {
+            List<String> vmArgs = new ArrayList<String>();
+            vmArgs.add("-XX:+UsePerfData");
+            vmArgs.addAll(Utils.getVmOptions());
+            app = LingeredApp.startApp(vmArgs);
+
             MonitoredHost localHost = MonitoredHost.getMonitoredHost("localhost");
-            Set vms = localHost.activeVms();
-            Integer vmInt =  (Integer) vms.iterator().next();
-            String uriString = "//" + vmInt + "?mode=r"; // NOI18N
+            String uriString = "//" + app.getPid() + "?mode=r"; // NOI18N
             VmIdentifier vmId = new VmIdentifier(uriString);
             MonitoredVm vm = localHost.getMonitoredVm(vmId);
+            System.out.println("Monitored vm command line: " + MonitoredVmUtil.commandLine(vm));
 
             vm.setInterval(INTERVAL);
             localHost.setInterval(INTERVAL);
-            vmInterval = vm.getInterval();
-            hostInterval = localHost.getInterval();
-        } catch (Exception ex) {
-            throw new Error ("Test failed",ex);
-        }
-        System.out.println("VM "+vmInterval);
-        if (vmInterval != INTERVAL) {
-            throw new Error("Test failed");
-        }
-        System.out.println("Host "+hostInterval);
-        if (hostInterval != INTERVAL) {
-            throw new Error("Test failed");
-        }
-    }
-}
 
+            Asserts.assertEquals(vm.getInterval(), INTERVAL, "Monitored vm interval should be equal the test value");
+            Asserts.assertEquals(localHost.getInterval(), INTERVAL, "Monitored host interval should be equal the test value");
+        } finally {
+            LingeredApp.stopApp(app);
+        }
+
+    }
+
+}


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8062938](https://bugs.openjdk.org/browse/JDK-8062938) needs maintainer approval

### Issue
 * [JDK-8062938](https://bugs.openjdk.org/browse/JDK-8062938): [TEST_BUG] sun/jvmstat/monitor/MonitoredVm/CR6672135.java: java.lang.IllegalArgumentException: Could not map vmid to user name (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/603/head:pull/603` \
`$ git checkout pull/603`

Update a local copy of the PR: \
`$ git checkout pull/603` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/603/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 603`

View PR using the GUI difftool: \
`$ git pr show -t 603`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/603.diff">https://git.openjdk.org/jdk8u-dev/pull/603.diff</a>

</details>
