### PR TITLE
8160974: [TESTBUG] Mark more headful tests with @key headful.

### DIFF
--- a/jdk/test/com/sun/java/swing/plaf/windows/8016551/bug8016551.java
+++ b/jdk/test/com/sun/java/swing/plaf/windows/8016551/bug8016551.java
@@ -21,7 +21,9 @@
  * questions.
  */
 
-/* @test
+/*
+ * @test
+ * @key headful
  * @bug 8016551
  * @summary JMenuItem in WindowsLookAndFeel can't paint default icons
  * @author Leonid Romanov

--- a/jdk/test/java/awt/Checkbox/SetStateExcessEvent/SetStateExcessEvent.java
+++ b/jdk/test/java/awt/Checkbox/SetStateExcessEvent/SetStateExcessEvent.java
@@ -29,6 +29,7 @@ import java.awt.Robot;
 
 /**
  * @test
+ * @key headful
  * @bug 8074500
  * @summary Checkbox.setState() call should not post ItemEvent
  * @author Sergey Bylokhov

--- a/jdk/test/java/awt/Choice/ChoiceLocationTest/ChoiceLocationTest.java
+++ b/jdk/test/java/awt/Choice/ChoiceLocationTest/ChoiceLocationTest.java
@@ -22,13 +22,14 @@
  */
 
 /*
- @test
-  @bug 7159566
-  @summary The choice positioned in the top of applet when clicking the choice.
-  @author Petr Pchelko
-  @library ../../regtesthelpers
-  @build Util
-  @run main ChoiceLocationTest
+ * @test
+ * @key headful
+ * @bug 7159566
+ * @summary The choice positioned in the top of applet when clicking the choice.
+ * @author Petr Pchelko
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main ChoiceLocationTest
  */
 
 import java.awt.*;

--- a/jdk/test/java/awt/Choice/DragMouseOutAndRelease/DragMouseOutAndRelease.java
+++ b/jdk/test/java/awt/Choice/DragMouseOutAndRelease/DragMouseOutAndRelease.java
@@ -22,6 +22,7 @@
  */
 /*
   @test
+  @key headful
   @bug 6322625
   @summary REG:Choice does not trigger MouseReleased when dragging and releasing the mouse outside choice, XAWT
   @author andrei.dmitriev area=awt.choice

--- a/jdk/test/java/awt/Choice/GetSizeTest/GetSizeTest.java
+++ b/jdk/test/java/awt/Choice/GetSizeTest/GetSizeTest.java
@@ -22,6 +22,7 @@
  */
 /*
   @test
+  @key headful
   @bug 4255631
   @summary Solaris: Size returned by Choice.getSize() does not match actual size
   @author Andrei Dmitriev : area=Choice

--- a/jdk/test/java/awt/Choice/ResizeAutoClosesChoice/ResizeAutoClosesChoice.java
+++ b/jdk/test/java/awt/Choice/ResizeAutoClosesChoice/ResizeAutoClosesChoice.java
@@ -22,6 +22,7 @@
  */
 /*
   @test
+  @key headful
   @bug 6399679
   @summary Choice is not invalidated when the frame gets resized programmatically when the drop-down is visible
   @author andrei.dmitriev area=awt.choice

--- a/jdk/test/java/awt/Choice/UnfocusableCB_ERR/UnfocusableCB_ERR.java
+++ b/jdk/test/java/awt/Choice/UnfocusableCB_ERR/UnfocusableCB_ERR.java
@@ -22,6 +22,7 @@
  */
 /*
   @test
+  @key headful
   @bug 6390103
   @summary Non-Focusable choice throws exception when selecting an item, Win32
   @author andrei.dmitriev area=awt.choice

--- a/jdk/test/java/awt/Choice/UnfocusableToplevel/UnfocusableToplevel.java
+++ b/jdk/test/java/awt/Choice/UnfocusableToplevel/UnfocusableToplevel.java
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6566434
   @library ../../regtesthelpers
   @build Util Sysout AbstractTest

--- a/jdk/test/java/awt/Component/DimensionEncapsulation/DimensionEncapsulation.java
+++ b/jdk/test/java/awt/Component/DimensionEncapsulation/DimensionEncapsulation.java
@@ -90,6 +90,7 @@ import static javax.swing.UIManager.getInstalledLookAndFeels;
 
 /**
  * @test
+ * @key headful
  * @bug 6459798
  * @author Sergey Bylokhov
  */

--- a/jdk/test/java/awt/Component/InsetsEncapsulation/InsetsEncapsulation.java
+++ b/jdk/test/java/awt/Component/InsetsEncapsulation/InsetsEncapsulation.java
@@ -74,6 +74,7 @@ import static javax.swing.UIManager.getInstalledLookAndFeels;
 
 /**
  * @test
+ * @key headful
  * @bug 6459800
  * @author Sergey Bylokhov
  */

--- a/jdk/test/java/awt/Component/PaintAll/PaintAll.java
+++ b/jdk/test/java/awt/Component/PaintAll/PaintAll.java
@@ -43,6 +43,7 @@ import java.awt.image.BufferedImage;
 
 /*
   @test
+  @key headful
   @bug 6596915
   @summary Test Component.paintAll() method
   @author sergey.bylokhov@oracle.com: area=awt.component

--- a/jdk/test/java/awt/Component/Revalidate/Revalidate.java
+++ b/jdk/test/java/awt/Component/Revalidate/Revalidate.java
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 7036669
   @summary Test Component.revalidate() method
   @author anthony.petrov@oracle.com: area=awt.component

--- a/jdk/test/java/awt/Component/SetEnabledPerformance/SetEnabledPerformance.java
+++ b/jdk/test/java/awt/Component/SetEnabledPerformance/SetEnabledPerformance.java
@@ -31,6 +31,7 @@ import javax.swing.SwingUtilities;
 
 /**
  * @test
+ * @key headful
  * @bug 8071306
  * @author Sergey Bylokhov
  */

--- a/jdk/test/java/awt/Container/CheckZOrderChange/CheckZOrderChange.java
+++ b/jdk/test/java/awt/Container/CheckZOrderChange/CheckZOrderChange.java
@@ -22,12 +22,14 @@
  */
 
 /*
-   @test %I% %E%
-   @bug 2161766
-   @summary Component is missing after changing the z-order of the component & focus is not transfered in
-   @author  Andrei Dmitriev : area=awt.container
-   @run main CheckZOrderChange
-*/
+ * @test %I% %E%
+ * @key headful
+ * @bug 2161766
+ * @summary Component is missing after changing the z-order of the component & focus is not transfered in
+ * @author  Andrei Dmitriev : area=awt.container
+ * @run main CheckZOrderChange
+ */
+
 import java.awt.*;
 import java.awt.event.*;
 

--- a/jdk/test/java/awt/Container/ValidateRoot/InvalidateMustRespectValidateRoots.java
+++ b/jdk/test/java/awt/Container/ValidateRoot/InvalidateMustRespectValidateRoots.java
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6852592
   @summary invalidate() must stop when it encounters a validate root
   @author anthony.petrov@sun.com

--- a/jdk/test/java/awt/Dialog/MakeWindowAlwaysOnTop/MakeWindowAlwaysOnTop.java
+++ b/jdk/test/java/awt/Dialog/MakeWindowAlwaysOnTop/MakeWindowAlwaysOnTop.java
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6829546
   @summary tests that an always-on-top modal dialog doesn't make any windows always-on-top
   @author artem.ananiev: area=awt.modal

--- a/jdk/test/java/awt/Dialog/ValidateOnShow/ValidateOnShow.java
+++ b/jdk/test/java/awt/Dialog/ValidateOnShow/ValidateOnShow.java
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 7027013
   @summary Dialog.show() should validate the window unconditionally
   @author anthony.petrov@oracle.com: area=awt.toplevel

--- a/jdk/test/java/awt/EventDispatchThread/LoopRobustness/LoopRobustness.java
+++ b/jdk/test/java/awt/EventDispatchThread/LoopRobustness/LoopRobustness.java
@@ -24,7 +24,8 @@
 /**
  *
  * @bug 4023283
- * @summary Checks that an Error which propogate up to the EventDispatch
+ * @key headful
+ * @summary Checks that an Error which propogates up to the EventDispatch
  * loop does not crash AWT.
  * @author Andrei Dmitriev: area=awt.event
  * @library ../../regtesthelpers

--- a/jdk/test/java/awt/Focus/6981400/Test1.java
+++ b/jdk/test/java/awt/Focus/6981400/Test1.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug     6981400
  * @summary Tabbing between textfiled do not work properly when ALT+TAB
  * @author  anton.tarasov

--- a/jdk/test/java/awt/Focus/6981400/Test2.java
+++ b/jdk/test/java/awt/Focus/6981400/Test2.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug     6981400
  * @summary Tabbing between textfiled do not work properly when ALT+TAB
  * @author  anton.tarasov

--- a/jdk/test/java/awt/Focus/6981400/Test3.java
+++ b/jdk/test/java/awt/Focus/6981400/Test3.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug     6981400
  * @summary Tabbing between textfiled do not work properly when ALT+TAB
  * @author  anton.tarasov

--- a/jdk/test/java/awt/Focus/8013611/JDK8013611.java
+++ b/jdk/test/java/awt/Focus/8013611/JDK8013611.java
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug      8013611
   @summary  Tests showing a modal dialog with requesting focus in frame.
   @author   Anton.Tarasov: area=awt.focus

--- a/jdk/test/java/awt/Focus/8073453/AWTFocusTransitionTest.java
+++ b/jdk/test/java/awt/Focus/8073453/AWTFocusTransitionTest.java
@@ -21,7 +21,9 @@
  * questions.
  */
 
-/* @test
+/*
+ * @test
+ * @key headful
  * @bug 8073453
  * @summary Focus doesn't move when pressing Shift + Tab keys
  * @author Dmitry Markov

--- a/jdk/test/java/awt/Focus/8073453/SwingFocusTransitionTest.java
+++ b/jdk/test/java/awt/Focus/8073453/SwingFocusTransitionTest.java
@@ -21,7 +21,9 @@
  * questions.
  */
 
-/* @test
+/*
+ * @test
+ * @key headful
  * @bug 8073453
  * @summary Focus doesn't move when pressing Shift + Tab keys
  * @author Dmitry Markov

--- a/jdk/test/java/awt/Focus/ActualFocusedWindowTest/ActualFocusedWindowRetaining.java
+++ b/jdk/test/java/awt/Focus/ActualFocusedWindowTest/ActualFocusedWindowRetaining.java
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug      4823903
   @summary  Tests actual focused window retaining.
   @author   Anton.Tarasov: area=awt.focus

--- a/jdk/test/java/awt/Focus/AutoRequestFocusTest/AutoRequestFocusSetVisibleTest.java
+++ b/jdk/test/java/awt/Focus/AutoRequestFocusTest/AutoRequestFocusSetVisibleTest.java
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug       6187066
   @summary   Tests the Window.autoRequestFocus property for the Window.setVisible() method.
   @author    anton.tarasov: area=awt.focus

--- a/jdk/test/java/awt/Focus/AutoRequestFocusTest/AutoRequestFocusToFrontTest.java
+++ b/jdk/test/java/awt/Focus/AutoRequestFocusTest/AutoRequestFocusToFrontTest.java
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug       6187066
   @summary   Tests the Window.autoRequestFocus property for the Window.toFront() method.
   @author    anton.tarasov: area=awt.focus

--- a/jdk/test/java/awt/Focus/ClearGlobalFocusOwnerTest/ClearGlobalFocusOwnerTest.java
+++ b/jdk/test/java/awt/Focus/ClearGlobalFocusOwnerTest/ClearGlobalFocusOwnerTest.java
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 4390555
   @summary Synopsis: clearGlobalFocusOwner() is not trigerring permanent FOCUS_LOST event
   @author son@sparc.spb.su, anton.tarasov: area=awt.focus

--- a/jdk/test/java/awt/Focus/KeyEventForBadFocusOwnerTest/KeyEventForBadFocusOwnerTest.java
+++ b/jdk/test/java/awt/Focus/KeyEventForBadFocusOwnerTest/KeyEventForBadFocusOwnerTest.java
@@ -22,6 +22,7 @@
  */
 /*
   @test
+  @key headful
   @bug 4476629
   @library ../../../../javax/swing/regtesthelpers
   @build Util

--- a/jdk/test/java/awt/Focus/MouseClickRequestFocusRaceTest/MouseClickRequestFocusRaceTest.java
+++ b/jdk/test/java/awt/Focus/MouseClickRequestFocusRaceTest/MouseClickRequestFocusRaceTest.java
@@ -21,12 +21,13 @@
  * questions.
  */
 
-/*
-  test
-  @bug       5028014
-  @summary   Focus request & mouse click performed nearly synchronously shouldn't lead to a focus race.
-  @author    anton.tarasov@sun.com: area=awt-focus
-  @run       applet MouseClickRequestFocusRaceTest.html
+/**
+ * test
+ * @key headful
+ * @bug       5028014
+ * @summary   Focus request & mouse click performed nearly synchronously shouldn't lead to a focus race.
+ * @author    anton.tarasov@sun.com: area=awt-focus
+ * @run       applet MouseClickRequestFocusRaceTest.html
 */
 
 import java.awt.*;

--- a/jdk/test/java/awt/Focus/RemoveAfterRequest/RemoveAfterRequest.java
+++ b/jdk/test/java/awt/Focus/RemoveAfterRequest/RemoveAfterRequest.java
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6411406
   @summary Components automatically transfer focus on removal, even if developer requests focus elsewhere first
   @author oleg.sukhodolsky, anton.tarasov: area=awt.focus

--- a/jdk/test/java/awt/Focus/RollbackFocusFromAnotherWindowTest/RollbackFocusFromAnotherWindowTest.java
+++ b/jdk/test/java/awt/Focus/RollbackFocusFromAnotherWindowTest/RollbackFocusFromAnotherWindowTest.java
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug       8139218
   @summary   Dialog that opens and closes quickly changes focus in original
              focusowner

--- a/jdk/test/java/awt/Focus/SimpleWindowActivationTest/SimpleWindowActivationTest.java
+++ b/jdk/test/java/awt/Focus/SimpleWindowActivationTest/SimpleWindowActivationTest.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug       6385277
  * @summary   Tests that override redirect window gets activated on click.
  * @author    anton.tarasov@sun.com: area=awt.focus

--- a/jdk/test/java/awt/Focus/TranserFocusToWindow/TranserFocusToWindow.java
+++ b/jdk/test/java/awt/Focus/TranserFocusToWindow/TranserFocusToWindow.java
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug       6562853
   @summary   Tests that focus transfered directy to window w/o transfering it to frame.
   @author    Oleg Sukhodolsky: area=awt.focus

--- a/jdk/test/java/awt/Focus/TypeAhead/TestFocusFreeze.java
+++ b/jdk/test/java/awt/Focus/TypeAhead/TestFocusFreeze.java
@@ -22,14 +22,15 @@
  */
 
 /*
-   @test
-   @bug        6183877 6216005 6225560
-   @library    ../../regtesthelpers
-   @build      Util
-   @summary    Tests that keyboard input doesn't freeze due to type-ahead problems
-   @author     Denis.Mikhalkin, Anton.Tarasov: area=awt.focus
-   @run        main TestFocusFreeze
-*/
+ * @test
+ * @key headful
+ * @bug        6183877 6216005 6225560
+ * @library    ../../regtesthelpers
+ * @build      Util
+ * @summary    Tests that keyboard input doesn't freeze due to type-ahead problems
+ * @author     Denis.Mikhalkin, Anton.Tarasov: area=awt.focus
+ * @run        main TestFocusFreeze
+ */
 
 import java.awt.Component;
 import java.awt.DefaultKeyboardFocusManager;

--- a/jdk/test/java/awt/Frame/DecoratedExceptions/DecoratedExceptions.java
+++ b/jdk/test/java/awt/Frame/DecoratedExceptions/DecoratedExceptions.java
@@ -29,6 +29,7 @@ import java.awt.*;
 
 /*
  * @test
+ * @key headful
  * @summary An attempt to set non-trivial background, shape, or translucency
  *          to a decorated toplevel should end with an exception.
  * @author Dmitriy Ermashov (dmitriy.ermashov@oracle.com)

--- a/jdk/test/java/awt/Frame/DisposeParentGC/DisposeParentGC.java
+++ b/jdk/test/java/awt/Frame/DisposeParentGC/DisposeParentGC.java
@@ -30,6 +30,7 @@ import java.util.Vector;
 
 /*
  * @test
+ * @key headful
  * @summary Display a dialog with a parent, the dialog contains all awt components
  *          added to it & each components are setted with different cursors types.
  *          Dispose the parent & collect GC. Garbage collection should happen

--- a/jdk/test/java/awt/Frame/FramesGC/FramesGC.java
+++ b/jdk/test/java/awt/Frame/FramesGC/FramesGC.java
@@ -30,6 +30,7 @@ import java.util.Vector;
 
 /*
  * @test
+ * @key headful
  * @summary Verify that disposed frames are collected with GC
  * @author Dmitriy Ermashov (dmitriy.ermashov@oracle.com)
  * @library ../../../../lib/testlibrary

--- a/jdk/test/java/awt/Frame/MiscUndecorated/ActiveAWTWindowTest.java
+++ b/jdk/test/java/awt/Frame/MiscUndecorated/ActiveAWTWindowTest.java
@@ -22,14 +22,15 @@
  */
 
 /*
-* @test
-* @summary To check proper WINDOW_EVENTS are triggered when Frame gains or losses the focus
-* @author Jitender(jitender.singh@eng.sun.com) area=AWT
-* @author yan
-* @library ../../../../lib/testlibrary
-* @build ExtendedRobot
-* @run main ActiveAWTWindowTest
-*/
+ * @test
+ * @key headful
+ * @summary To check proper WINDOW_EVENTS are triggered when Frame gains or losses the focus
+ * @author Jitender(jitender.singh@eng.sun.com) area=AWT
+ * @author yan
+ * @library ../../../../lib/testlibrary
+ * @build ExtendedRobot
+ * @run main ActiveAWTWindowTest
+ */
 
 import java.awt.*;
 import java.awt.event.*;

--- a/jdk/test/java/awt/Frame/MiscUndecorated/ActiveSwingWindowTest.java
+++ b/jdk/test/java/awt/Frame/MiscUndecorated/ActiveSwingWindowTest.java
@@ -22,14 +22,15 @@
  */
 
 /*
-* @test
-* @summary To check proper WINDOW_EVENTS are triggered when JFrame gains or losses the focus
-* @author Jitender(jitender.singh@eng.sun.com) area=AWT
-* @author yan
-* @library ../../../../lib/testlibrary
-* @build ExtendedRobot
-* @run main ActiveSwingWindowTest
-*/
+ * @test
+ * @key headful
+ * @summary To check proper WINDOW_EVENTS are triggered when JFrame gains or losses the focus
+ * @author Jitender(jitender.singh@eng.sun.com) area=AWT
+ * @author yan
+ * @library ../../../../lib/testlibrary
+ * @build ExtendedRobot
+ * @run main ActiveSwingWindowTest
+ */
 
 import java.awt.*;
 import java.awt.event.*;

--- a/jdk/test/java/awt/Frame/MiscUndecorated/FrameCloseTest.java
+++ b/jdk/test/java/awt/Frame/MiscUndecorated/FrameCloseTest.java
@@ -22,14 +22,15 @@
  */
 
 /*
-* @test
-* @summary To make sure Undecorated Frame triggers correct windows events while closing
-* @author Jitender(jitender.singh@eng.sun.com) area=AWT*
-* @author yan
-* @library ../../../../lib/testlibrary
-* @build ExtendedRobot
-* @run main FrameCloseTest
-*/
+ * @test
+ * @key headful
+ * @summary To make sure Undecorated Frame triggers correct windows events while closing
+ * @author Jitender(jitender.singh@eng.sun.com) area=AWT*
+ * @author yan
+ * @library ../../../../lib/testlibrary
+ * @build ExtendedRobot
+ * @run main FrameCloseTest
+ */
 
 import java.awt.*;
 import java.awt.event.*;

--- a/jdk/test/java/awt/Frame/MiscUndecorated/RepaintTest.java
+++ b/jdk/test/java/awt/Frame/MiscUndecorated/RepaintTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,16 +20,18 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 /*
-* @test
-* @summary Make sure that on changing state of Undecorated Frame,
-*          all the components on it are repainted correctly
-* @author Jitender(jitender.singh@eng.sun.com) area=AWT
-* @author yan
-* @library ../../../../lib/testlibrary
-* @build ExtendedRobot
-* @run main RepaintTest
-*/
+ * @test
+ * @key headful
+ * @summary Make sure that on changing state of Undecorated Frame,
+ *          all the components on it are repainted correctly
+ * @author Jitender(jitender.singh@eng.sun.com) area=AWT
+ * @author yan
+ * @library ../../../../lib/testlibrary
+ * @build ExtendedRobot
+ * @run main RepaintTest
+ */
 
 import java.awt.*;
 import java.awt.event.*;

--- a/jdk/test/java/awt/Frame/ShapeNotSetSometimes/ShapeNotSetSometimes.java
+++ b/jdk/test/java/awt/Frame/ShapeNotSetSometimes/ShapeNotSetSometimes.java
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6988428
   @summary Tests whether shape is always set
   @author anthony.petrov@oracle.com: area=awt.toplevel

--- a/jdk/test/java/awt/FullScreen/TranslucentWindow/TranslucentWindow.java
+++ b/jdk/test/java/awt/FullScreen/TranslucentWindow/TranslucentWindow.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6837004
  * @summary Checks that non-opaque window can be made a fullscreen window
  * @author Artem Ananiev

--- a/jdk/test/java/awt/Graphics2D/WhiteTextColorTest.java
+++ b/jdk/test/java/awt/Graphics2D/WhiteTextColorTest.java
@@ -27,11 +27,13 @@ import javax.swing.*;
 
 /**
  * @test
+ * @key headful
  * @bug 8056009
  * @summary tests whether Graphics.setColor-calls with Color.white are ignored directly
  *          after pipeline initialization for a certain set of operations.
  * @author ceisserer
  */
+
 public class WhiteTextColorTest extends Frame {
     public static volatile boolean success = false;
 

--- a/jdk/test/java/awt/GridLayout/ChangeGridSize/ChangeGridSize.java
+++ b/jdk/test/java/awt/GridLayout/ChangeGridSize/ChangeGridSize.java
@@ -26,6 +26,7 @@ import java.awt.event.*;
 
 /*
  * @test
+ * @key headful
  * @summary Have different components having different preferred sizes
  *          added to a grid layout. Change the rows and columns of the
  *          grid layout and check the components are re-laid out.

--- a/jdk/test/java/awt/GridLayout/ComponentPreferredSize/ComponentPreferredSize.java
+++ b/jdk/test/java/awt/GridLayout/ComponentPreferredSize/ComponentPreferredSize.java
@@ -26,6 +26,7 @@ import java.awt.event.InputEvent;
 
 /*
  * @test
+ * @key headful
  * @summary Have different components having different preferred sizes
  *          added to a grid layout having various values of row/columns.
  *          Check if the compnents are correctly laid out.

--- a/jdk/test/java/awt/LightweightDispatcher/LWDispatcherMemoryLeakTest.java
+++ b/jdk/test/java/awt/LightweightDispatcher/LWDispatcherMemoryLeakTest.java
@@ -38,6 +38,7 @@ import test.java.awt.regtesthelpers.Util;
 
 /*
  @test
+ @key headful
  @bug 7079254
  @summary Toolkit eventListener leaks memory
  @library ../regtesthelpers

--- a/jdk/test/java/awt/List/EmptyListEventTest/EmptyListEventTest.java
+++ b/jdk/test/java/awt/List/EmptyListEventTest/EmptyListEventTest.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6366126
  * @summary List throws ArrayIndexOutOfBoundsException when pressing ENTER after removing all the items, Win32
  * @author Dmitry Cherepanov area=awt.list

--- a/jdk/test/java/awt/List/NofocusListDblClickTest/NofocusListDblClickTest.java
+++ b/jdk/test/java/awt/List/NofocusListDblClickTest/NofocusListDblClickTest.java
@@ -22,6 +22,7 @@
  */
 /*
   @test
+  @key headful
   @bug       6240202
   @summary   Tests that non-focusable List in a Window generates ActionEvent.
   @author    anton.tarasov@sun.com: area=awt-list

--- a/jdk/test/java/awt/MenuBar/MenuBarSetFont/MenuBarSetFont.java
+++ b/jdk/test/java/awt/MenuBar/MenuBarSetFont/MenuBarSetFont.java
@@ -37,6 +37,7 @@ import jdk.testlibrary.OSInfo;
 
 /**
  * @test
+ * @key headful
  * @bug 6263470
  * @summary Tries to change font of MenuBar. Test passes if the font has changed
  * fails otherwise.

--- a/jdk/test/java/awt/Modal/FileDialog/FileDialogAppModal1Test.java
+++ b/jdk/test/java/awt/Modal/FileDialog/FileDialogAppModal1Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054359 7186009
  *
  * @summary Check whether FileDialog blocks an application modal Dialog

--- a/jdk/test/java/awt/Modal/FileDialog/FileDialogAppModal2Test.java
+++ b/jdk/test/java/awt/Modal/FileDialog/FileDialogAppModal2Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054359 7186009
  *
  * @summary Check whether FileDialog blocks an application modal Dialog

--- a/jdk/test/java/awt/Modal/FileDialog/FileDialogAppModal3Test.java
+++ b/jdk/test/java/awt/Modal/FileDialog/FileDialogAppModal3Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054359 7186009
  *
  * @summary Check whether FileDialog blocks an application modal Dialog

--- a/jdk/test/java/awt/Modal/FileDialog/FileDialogAppModal4Test.java
+++ b/jdk/test/java/awt/Modal/FileDialog/FileDialogAppModal4Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054359 7186009
  *
  * @summary Check whether FileDialog blocks an application modal Dialog

--- a/jdk/test/java/awt/Modal/FileDialog/FileDialogAppModal5Test.java
+++ b/jdk/test/java/awt/Modal/FileDialog/FileDialogAppModal5Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054359 7186009
  *
  * @summary Check whether FileDialog blocks an application modal Dialog

--- a/jdk/test/java/awt/Modal/FileDialog/FileDialogAppModal6Test.java
+++ b/jdk/test/java/awt/Modal/FileDialog/FileDialogAppModal6Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054359 7186009
  *
  * @summary Check whether FileDialog blocks an application modal Dialog

--- a/jdk/test/java/awt/Modal/FileDialog/FileDialogDocModal1Test.java
+++ b/jdk/test/java/awt/Modal/FileDialog/FileDialogDocModal1Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054359 7186009
  *
  * @summary Check whether FileDialog blocks a document modal Dialog

--- a/jdk/test/java/awt/Modal/FileDialog/FileDialogDocModal2Test.java
+++ b/jdk/test/java/awt/Modal/FileDialog/FileDialogDocModal2Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054359 7186009
  *
  * @summary Check whether FileDialog blocks a document modal Dialog

--- a/jdk/test/java/awt/Modal/FileDialog/FileDialogDocModal3Test.java
+++ b/jdk/test/java/awt/Modal/FileDialog/FileDialogDocModal3Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054359 7186009
  *
  * @summary Check whether FileDialog blocks a document modal Dialog

--- a/jdk/test/java/awt/Modal/FileDialog/FileDialogDocModal4Test.java
+++ b/jdk/test/java/awt/Modal/FileDialog/FileDialogDocModal4Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054359 7186009
  *
  * @summary Check whether FileDialog blocks a document modal Dialog

--- a/jdk/test/java/awt/Modal/FileDialog/FileDialogDocModal5Test.java
+++ b/jdk/test/java/awt/Modal/FileDialog/FileDialogDocModal5Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054359 7186009
  *
  * @summary Check whether FileDialog blocks a document modal Dialog

--- a/jdk/test/java/awt/Modal/FileDialog/FileDialogDocModal6Test.java
+++ b/jdk/test/java/awt/Modal/FileDialog/FileDialogDocModal6Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054359 7186009
  *
  * @summary Check whether FileDialog blocks a document modal Dialog

--- a/jdk/test/java/awt/Modal/FileDialog/FileDialogDocModal7Test.java
+++ b/jdk/test/java/awt/Modal/FileDialog/FileDialogDocModal7Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054359 7186009
  * @summary Check whether a FileDialog set to document modality behaves as expected.
  *

--- a/jdk/test/java/awt/Modal/FileDialog/FileDialogModal1Test.java
+++ b/jdk/test/java/awt/Modal/FileDialog/FileDialogModal1Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8054359 7186009
  *
  * @summary Check whether FileDialog blocks a modal Dialog

--- a/jdk/test/java/awt/Modal/FileDialog/FileDialogModal2Test.java
+++ b/jdk/test/java/awt/Modal/FileDialog/FileDialogModal2Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8054359 7186009
  *
  * @summary Check whether FileDialog blocks a modal Dialog

--- a/jdk/test/java/awt/Modal/FileDialog/FileDialogModal3Test.java
+++ b/jdk/test/java/awt/Modal/FileDialog/FileDialogModal3Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8054359 7186009
  *
  * @summary Check whether FileDialog blocks a modal Dialog

--- a/jdk/test/java/awt/Modal/FileDialog/FileDialogModal4Test.java
+++ b/jdk/test/java/awt/Modal/FileDialog/FileDialogModal4Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8054359 7186009
  *
  * @summary Check whether FileDialog blocks a modal Dialog

--- a/jdk/test/java/awt/Modal/FileDialog/FileDialogModal5Test.java
+++ b/jdk/test/java/awt/Modal/FileDialog/FileDialogModal5Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8054359 7186009
  *
  * @summary Check whether FileDialog blocks a modal Dialog

--- a/jdk/test/java/awt/Modal/FileDialog/FileDialogModal6Test.java
+++ b/jdk/test/java/awt/Modal/FileDialog/FileDialogModal6Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8054359 7186009
  *
  * @summary Check whether FileDialog blocks a modal Dialog

--- a/jdk/test/java/awt/Modal/FileDialog/FileDialogNonModal1Test.java
+++ b/jdk/test/java/awt/Modal/FileDialog/FileDialogNonModal1Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8054359 7186009
  *
  * @summary Check whether FileDialog blocks a non-modal Dialog

--- a/jdk/test/java/awt/Modal/FileDialog/FileDialogNonModal2Test.java
+++ b/jdk/test/java/awt/Modal/FileDialog/FileDialogNonModal2Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8054359
  *
  * @summary Check whether FileDialog blocks a non-modal Dialog

--- a/jdk/test/java/awt/Modal/FileDialog/FileDialogNonModal3Test.java
+++ b/jdk/test/java/awt/Modal/FileDialog/FileDialogNonModal3Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8054359
  *
  * @summary Check whether FileDialog blocks a non-modal Dialog

--- a/jdk/test/java/awt/Modal/FileDialog/FileDialogNonModal4Test.java
+++ b/jdk/test/java/awt/Modal/FileDialog/FileDialogNonModal4Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8054359
  *
  * @summary Check whether FileDialog blocks a non-modal Dialog

--- a/jdk/test/java/awt/Modal/FileDialog/FileDialogNonModal5Test.java
+++ b/jdk/test/java/awt/Modal/FileDialog/FileDialogNonModal5Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8054359
  *
  * @summary Check whether FileDialog blocks a non-modal Dialog

--- a/jdk/test/java/awt/Modal/FileDialog/FileDialogNonModal6Test.java
+++ b/jdk/test/java/awt/Modal/FileDialog/FileDialogNonModal6Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8054359
  *
  * @summary Check whether FileDialog blocks a non-modal Dialog

--- a/jdk/test/java/awt/Modal/FileDialog/FileDialogNonModal7Test.java
+++ b/jdk/test/java/awt/Modal/FileDialog/FileDialogNonModal7Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054359
  * @summary Check whether a modeless FileDialog behaves as expected.
  *

--- a/jdk/test/java/awt/Modal/FileDialog/FileDialogTKModal1Test.java
+++ b/jdk/test/java/awt/Modal/FileDialog/FileDialogTKModal1Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054359 8055752
  *
  * @summary Check whether FileDialog blocks a toolkit modal Dialog

--- a/jdk/test/java/awt/Modal/FileDialog/FileDialogTKModal2Test.java
+++ b/jdk/test/java/awt/Modal/FileDialog/FileDialogTKModal2Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054359 8055752
  *
  * @summary Check whether FileDialog blocks a toolkit modal Dialog

--- a/jdk/test/java/awt/Modal/FileDialog/FileDialogTKModal3Test.java
+++ b/jdk/test/java/awt/Modal/FileDialog/FileDialogTKModal3Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054359 8055752
  *
  * @summary Check whether FileDialog blocks a toolkit modal Dialog

--- a/jdk/test/java/awt/Modal/FileDialog/FileDialogTKModal4Test.java
+++ b/jdk/test/java/awt/Modal/FileDialog/FileDialogTKModal4Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054359 8055752
  *
  * @summary Check whether FileDialog blocks a toolkit modal Dialog

--- a/jdk/test/java/awt/Modal/FileDialog/FileDialogTKModal5Test.java
+++ b/jdk/test/java/awt/Modal/FileDialog/FileDialogTKModal5Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054359 8055752
  *
  * @summary Check whether FileDialog blocks a toolkit modal Dialog

--- a/jdk/test/java/awt/Modal/FileDialog/FileDialogTKModal6Test.java
+++ b/jdk/test/java/awt/Modal/FileDialog/FileDialogTKModal6Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054359 8055752
  *
  * @summary Check whether FileDialog blocks a toolkit modal Dialog

--- a/jdk/test/java/awt/Modal/FileDialog/FileDialogTKModal7Test.java
+++ b/jdk/test/java/awt/Modal/FileDialog/FileDialogTKModal7Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054359 7186009
  * @summary Check whether a FileDialog set to toolkit modality behaves as expected.
  *

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingDDAppModalTest.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingDDAppModalTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether an application modal Dialog created with a Dialog
  *          constructor receives focus, whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingDDDocModalTest.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingDDDocModalTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a document modal Dialog created with a Dialog
  *          constructor receives focus, whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingDDModelessTest.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingDDModelessTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a modeless Dialog created with a Dialog
  *          constructor receives focus, whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingDDNonModalTest.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingDDNonModalTest.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a non-modal Dialog created with a Dialog
  *          constructor receives focus, whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingDDSetModalTest.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingDDSetModalTest.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a modal Dialog created with a Dialog
  *          constructor receives focus, whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingDDToolkitModalTest.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingDDToolkitModalTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a toolkit modal Dialog created with a Dialog
  *          constructor receives focus, whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingDFAppModalTest.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingDFAppModalTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether an application modal Dialog created with a Frame
  *          constructor receives focus, whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingDFSetModalTest.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingDFSetModalTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a modal Dialog created with a Frame
  *          constructor receives focus, whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingDFToolkitModalTest.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingDFToolkitModalTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a toolkit modal Dialog created with a Frame
  *          constructor receives focus, whether its components receives focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingDFWModeless1Test.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingDFWModeless1Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a modeless Dialog created with a Frame
  *          constructor receives focus, whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingDFWModeless2Test.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingDFWModeless2Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a modeless Dialog created with a Dialog
  *          constructor receives focus, whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingDFWNonModal1Test.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingDFWNonModal1Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a non-modal Dialog created with a Frame
  *          constructor receives focus, whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingDFWNonModal2Test.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingDFWNonModal2Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a non-modal Dialog created with a Dialog
  *          constructor receives focus, whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingDocModalTest.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingDocModalTest.java
@@ -28,6 +28,7 @@ import static jdk.testlibrary.Asserts.*;
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Test if a document modality works as expected:
  *          whether all the windows lying down the document root

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingFDAppModalTest.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingFDAppModalTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether an application modal Dialog created with a Frame
  *          constructor receives focus, whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingFDDocModalTest.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingFDDocModalTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a document modal Dialog created with a Frame
  *          constructor receives focus, whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingFDModelessTest.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingFDModelessTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a modeless Dialog created with a Frame
  *          constructor receives focus, whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingFDNonModalTest.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingFDNonModalTest.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a non-modal Dialog created with a Frame
  *          constructor receives focus, whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingFDSetModalTest.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingFDSetModalTest.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a modal Dialog created with a Frame
  *          constructor receives focus, whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingFDToolkitModalTest.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingFDToolkitModalTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a toolkit modal Dialog created with a Frame
  *          constructor receives focus, whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingFDWDocModal1Test.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingFDWDocModal1Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a document modal Dialog created with a null Frame
  *          constructor receives focus; whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingFDWDocModal2Test.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingFDWDocModal2Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a document modal Dialog created with a null Dialog
  *          constructor receives focus; whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingFDWDocModal3Test.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingFDWDocModal3Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a document modal Dialog created with a hidden Frame
  *          constructor receives focus; whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingFDWDocModal4Test.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingFDWDocModal4Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a document modal Dialog created with a hidden Dialog
  *          constructor receives focus; whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingFDWModeless1Test.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingFDWModeless1Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a modeless Dialog created with a null Frame
  *          constructor receives focus; whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingFDWModeless2Test.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingFDWModeless2Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a modeless Dialog created with a null Dialog
  *          constructor receives focus; whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingFDWModeless3Test.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingFDWModeless3Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a modeless Dialog created with a hidden Frame
  *          constructor receives focus; whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingFDWModeless4Test.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingFDWModeless4Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a modeless Dialog created with a hidden Dialog
  *          constructor receives focus; whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingFDWNonModal1Test.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingFDWNonModal1Test.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a non-modal Dialog created with a null Frame
  *          constructor receives focus; whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingFDWNonModal2Test.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingFDWNonModal2Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a non-modal Dialog created with a null Dialog
  *          constructor receives focus; whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingFDWNonModal3Test.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingFDWNonModal3Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a non-modal Dialog created with a hidden Frame
  *          constructor receives focus; whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingFDWNonModal4Test.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingFDWNonModal4Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a non-modal Dialog created with a hidden Dialog
  *          constructor receives focus; whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingWindowsAppModal1Test.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingWindowsAppModal1Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether an application modal Dialog created with a null Frame
  *          constructor receives focus; whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingWindowsAppModal2Test.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingWindowsAppModal2Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether an application modal Dialog created with a null Dialog
  *          constructor receives focus; whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingWindowsAppModal3Test.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingWindowsAppModal3Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether an application modal Dialog created with a hidden Frame
  *          constructor receives focus; whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingWindowsAppModal4Test.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingWindowsAppModal4Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether an application modal Dialog created with a hidden Dialog
  *          constructor receives focus; whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingWindowsAppModal5Test.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingWindowsAppModal5Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether an application modal Dialog created with a Frame
  *          constructor receives focus; whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingWindowsAppModal6Test.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingWindowsAppModal6Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether an application modal Dialog created with a Dialog
  *          constructor receives focus; whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingWindowsDocModal1Test.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingWindowsDocModal1Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a document modal Dialog created with a Frame
  *          constructor receives focus; whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingWindowsDocModal2Test.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingWindowsDocModal2Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a document modal Dialog created with a Dialog
  *          constructor receives focus; whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingWindowsSetModal1Test.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingWindowsSetModal1Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a modal Dialog created with a null Frame
  *          constructor receives focus; whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingWindowsSetModal2Test.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingWindowsSetModal2Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a modal Dialog created with a null Dialog
  *          constructor receives focus; whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingWindowsSetModal3Test.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingWindowsSetModal3Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a modal Dialog created with a hidden Frame
  *          constructor receives focus; whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingWindowsSetModal4Test.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingWindowsSetModal4Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a modal Dialog created with a hidden Dialog
  *          constructor receives focus; whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingWindowsSetModal5Test.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingWindowsSetModal5Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a modal Dialog created with a Frame
  *          constructor receives focus; whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingWindowsSetModal6Test.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingWindowsSetModal6Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a modal Dialog created with a Dialog
  *          constructor receives focus; whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingWindowsToolkitModal1Test.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingWindowsToolkitModal1Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a toolkit modal Dialog created with a null Frame
  *          constructor receives focus; whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingWindowsToolkitModal2Test.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingWindowsToolkitModal2Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a toolkit modal Dialog created with a null Dialog
  *          constructor receives focus; whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingWindowsToolkitModal3Test.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingWindowsToolkitModal3Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a toolkit modal Dialog created with a hidden Frame
  *          constructor receives focus; whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingWindowsToolkitModal4Test.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingWindowsToolkitModal4Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a toolkit modal Dialog created with a hidden Dialog
  *          constructor receives focus; whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingWindowsToolkitModal5Test.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingWindowsToolkitModal5Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a toolkit modal Dialog created with a Frame
  *          constructor receives focus; whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingWindowsToolkitModal6Test.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/BlockingWindowsToolkitModal6Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a toolkit modal Dialog created with a Dialog
  *          constructor receives focus; whether its components receive focus

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/UnblockedDialogAppModalTest.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/UnblockedDialogAppModalTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether an application modal Dialog receives focus; check
  *          if its components receive focus and respond to key events

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/UnblockedDialogDocModalTest.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/UnblockedDialogDocModalTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a document modal Dialog receives focus; check
  *          if its components receive focus and respond to key events

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/UnblockedDialogModelessTest.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/UnblockedDialogModelessTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a modeless Dialog receives focus; check
  *          if its components receive focus and respond to key events

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/UnblockedDialogNonModalTest.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/UnblockedDialogNonModalTest.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a non-modal Dialog receives focus; check
  *          if its components receive focus and respond to key events

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/UnblockedDialogSetModalTest.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/UnblockedDialogSetModalTest.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a modal Dialog receives focus; check
  *          if its components receive focus and respond to key events

--- a/jdk/test/java/awt/Modal/ModalBlockingTests/UnblockedDialogToolkitModalTest.java
+++ b/jdk/test/java/awt/Modal/ModalBlockingTests/UnblockedDialogToolkitModalTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8049617
  * @summary Check whether a toolkit modal Dialog receives focus; check
  *          if its components receive focus and respond to key events

--- a/jdk/test/java/awt/Modal/ModalExclusionTests/ApplicationExcludeDialogFileTest.java
+++ b/jdk/test/java/awt/Modal/ModalExclusionTests/ApplicationExcludeDialogFileTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047179 8044429
  * @summary Check whether a FileDialog blocks an application modality excluded Dialog
  *          (it shouldn't). Checks also whether setting a parent dialog to be

--- a/jdk/test/java/awt/Modal/ModalExclusionTests/ApplicationExcludeDialogPageSetupTest.java
+++ b/jdk/test/java/awt/Modal/ModalExclusionTests/ApplicationExcludeDialogPageSetupTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 7125054 8044429
  * @summary Check whether a pageDialog blocks an application modality excluded Dialog
  *          (it shouldn't). Checks also whether setting a parent dialog to be

--- a/jdk/test/java/awt/Modal/ModalExclusionTests/ApplicationExcludeDialogPrintSetupTest.java
+++ b/jdk/test/java/awt/Modal/ModalExclusionTests/ApplicationExcludeDialogPrintSetupTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 7125054 8044429
  * @summary Check whether a printDialog blocks an application modality excluded Dialog
  *          (it shouldn't). Checks also whether setting a parent dialog to be

--- a/jdk/test/java/awt/Modal/ModalExclusionTests/ApplicationExcludeFrameFileTest.java
+++ b/jdk/test/java/awt/Modal/ModalExclusionTests/ApplicationExcludeFrameFileTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047179 8044429
  * @summary Check whether a FileDialog blocks an application modality excluded Frame
  *          (it shouldn't). Checks also whether setting a parent frame to be

--- a/jdk/test/java/awt/Modal/ModalExclusionTests/ApplicationExcludeFramePageSetupTest.java
+++ b/jdk/test/java/awt/Modal/ModalExclusionTests/ApplicationExcludeFramePageSetupTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 7125054 8044429
  * @summary Check whether a pageDialog blocks an application modality excluded Frame
  *          (it shouldn't). Checks also whether setting a parent frame to be

--- a/jdk/test/java/awt/Modal/ModalExclusionTests/ApplicationExcludeFramePrintSetupTest.java
+++ b/jdk/test/java/awt/Modal/ModalExclusionTests/ApplicationExcludeFramePrintSetupTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 7125054 8044429
  * @summary Check whether a printDialog blocks an application modality excluded Frame
  *          (it shouldn't). Checks also whether setting a parent frame to be

--- a/jdk/test/java/awt/Modal/ModalExclusionTests/ToolkitExcludeDialogFileTest.java
+++ b/jdk/test/java/awt/Modal/ModalExclusionTests/ToolkitExcludeDialogFileTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047179 8044429
  * @summary Check whether a FileDialog blocks a toolkit modality excluded Dialog
  *          (it shouldn't). Checks also whether setting a parent dialog to be

--- a/jdk/test/java/awt/Modal/ModalExclusionTests/ToolkitExcludeDialogPageSetupTest.java
+++ b/jdk/test/java/awt/Modal/ModalExclusionTests/ToolkitExcludeDialogPageSetupTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 7125054 8044429
  * @summary Check whether a pageDialog blocks a toolkit modality excluded Dialog
  *          (it shouldn't). Checks also whether setting a parent dialog to be

--- a/jdk/test/java/awt/Modal/ModalExclusionTests/ToolkitExcludeDialogPrintSetupTest.java
+++ b/jdk/test/java/awt/Modal/ModalExclusionTests/ToolkitExcludeDialogPrintSetupTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 7125054 8044429
  * @summary Check whether a printDialog blocks a toolkit modality excluded Dialog
  *          (it shouldn't). Checks also whether setting a parent dialog to be

--- a/jdk/test/java/awt/Modal/ModalExclusionTests/ToolkitExcludeFrameFileTest.java
+++ b/jdk/test/java/awt/Modal/ModalExclusionTests/ToolkitExcludeFrameFileTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047179 8044429
  * @summary Check whether a FileDialog blocks a toolkit modality excluded Frame
  *          (it shouldn't). Checks also whether setting a parent frame to be

--- a/jdk/test/java/awt/Modal/ModalExclusionTests/ToolkitExcludeFramePageSetupTest.java
+++ b/jdk/test/java/awt/Modal/ModalExclusionTests/ToolkitExcludeFramePageSetupTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 7125054 8044429
  * @summary Check whether a pageDialog blocks a toolkit modality excluded Frame
  *          (it shouldn't). Checks also whether setting a parent frame to be

--- a/jdk/test/java/awt/Modal/ModalExclusionTests/ToolkitExcludeFramePrintSetupTest.java
+++ b/jdk/test/java/awt/Modal/ModalExclusionTests/ToolkitExcludeFramePrintSetupTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 7125054 8044429
  * @summary Check whether a printDialog blocks a toolkit modality excluded Frame
  *          (it shouldn't). Checks also whether setting a parent frame to be

--- a/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferDWFAppModalTest.java
+++ b/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferDWFAppModalTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367
  * @summary Check whether the focus transfer between windows occurs correctly when the following
  *          happens: an application modal dialog (D) having null frame owner is shown;

--- a/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferDWFDocModalTest.java
+++ b/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferDWFDocModalTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367 8049339
  * @summary Check whether the focus transfer between windows occurs correctly when the
  *          following happens: a document modal dialog (D) having null frame owner is shown;

--- a/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferDWFModelessTest.java
+++ b/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferDWFModelessTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367 8049339
  * @summary Check whether the focus transfer between windows occurs correctly when the
  *          following happens: a modeless dialog (D) having null frame owner is shown;

--- a/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferDWFNonModalTest.java
+++ b/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferDWFNonModalTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367 8049339
  * @summary Check whether the focus transfer between windows occurs correctly when the following
  *          happens: a non-modal dialog (D) having null frame owner is shown; a window having D

--- a/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferDialogsAppModalTest.java
+++ b/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferDialogsAppModalTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367
  * @summary Check whether the focus transfer between windows occurs correctly when
  *          the following happens: an application modal dialog (D1) having a null

--- a/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferDialogsDocModalTest.java
+++ b/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferDialogsDocModalTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367
  * @summary Check whether the focus transfer between windows occurs correctly when
  *          the following happens: a document modal dialog (D1) having a null

--- a/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferDialogsModelessTest.java
+++ b/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferDialogsModelessTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367
  * @summary Check whether the focus transfer between windows occurs correctly when
  *          the following happens: a modeless dialog (D1) having a null

--- a/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferDialogsNonModalTest.java
+++ b/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferDialogsNonModalTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367
  * @summary Check whether the focus transfer between windows occurs correctly when
  *          the following happens: a non-modal dialog (D1) having a null

--- a/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferFDWAppModalTest.java
+++ b/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferFDWAppModalTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367
  * @summary Check whether the focus transfer between windows occurs correctly when
  *          the following happens: a frame is shown; an application modal dialog (D)

--- a/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferFDWDocModalTest.java
+++ b/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferFDWDocModalTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367
  * @summary Check whether the focus transfer between windows occurs correctly when
  *          the following happens: a frame is shown; a document modal dialog (D)

--- a/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferFDWModelessTest.java
+++ b/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferFDWModelessTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367
  * @summary Check whether the focus transfer between windows occurs correctly when
  *          the following happens: a frame is shown; a modeless dialog (D)

--- a/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferFDWNonModalTest.java
+++ b/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferFDWNonModalTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367
  * @summary Check whether the focus transfer between windows occurs correctly when
  *          the following happens: a frame is shown; a non-modal dialog (D)

--- a/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDAppModal1Test.java
+++ b/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDAppModal1Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367 8049339
  * @summary Check whether the focus transfer between windows occurs correctly when the following happens:
  *          a frame (F) is shown; a window having F as owner is shown; an application modal dialog having

--- a/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDAppModal2Test.java
+++ b/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDAppModal2Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367 8049339
  * @summary Check whether the focus transfer between windows occurs correctly when the following happens:
  *          a frame (F) is shown; a window having F as owner is shown; an application modal dialog having

--- a/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDAppModal3Test.java
+++ b/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDAppModal3Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367 8049339
  * @summary Check whether the focus transfer between windows occurs correctly when the following happens:
  *          a frame (F) is shown; a window having F as owner is shown; an application modal dialog having

--- a/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDAppModal4Test.java
+++ b/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDAppModal4Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367 8049339
  * @summary Check whether the focus transfer between windows occurs correctly when the following happens:
  *          a frame (F) is shown; a window having F as owner is shown; an application modal dialog having

--- a/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDDocModal1Test.java
+++ b/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDDocModal1Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367 8049339
  * @summary Check whether the focus transfer between windows occurs correctly when the following happens:
  *          a frame (F) is shown; a window having F as owner is shown; a document modal dialog having

--- a/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDDocModal2Test.java
+++ b/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDDocModal2Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367 8049339
  * @summary Check whether the focus transfer between windows occurs correctly when the following happens:
  *          a frame (F) is shown; a window having F as owner is shown; a document modal dialog having

--- a/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDDocModal3Test.java
+++ b/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDDocModal3Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367 8049339
  * @summary Check whether the focus transfer between windows occurs correctly when the following happens:
  *          a frame (F) is shown; a window having F as owner is shown; a document modal dialog having

--- a/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDDocModal4Test.java
+++ b/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDDocModal4Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367 8049339
  * @summary Check whether the focus transfer between windows occurs correctly when the following happens:
  *          a frame (F) is shown; a window having F as owner is shown; a document modal dialog having

--- a/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDModeless1Test.java
+++ b/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDModeless1Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367 8049339
  * @summary Check whether the focus transfer between windows occurs correctly when the following happens:
  *          a frame (F) is shown; a window having F as owner is shown; a modeless dialog having

--- a/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDModeless2Test.java
+++ b/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDModeless2Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367 8049339
  * @summary Check whether the focus transfer between windows occurs correctly when the following happens:
  *          a frame (F) is shown; a window having F as owner is shown; a modeless dialog having

--- a/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDModeless3Test.java
+++ b/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDModeless3Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367 8049339
  * @summary Check whether the focus transfer between windows occurs correctly when the following happens:
  *          a frame (F) is shown; a window having F as owner is shown; a modeless dialog having

--- a/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDModeless4Test.java
+++ b/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDModeless4Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367 8049339
  * @summary Check whether the focus transfer between windows occurs correctly when the following happens:
  *          a frame (F) is shown; a window having F as owner is shown; a modeless dialog having

--- a/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDNonModal1Test.java
+++ b/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDNonModal1Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367 8049339
  * @summary Check whether the focus transfer between windows occurs correctly when the following happens:
  *          a frame (F) is shown; a window having F as owner is shown; a non-modal dialog having

--- a/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDNonModal2Test.java
+++ b/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDNonModal2Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367 8049339
  * @summary Check whether the focus transfer between windows occurs correctly when the following happens:
  *          a frame (F) is shown; a window having F as owner is shown; a non-modal dialog having

--- a/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDNonModal3Test.java
+++ b/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDNonModal3Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367 8049339
  * @summary Check whether the focus transfer between windows occurs correctly when the following happens:
  *          a frame (F) is shown; a window having F as owner is shown; a non-modal dialog having

--- a/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDNonModal4Test.java
+++ b/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferFWDNonModal4Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367 8049339
  * @summary Check whether the focus transfer between windows occurs correctly when the following happens:
  *          a frame (F) is shown; a window having F as owner is shown; a non-modal dialog having

--- a/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferWDFAppModal1Test.java
+++ b/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferWDFAppModal1Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367
  * @summary Check whether the focus transfer between windows occurs correctly when
  *          the following happens: a window having a hidden frame owner is shown;

--- a/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferWDFAppModal2Test.java
+++ b/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferWDFAppModal2Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367 8048263
  * @summary Check whether the focus transfer between windows occurs correctly when
  *          the following happens: a window having a hidden frame owner is shown;

--- a/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferWDFAppModal3Test.java
+++ b/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferWDFAppModal3Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367
  * @summary Check whether the focus transfer between windows occurs correctly when
  *          the following happens: a window having a frame (F) owner is shown;

--- a/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferWDFDocModal1Test.java
+++ b/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferWDFDocModal1Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367
  * @summary Check whether the focus transfer between windows occurs correctly when
  *          the following happens: a window having a hidden frame owner is shown;

--- a/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferWDFDocModal2Test.java
+++ b/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferWDFDocModal2Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367
  * @summary Check whether the focus transfer between windows occurs correctly when
  *          the following happens: a window having a hidden frame owner is shown;

--- a/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferWDFDocModal3Test.java
+++ b/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferWDFDocModal3Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367
  * @summary Check whether the focus transfer between windows occurs correctly when
  *          the following happens: a window having a frame (F) owner is shown;

--- a/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferWDFModeless1Test.java
+++ b/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferWDFModeless1Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367
  * @summary Check whether the focus transfer between windows occurs correctly when
  *          the following happens: a window having a hidden frame owner is shown;

--- a/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferWDFModeless2Test.java
+++ b/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferWDFModeless2Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367
  * @summary Check whether the focus transfer between windows occurs correctly when
  *          the following happens: a window having a hidden frame owner is shown;

--- a/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferWDFModeless3Test.java
+++ b/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferWDFModeless3Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367
  * @summary Check whether the focus transfer between windows occurs correctly when
  *          the following happens: a window having a frame (F) owner is shown;

--- a/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferWDFNonModal1Test.java
+++ b/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferWDFNonModal1Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367
  * @summary Check whether the focus transfer between windows occurs correctly when
  *          the following happens: a window having a hidden frame owner is shown;

--- a/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferWDFNonModal2Test.java
+++ b/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferWDFNonModal2Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367
  * @summary Check whether the focus transfer between windows occurs correctly when
  *          the following happens: a window having a hidden frame owner is shown;

--- a/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferWDFNonModal3Test.java
+++ b/jdk/test/java/awt/Modal/ModalFocusTransferTests/FocusTransferWDFNonModal3Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367
  * @summary Check whether the focus transfer between windows occurs correctly when
  *          the following happens: a window having a frame (F) owner is shown;

--- a/jdk/test/java/awt/Modal/ModalInternalFrameTest/ModalInternalFrameTest.java
+++ b/jdk/test/java/awt/Modal/ModalInternalFrameTest/ModalInternalFrameTest.java
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6518753
   @summary Tests the functionality of modal Swing internal frames
   @author artem.ananiev: area=awt.modal

--- a/jdk/test/java/awt/Modal/MultipleDialogs/MultipleDialogs1Test.java
+++ b/jdk/test/java/awt/Modal/MultipleDialogs/MultipleDialogs1Test.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8054358
  * @summary Check whether a set of dialogs created with a toolkit excluded Frame
  *          parent has a proper modal blocking behavior. Also show a document modal

--- a/jdk/test/java/awt/Modal/MultipleDialogs/MultipleDialogs2Test.java
+++ b/jdk/test/java/awt/Modal/MultipleDialogs/MultipleDialogs2Test.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8054358
  * @summary Check whether a set of dialogs created with an application excluded Frame
  *          parent has a proper modal blocking behavior. Also show a document modal

--- a/jdk/test/java/awt/Modal/MultipleDialogs/MultipleDialogs3Test.java
+++ b/jdk/test/java/awt/Modal/MultipleDialogs/MultipleDialogs3Test.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8054358
  * @summary Check correctness of modal blocking behavior for a chain of Dialogs
  *          having different modality types with a Frame as a document root.

--- a/jdk/test/java/awt/Modal/MultipleDialogs/MultipleDialogs4Test.java
+++ b/jdk/test/java/awt/Modal/MultipleDialogs/MultipleDialogs4Test.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8054358 8055003
  * @summary Check whether application and document modality levels for Dialog
  *          work properly. Also check whether the blocking dialogs are

--- a/jdk/test/java/awt/Modal/MultipleDialogs/MultipleDialogs5Test.java
+++ b/jdk/test/java/awt/Modal/MultipleDialogs/MultipleDialogs5Test.java
@@ -23,9 +23,10 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8054358
  * @summary This is a simple check if a chain of dialogs having different
-  *         modality types block each other properly.
+ *          modality types block each other properly.
  *
  * @library ../helpers ../../../../lib/testlibrary/
  * @build ExtendedRobot

--- a/jdk/test/java/awt/Modal/NullModalityDialogTest/NullModalityDialogTest.java
+++ b/jdk/test/java/awt/Modal/NullModalityDialogTest/NullModalityDialogTest.java
@@ -29,6 +29,7 @@ import static jdk.testlibrary.Asserts.*;
 
 /*
  * @test
+ * @key headful
  * @bug 8047367
  * @summary Check whether a Dialog set with null modality type
  *          behaves like a modeless dialog

--- a/jdk/test/java/awt/Modal/OnTop/OnTopAppModal1Test.java
+++ b/jdk/test/java/awt/Modal/OnTop/OnTopAppModal1Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8052012
  * @summary Check whether an application modal Dialog created with null Frame
  *          constructor stays on top of the windows it blocks.

--- a/jdk/test/java/awt/Modal/OnTop/OnTopAppModal2Test.java
+++ b/jdk/test/java/awt/Modal/OnTop/OnTopAppModal2Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8052012
  * @summary Check whether an application modal Dialog created with null Dialog
  *          constructor stays on top of the windows it blocks.

--- a/jdk/test/java/awt/Modal/OnTop/OnTopAppModal3Test.java
+++ b/jdk/test/java/awt/Modal/OnTop/OnTopAppModal3Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8052012
  * @summary Check whether an application modal Dialog created with hidden Frame
  *          constructor stays on top of the windows it blocks.

--- a/jdk/test/java/awt/Modal/OnTop/OnTopAppModal4Test.java
+++ b/jdk/test/java/awt/Modal/OnTop/OnTopAppModal4Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8052012
  * @summary Check whether an application modal Dialog created with hidden Dialog
  *          constructor stays on top of the windows it blocks.

--- a/jdk/test/java/awt/Modal/OnTop/OnTopAppModal5Test.java
+++ b/jdk/test/java/awt/Modal/OnTop/OnTopAppModal5Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8052012
  * @summary Check whether an application modal Dialog created with visible Frame
  *          constructor stays on top of the windows it blocks.

--- a/jdk/test/java/awt/Modal/OnTop/OnTopAppModal6Test.java
+++ b/jdk/test/java/awt/Modal/OnTop/OnTopAppModal6Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8052012
  * @summary Check whether an application modal Dialog created with visible
  *          Dialog constructor stays on top of the windows it blocks.

--- a/jdk/test/java/awt/Modal/OnTop/OnTopDocModal1Test.java
+++ b/jdk/test/java/awt/Modal/OnTop/OnTopDocModal1Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8052012
  * @summary Check whether a document modal Dialog created with null Frame
  *          constructor follows normal Z order.

--- a/jdk/test/java/awt/Modal/OnTop/OnTopDocModal2Test.java
+++ b/jdk/test/java/awt/Modal/OnTop/OnTopDocModal2Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8052012
  * @summary Check whether a document modal Dialog created with null Dialog
  *          constructor follows normal Z order.

--- a/jdk/test/java/awt/Modal/OnTop/OnTopDocModal3Test.java
+++ b/jdk/test/java/awt/Modal/OnTop/OnTopDocModal3Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8052012
  * @summary Check whether a document modal Dialog created with hidden Frame
  *          constructor follows normal Z order.

--- a/jdk/test/java/awt/Modal/OnTop/OnTopDocModal4Test.java
+++ b/jdk/test/java/awt/Modal/OnTop/OnTopDocModal4Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8052012
  * @summary Check whether a document modal Dialog created with hidden Dialog
  *          constructor follows normal Z order.

--- a/jdk/test/java/awt/Modal/OnTop/OnTopDocModal5Test.java
+++ b/jdk/test/java/awt/Modal/OnTop/OnTopDocModal5Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8052012
  * @summary Check whether a document modal Dialog created with visible Frame
  *          constructor stays on top of the windows it blocks.

--- a/jdk/test/java/awt/Modal/OnTop/OnTopDocModal6Test.java
+++ b/jdk/test/java/awt/Modal/OnTop/OnTopDocModal6Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8052012
  * @summary Check whether a document modal Dialog created with visible
  *          Dialog constructor stays on top of the windows it blocks.

--- a/jdk/test/java/awt/Modal/OnTop/OnTopModal1Test.java
+++ b/jdk/test/java/awt/Modal/OnTop/OnTopModal1Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8052012
  * @summary Check whether a modal Dialog created with null Frame
  *          constructor stays on top of the windows it blocks.

--- a/jdk/test/java/awt/Modal/OnTop/OnTopModal2Test.java
+++ b/jdk/test/java/awt/Modal/OnTop/OnTopModal2Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8052012
  * @summary Check whether a modal Dialog created with null Dialog
  *          constructor stays on top of the windows it blocks.

--- a/jdk/test/java/awt/Modal/OnTop/OnTopModal3Test.java
+++ b/jdk/test/java/awt/Modal/OnTop/OnTopModal3Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8052012
  * @summary Check whether a modal Dialog created with hidden Frame
  *          constructor stays on top of the windows it blocks.

--- a/jdk/test/java/awt/Modal/OnTop/OnTopModal4Test.java
+++ b/jdk/test/java/awt/Modal/OnTop/OnTopModal4Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8052012
  * @summary Check whether a modal Dialog created with hidden Dialog
  *          constructor stays on top of the windows it blocks.

--- a/jdk/test/java/awt/Modal/OnTop/OnTopModal5Test.java
+++ b/jdk/test/java/awt/Modal/OnTop/OnTopModal5Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8052012
  * @summary Check whether a modal Dialog created with visible Frame
  *          constructor stays on top of the windows it blocks.

--- a/jdk/test/java/awt/Modal/OnTop/OnTopModal6Test.java
+++ b/jdk/test/java/awt/Modal/OnTop/OnTopModal6Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8052012
  * @summary Check whether a modal Dialog created with visible Dialog
  *          constructor stays on top of the windows it blocks.

--- a/jdk/test/java/awt/Modal/OnTop/OnTopModeless1Test.java
+++ b/jdk/test/java/awt/Modal/OnTop/OnTopModeless1Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8052012
  * @summary Check whether a modeless Dialog created with a
  *          null Frame constructor follows normal Z Order.

--- a/jdk/test/java/awt/Modal/OnTop/OnTopModeless2Test.java
+++ b/jdk/test/java/awt/Modal/OnTop/OnTopModeless2Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8052012
  * @summary Check whether a modeless Dialog created with a
  *          null Dialog constructor follows normal Z Order.

--- a/jdk/test/java/awt/Modal/OnTop/OnTopModeless3Test.java
+++ b/jdk/test/java/awt/Modal/OnTop/OnTopModeless3Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8052012
  * @summary Check whether a modeless Dialog created with a
  *          hidden Frame constructor follows normal Z Order.

--- a/jdk/test/java/awt/Modal/OnTop/OnTopModeless4Test.java
+++ b/jdk/test/java/awt/Modal/OnTop/OnTopModeless4Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8052012
  * @summary Check whether a modeless Dialog created with a
  *          hidden Dialog constructor follows normal Z Order.

--- a/jdk/test/java/awt/Modal/OnTop/OnTopModeless5Test.java
+++ b/jdk/test/java/awt/Modal/OnTop/OnTopModeless5Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8052012
  * @summary Check whether a modeless Dialog created with a
  *          visible Frame constructor follows normal Z Order.

--- a/jdk/test/java/awt/Modal/OnTop/OnTopModeless6Test.java
+++ b/jdk/test/java/awt/Modal/OnTop/OnTopModeless6Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8052012
  * @summary Check whether a modeless Dialog created with a visible Dialog
  *          constructor follows a normal Z order.

--- a/jdk/test/java/awt/Modal/OnTop/OnTopTKModal1Test.java
+++ b/jdk/test/java/awt/Modal/OnTop/OnTopTKModal1Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8052012
  * @summary Check whether a toolkit modal Dialog created with null Frame
  *          constructor stays on top of the windows it blocks.

--- a/jdk/test/java/awt/Modal/OnTop/OnTopTKModal2Test.java
+++ b/jdk/test/java/awt/Modal/OnTop/OnTopTKModal2Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8052012
  * @summary Check whether a toolkit modal Dialog created with null Dialog
  *          constructor stays on top of the windows it blocks.

--- a/jdk/test/java/awt/Modal/OnTop/OnTopTKModal3Test.java
+++ b/jdk/test/java/awt/Modal/OnTop/OnTopTKModal3Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8052012
  * @summary Check whether a toolkit modal Dialog created with hidden Frame
  *          constructor stays on top of the windows it blocks.

--- a/jdk/test/java/awt/Modal/OnTop/OnTopTKModal4Test.java
+++ b/jdk/test/java/awt/Modal/OnTop/OnTopTKModal4Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8052012
  * @summary Check whether a toolkit modal Dialog created with hidden Dialog
  *          constructor stays on top of the windows it blocks.

--- a/jdk/test/java/awt/Modal/OnTop/OnTopTKModal5Test.java
+++ b/jdk/test/java/awt/Modal/OnTop/OnTopTKModal5Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8052012
  * @summary Check whether a toolkit modal Dialog created with visible Frame
  *          constructor stays on top of the windows it blocks.

--- a/jdk/test/java/awt/Modal/OnTop/OnTopTKModal6Test.java
+++ b/jdk/test/java/awt/Modal/OnTop/OnTopTKModal6Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8052012
  * @summary Check whether a toolkit modal Dialog created with visible
  *          Dialog constructor stays on top of the windows it blocks.

--- a/jdk/test/java/awt/Modal/ToBack/ToBackAppModal1Test.java
+++ b/jdk/test/java/awt/Modal/ToBack/ToBackAppModal1Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054143
  * @summary Check whether an application modal dialog having a null Frame
  *          constructor still stays on top of the blocked windows even

--- a/jdk/test/java/awt/Modal/ToBack/ToBackAppModal2Test.java
+++ b/jdk/test/java/awt/Modal/ToBack/ToBackAppModal2Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054143
  * @summary Check whether an application modal dialog having a null Dialog
  *          constructor still stays on top of the blocked windows even

--- a/jdk/test/java/awt/Modal/ToBack/ToBackAppModal3Test.java
+++ b/jdk/test/java/awt/Modal/ToBack/ToBackAppModal3Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054143
  * @summary Check whether an application modal dialog having a hidden Frame
  *          constructor still stays on top of the blocked windows even

--- a/jdk/test/java/awt/Modal/ToBack/ToBackAppModal4Test.java
+++ b/jdk/test/java/awt/Modal/ToBack/ToBackAppModal4Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054143
  * @summary Check whether an application modal dialog having a hidden Dialog
  *          constructor still stays on top of the blocked windows even

--- a/jdk/test/java/awt/Modal/ToBack/ToBackAppModal5Test.java
+++ b/jdk/test/java/awt/Modal/ToBack/ToBackAppModal5Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054143
  * @summary Check whether an application modal dialog having a visible Frame
  *          constructor still stays on top of the blocked windows even

--- a/jdk/test/java/awt/Modal/ToBack/ToBackAppModal6Test.java
+++ b/jdk/test/java/awt/Modal/ToBack/ToBackAppModal6Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054143
  * @summary Check whether an application modal dialog having a visible Dialog
  *          constructor still stays on top of the blocked windows even

--- a/jdk/test/java/awt/Modal/ToBack/ToBackDocModal1Test.java
+++ b/jdk/test/java/awt/Modal/ToBack/ToBackDocModal1Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054143
  * @summary Check if toBack method works correctly for
  *          a document modal dialog with null Frame parent.

--- a/jdk/test/java/awt/Modal/ToBack/ToBackDocModal2Test.java
+++ b/jdk/test/java/awt/Modal/ToBack/ToBackDocModal2Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054143
  * @summary Check if toBack method works correctly for
  *          a document modal dialog with null Dialog parent.

--- a/jdk/test/java/awt/Modal/ToBack/ToBackDocModal3Test.java
+++ b/jdk/test/java/awt/Modal/ToBack/ToBackDocModal3Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054143
  * @summary Check if toBack method works correctly for
  *          a document modal dialog with hidden Frame parent.

--- a/jdk/test/java/awt/Modal/ToBack/ToBackDocModal4Test.java
+++ b/jdk/test/java/awt/Modal/ToBack/ToBackDocModal4Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054143
  * @summary Check if toBack method works correctly for
  *          a document modal dialog with hidden Dialog parent.

--- a/jdk/test/java/awt/Modal/ToBack/ToBackDocModal5Test.java
+++ b/jdk/test/java/awt/Modal/ToBack/ToBackDocModal5Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054143
  * @summary Check whether a document modal dialog having a visible Frame
  *          constructor still stays on top of the blocked windows even

--- a/jdk/test/java/awt/Modal/ToBack/ToBackDocModal6Test.java
+++ b/jdk/test/java/awt/Modal/ToBack/ToBackDocModal6Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054143
  * @summary Check whether a document modal dialog having a visible Dialog
  *          constructor still stays on top of the blocked windows even

--- a/jdk/test/java/awt/Modal/ToBack/ToBackModal1Test.java
+++ b/jdk/test/java/awt/Modal/ToBack/ToBackModal1Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8054143
  * @summary Check whether a modal dialog having a null Frame
  *          constructor still stays on top of the blocked windows even

--- a/jdk/test/java/awt/Modal/ToBack/ToBackModal2Test.java
+++ b/jdk/test/java/awt/Modal/ToBack/ToBackModal2Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8054143
  * @summary Check whether a modal dialog having a null Dialog
  *          constructor still stays on top of the blocked windows even

--- a/jdk/test/java/awt/Modal/ToBack/ToBackModal3Test.java
+++ b/jdk/test/java/awt/Modal/ToBack/ToBackModal3Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8054143
  * @summary Check whether a modal dialog having a hidden Frame
  *          constructor still stays on top of the blocked windows even

--- a/jdk/test/java/awt/Modal/ToBack/ToBackModal4Test.java
+++ b/jdk/test/java/awt/Modal/ToBack/ToBackModal4Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8054143
  * @summary Check whether a modal dialog having a hidden Dialog
  *          constructor still stays on top of the blocked windows even

--- a/jdk/test/java/awt/Modal/ToBack/ToBackModal5Test.java
+++ b/jdk/test/java/awt/Modal/ToBack/ToBackModal5Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8054143
  * @summary Check whether a modal dialog having a visible Frame
  *          constructor still stays on top of the blocked windows even

--- a/jdk/test/java/awt/Modal/ToBack/ToBackModal6Test.java
+++ b/jdk/test/java/awt/Modal/ToBack/ToBackModal6Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8054143
  * @summary Check whether a modal dialog having a visible Dialog
  *          constructor still stays on top of the blocked windows even

--- a/jdk/test/java/awt/Modal/ToBack/ToBackModeless1Test.java
+++ b/jdk/test/java/awt/Modal/ToBack/ToBackModeless1Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054143
  * @summary Check whether a modeless dialog having a null Frame constructor
  *          goes behind other windows when toBack is called for it.

--- a/jdk/test/java/awt/Modal/ToBack/ToBackModeless2Test.java
+++ b/jdk/test/java/awt/Modal/ToBack/ToBackModeless2Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054143
  * @summary Check whether a modeless dialog having a null Dialog constructor
  *          goes behind other windows when toBack is called for it.

--- a/jdk/test/java/awt/Modal/ToBack/ToBackModeless3Test.java
+++ b/jdk/test/java/awt/Modal/ToBack/ToBackModeless3Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054143
  * @summary Check whether a modeless dialog having a hidden Frame constructor
  *          goes behind other windows when toBack is called for it.

--- a/jdk/test/java/awt/Modal/ToBack/ToBackModeless4Test.java
+++ b/jdk/test/java/awt/Modal/ToBack/ToBackModeless4Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054143
  * @summary Check whether a modeless dialog having a hidden Dialog constructor
  *          goes behind other windows when toBack is called for it.

--- a/jdk/test/java/awt/Modal/ToBack/ToBackModeless5Test.java
+++ b/jdk/test/java/awt/Modal/ToBack/ToBackModeless5Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054143
  * @summary Check if toBack method works correctly for a modeless dialog
  *          having a visible Frame constructor.

--- a/jdk/test/java/awt/Modal/ToBack/ToBackModeless6Test.java
+++ b/jdk/test/java/awt/Modal/ToBack/ToBackModeless6Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054143
  * @summary Check if toBack method works correctly for a modeless dialog
  *          having a visible Dialog constructor.

--- a/jdk/test/java/awt/Modal/ToBack/ToBackNonModal1Test.java
+++ b/jdk/test/java/awt/Modal/ToBack/ToBackNonModal1Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8054143
  * @summary Check whether a non-modal dialog having a null Frame constructor
  *          goes behind other windows when toBack is called for it.

--- a/jdk/test/java/awt/Modal/ToBack/ToBackNonModal2Test.java
+++ b/jdk/test/java/awt/Modal/ToBack/ToBackNonModal2Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8054143
  * @summary Check whether a non-modal dialog having a null Dialog constructor
  *          goes behind other windows when toBack is called for it.

--- a/jdk/test/java/awt/Modal/ToBack/ToBackNonModal3Test.java
+++ b/jdk/test/java/awt/Modal/ToBack/ToBackNonModal3Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8054143
  * @summary Check whether a non-modal dialog having a hidden Frame constructor
  *          goes behind other windows when toBack is called for it.

--- a/jdk/test/java/awt/Modal/ToBack/ToBackNonModal4Test.java
+++ b/jdk/test/java/awt/Modal/ToBack/ToBackNonModal4Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8054143
  * @summary Check whether a non-modal dialog having a hidden Dialog constructor
  *          goes behind other windows when toBack is called for it.

--- a/jdk/test/java/awt/Modal/ToBack/ToBackNonModal5Test.java
+++ b/jdk/test/java/awt/Modal/ToBack/ToBackNonModal5Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8054143
  * @summary Check if toBack method works correctly for a non-modal dialog
  *          having a visible Frame constructor.

--- a/jdk/test/java/awt/Modal/ToBack/ToBackNonModal6Test.java
+++ b/jdk/test/java/awt/Modal/ToBack/ToBackNonModal6Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8054143
  * @summary Check if toBack method works correctly for a non-modal dialog
  *          having a visible Dialog constructor.

--- a/jdk/test/java/awt/Modal/ToBack/ToBackTKModal1Test.java
+++ b/jdk/test/java/awt/Modal/ToBack/ToBackTKModal1Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054143
  * @summary Check whether a toolkit modal dialog having a null Frame
  *          constructor still stays on top of the blocked windows even

--- a/jdk/test/java/awt/Modal/ToBack/ToBackTKModal2Test.java
+++ b/jdk/test/java/awt/Modal/ToBack/ToBackTKModal2Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054143
  * @summary Check whether a toolkit modal dialog having a null Dialog
  *          constructor still stays on top of the blocked windows even

--- a/jdk/test/java/awt/Modal/ToBack/ToBackTKModal3Test.java
+++ b/jdk/test/java/awt/Modal/ToBack/ToBackTKModal3Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054143
  * @summary Check whether a toolkit modal dialog having a hidden Frame
  *          constructor still stays on top of the blocked windows even

--- a/jdk/test/java/awt/Modal/ToBack/ToBackTKModal4Test.java
+++ b/jdk/test/java/awt/Modal/ToBack/ToBackTKModal4Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054143
  * @summary Check whether a toolkit modal dialog having a hidden Dialog
  *          constructor still stays on top of the blocked windows even

--- a/jdk/test/java/awt/Modal/ToBack/ToBackTKModal5Test.java
+++ b/jdk/test/java/awt/Modal/ToBack/ToBackTKModal5Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054143
  * @summary Check whether a toolkit modal dialog having a visible Frame
  *          constructor still stays on top of the blocked windows even

--- a/jdk/test/java/awt/Modal/ToBack/ToBackTKModal6Test.java
+++ b/jdk/test/java/awt/Modal/ToBack/ToBackTKModal6Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8054143
  * @summary Check whether a toolkit modal dialog having a visible Dialog
  *          constructor still stays on top of the blocked windows even

--- a/jdk/test/java/awt/Modal/ToFront/DialogToFrontAppModalTest.java
+++ b/jdk/test/java/awt/Modal/ToFront/DialogToFrontAppModalTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8050885
  * @summary Check that calling toFront method for a dialog in presence of
  *          blocking application modal dialog does not bring it to the top

--- a/jdk/test/java/awt/Modal/ToFront/DialogToFrontDocModalTest.java
+++ b/jdk/test/java/awt/Modal/ToFront/DialogToFrontDocModalTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8050885
  * @summary Check that calling toFront method for a dialog in presence of
  *          blocking document modal dialog does not bring it to the top

--- a/jdk/test/java/awt/Modal/ToFront/DialogToFrontModalTest.java
+++ b/jdk/test/java/awt/Modal/ToFront/DialogToFrontModalTest.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8050885
  * @summary Check that calling toFront method for a dialog in presence of
  *          blocking modal dialog does not bring it to the top

--- a/jdk/test/java/awt/Modal/ToFront/DialogToFrontModeless1Test.java
+++ b/jdk/test/java/awt/Modal/ToFront/DialogToFrontModeless1Test.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8050885
  * @summary Check that calling toFront method does not bring a dialog to the top
  *          of a child modeless dialog.

--- a/jdk/test/java/awt/Modal/ToFront/DialogToFrontNonModalTest.java
+++ b/jdk/test/java/awt/Modal/ToFront/DialogToFrontNonModalTest.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8050885
  * @summary Check that calling toFront method does not bring a dialog to the top
  *          of a non-modal child dialog.

--- a/jdk/test/java/awt/Modal/ToFront/DialogToFrontTKModalTest.java
+++ b/jdk/test/java/awt/Modal/ToFront/DialogToFrontTKModalTest.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8050885
  * @summary Check that calling toFront method for a dialog in presence of
  *          blocking toolkit modal dialog does not bring it to the top

--- a/jdk/test/java/awt/Modal/ToFront/FrameToFrontAppModal1Test.java
+++ b/jdk/test/java/awt/Modal/ToFront/FrameToFrontAppModal1Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8050885
  * @summary Check that calling toFront method for a frame in presence of
  *          blocking application modal dialog having a null Frame parent

--- a/jdk/test/java/awt/Modal/ToFront/FrameToFrontAppModal2Test.java
+++ b/jdk/test/java/awt/Modal/ToFront/FrameToFrontAppModal2Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8050885
  * @summary Check that calling toFront method for a frame in presence of
  *          blocking application modal dialog having a null Dialog parent

--- a/jdk/test/java/awt/Modal/ToFront/FrameToFrontAppModal3Test.java
+++ b/jdk/test/java/awt/Modal/ToFront/FrameToFrontAppModal3Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8050885
  * @summary Check that calling toFront method for a frame in presence of
  *          blocking application modal dialog having a hidden Frame parent

--- a/jdk/test/java/awt/Modal/ToFront/FrameToFrontAppModal4Test.java
+++ b/jdk/test/java/awt/Modal/ToFront/FrameToFrontAppModal4Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8050885
  * @summary Check that calling toFront method for a frame in presence of
  *          blocking application modal dialog having a hidden Dialog parent

--- a/jdk/test/java/awt/Modal/ToFront/FrameToFrontAppModal5Test.java
+++ b/jdk/test/java/awt/Modal/ToFront/FrameToFrontAppModal5Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8050885
  * @summary Check that calling toFront method for a frame in presence of
  *          blocking application modal dialog having a visible Frame parent

--- a/jdk/test/java/awt/Modal/ToFront/FrameToFrontDocModal1Test.java
+++ b/jdk/test/java/awt/Modal/ToFront/FrameToFrontDocModal1Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8050885
  * @summary Check that calling toFront method for a frame in presence of
  *          blocking document modal dialog having a visible Frame parent

--- a/jdk/test/java/awt/Modal/ToFront/FrameToFrontDocModal2Test.java
+++ b/jdk/test/java/awt/Modal/ToFront/FrameToFrontDocModal2Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8050885
  * @summary Check if toFront method works correctly for a document modal dialog.
  *

--- a/jdk/test/java/awt/Modal/ToFront/FrameToFrontModal1Test.java
+++ b/jdk/test/java/awt/Modal/ToFront/FrameToFrontModal1Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8050885
  * @summary Check that calling toFront method for a frame in presence of
  *          blocking modal dialog having a null Frame parent

--- a/jdk/test/java/awt/Modal/ToFront/FrameToFrontModal2Test.java
+++ b/jdk/test/java/awt/Modal/ToFront/FrameToFrontModal2Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8050885
  * @summary Check that calling toFront method for a frame in presence of
  *          blocking modal dialog having a null Dialog parent

--- a/jdk/test/java/awt/Modal/ToFront/FrameToFrontModal3Test.java
+++ b/jdk/test/java/awt/Modal/ToFront/FrameToFrontModal3Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8050885
  * @summary Check that calling toFront method for a frame in presence of
  *          blocking modal dialog having a hidden Frame parent

--- a/jdk/test/java/awt/Modal/ToFront/FrameToFrontModal4Test.java
+++ b/jdk/test/java/awt/Modal/ToFront/FrameToFrontModal4Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8050885
  * @summary Check that calling toFront method for a frame in presence of
  *          blocking modal dialog having a hidden Dialog parent

--- a/jdk/test/java/awt/Modal/ToFront/FrameToFrontModal5Test.java
+++ b/jdk/test/java/awt/Modal/ToFront/FrameToFrontModal5Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8050885
  * @summary Check that calling toFront method for a frame in presence of
  *          blocking modal dialog having a visible Frame parent

--- a/jdk/test/java/awt/Modal/ToFront/FrameToFrontModeless1Test.java
+++ b/jdk/test/java/awt/Modal/ToFront/FrameToFrontModeless1Test.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8050885
  * @summary Check that calling toFront method does not bring a frame to the top of
  *          a modeless child dialog.

--- a/jdk/test/java/awt/Modal/ToFront/FrameToFrontNonModalTest.java
+++ b/jdk/test/java/awt/Modal/ToFront/FrameToFrontNonModalTest.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8050885
  * @summary Check that calling toFront method does not bring a frame to the top
  *          of a non-modal child dialog.

--- a/jdk/test/java/awt/Modal/ToFront/FrameToFrontTKModal1Test.java
+++ b/jdk/test/java/awt/Modal/ToFront/FrameToFrontTKModal1Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8050885
  * @summary Check that calling toFront method for a frame in presence of
  *          blocking modal toolkit dialog having a null Frame parent

--- a/jdk/test/java/awt/Modal/ToFront/FrameToFrontTKModal2Test.java
+++ b/jdk/test/java/awt/Modal/ToFront/FrameToFrontTKModal2Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8050885
  * @summary Check that calling toFront method for a frame in presence of
  *          blocking toolkit modal dialog having a null Dialog parent

--- a/jdk/test/java/awt/Modal/ToFront/FrameToFrontTKModal3Test.java
+++ b/jdk/test/java/awt/Modal/ToFront/FrameToFrontTKModal3Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8050885
  * @summary Check that calling toFront method for a frame in presence of
  *          blocking toolkit modal dialog having a hidden Frame parent

--- a/jdk/test/java/awt/Modal/ToFront/FrameToFrontTKModal4Test.java
+++ b/jdk/test/java/awt/Modal/ToFront/FrameToFrontTKModal4Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8050885
  * @summary Check that calling toFront method for a frame in presence of
  *          blocking toolkit modal dialog having a hidden Dialog parent

--- a/jdk/test/java/awt/Modal/ToFront/FrameToFrontTKModal5Test.java
+++ b/jdk/test/java/awt/Modal/ToFront/FrameToFrontTKModal5Test.java
@@ -25,6 +25,7 @@ import java.awt.Dialog;
 
 /*
  * @test
+ * @key headful
  * @bug 8050885
  * @summary Check that calling toFront method for a frame in presence of
  *          blocking toolkit modal dialog having a visible Frame parent

--- a/jdk/test/java/awt/Mouse/EnterExitEvents/DragWindowOutOfFrameTest.java
+++ b/jdk/test/java/awt/Mouse/EnterExitEvents/DragWindowOutOfFrameTest.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 7154048
  * @summary Window created under a mouse does not receive mouse enter event.
  *     Mouse Entered/Exited events should be generated during dragging the window

--- a/jdk/test/java/awt/Mouse/EnterExitEvents/DragWindowTest.java
+++ b/jdk/test/java/awt/Mouse/EnterExitEvents/DragWindowTest.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 7154048
  * @summary Window created under a mouse does not receive mouse enter event.
  *     Mouse Entered/Exited events are wrongly generated during dragging the window

--- a/jdk/test/java/awt/Mouse/EnterExitEvents/ResizingFrameTest.java
+++ b/jdk/test/java/awt/Mouse/EnterExitEvents/ResizingFrameTest.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 7154048
  * @summary Programmatically resized  window does not receive mouse entered/exited events
  * @author  alexandr.scherbatiy area=awt.event

--- a/jdk/test/java/awt/Mouse/GetMousePositionTest/GetMousePositionWithOverlay.java
+++ b/jdk/test/java/awt/Mouse/GetMousePositionTest/GetMousePositionWithOverlay.java
@@ -29,6 +29,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * @test
+ * @key headful
  * @bug 8012026
  * @summary Component.getMousePosition() does not work in an applet on MacOS
  * @author Petr Pchelko

--- a/jdk/test/java/awt/Mouse/GetMousePositionTest/GetMousePositionWithPopup.java
+++ b/jdk/test/java/awt/Mouse/GetMousePositionTest/GetMousePositionWithPopup.java
@@ -30,6 +30,7 @@ import java.awt.event.MouseMotionAdapter;
 
 /**
  * @test
+ * @key headful
  * @bug 8012026 8027154
  * @summary Component.getMousePosition() does not work in an applet on MacOS
  * @author Petr Pchelko

--- a/jdk/test/java/awt/Mouse/MouseComboBoxTest/MouseComboBoxTest.java
+++ b/jdk/test/java/awt/Mouse/MouseComboBoxTest/MouseComboBoxTest.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8032872
  * @summary Tests JComboBox selection via the mouse
  * @author Dmitry Markov

--- a/jdk/test/java/awt/Mouse/MouseDragEvent/MouseDraggedTest.java
+++ b/jdk/test/java/awt/Mouse/MouseDragEvent/MouseDraggedTest.java
@@ -26,6 +26,7 @@ import java.awt.event.*;
 import javax.swing.*;
 /*
  * @test
+ * @key headful
  * @bug 8080137
  * @summary Dragged events for extra mouse buttons (4,5,6) are not generated
  *            on JSplitPane

--- a/jdk/test/java/awt/Mouse/RemovedComponentMouseListener/RemovedComponentMouseListener.java
+++ b/jdk/test/java/awt/Mouse/RemovedComponentMouseListener/RemovedComponentMouseListener.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8061636
  * @summary fix for 7079254 changes behavior of MouseListener, MouseMotionListener
  * @library ../../regtesthelpers

--- a/jdk/test/java/awt/MouseAdapter/MouseAdapterUnitTest/MouseAdapterUnitTest.java
+++ b/jdk/test/java/awt/MouseAdapter/MouseAdapterUnitTest/MouseAdapterUnitTest.java
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 4453162
   @summary MouseAdapter should implement MouseMotionListener and MouseWheelListener
   @author andrei.dmitriev: area=

--- a/jdk/test/java/awt/MouseInfo/JContainerMousePositionTest.java
+++ b/jdk/test/java/awt/MouseInfo/JContainerMousePositionTest.java
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @summary unit test for a new method in Container class: getMousePosition(boolean)
   @author dav@sparc.spb.su: area=
   @bug 4009555

--- a/jdk/test/java/awt/Multiscreen/LocationRelativeToTest/LocationRelativeToTest.java
+++ b/jdk/test/java/awt/Multiscreen/LocationRelativeToTest/LocationRelativeToTest.java
@@ -22,15 +22,16 @@
  */
 
 /*
- @test
- @bug 6232687
- @summary Tests that Window.setLocationRelativeTo() method works correctly
-for different multiscreen configurations
- @author artem.ananiev, area=awt.multiscreen
- @library ../../regtesthelpers
- @build Util
- @run main LocationRelativeToTest
-*/
+ * @test
+ * @key headful
+ * @bug 6232687
+ * @summary Tests that Window.setLocationRelativeTo() method works correctly
+ *          for different multiscreen configurations
+ * @author artem.ananiev, area=awt.multiscreen
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main LocationRelativeToTest
+ */
 
 import java.awt.*;
 import java.awt.event.*;

--- a/jdk/test/java/awt/Multiscreen/TranslucencyThrowsExceptionWhenFullScreen/TranslucencyThrowsExceptionWhenFullScreen.java
+++ b/jdk/test/java/awt/Multiscreen/TranslucencyThrowsExceptionWhenFullScreen/TranslucencyThrowsExceptionWhenFullScreen.java
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6838089
   @summary Translucent windows should throw exception in FS mode
   @author dmitry.cherepanov@oracle.com: area=awt-multiscreen

--- a/jdk/test/java/awt/Paint/ExposeOnEDT.java
+++ b/jdk/test/java/awt/Paint/ExposeOnEDT.java
@@ -26,6 +26,7 @@ import java.awt.*;
 
 /**
  * @test
+ * @key headful
  * @bug 7090424
  * @author Sergey Bylokhov
  * @library ../../../lib/testlibrary/

--- a/jdk/test/java/awt/Paint/PaintNativeOnUpdate.java
+++ b/jdk/test/java/awt/Paint/PaintNativeOnUpdate.java
@@ -31,6 +31,7 @@ import java.awt.Point;
 
 /**
  * @test
+ * @key headful
  * @bug 7157680
  * @library ../../../lib/testlibrary
  * @build ExtendedRobot

--- a/jdk/test/java/awt/Paint/bug8024864.java
+++ b/jdk/test/java/awt/Paint/bug8024864.java
@@ -21,7 +21,9 @@
  * questions.
  */
 
-/* @test
+/*
+ * @test
+ * @key headful
  * @bug 8024864 8031422
  * @summary [macosx] Problems with rendering of controls
  * @author Petr Pchelko

--- a/jdk/test/java/awt/Robot/AcceptExtraMouseButtons/AcceptExtraMouseButtons.java
+++ b/jdk/test/java/awt/Robot/AcceptExtraMouseButtons/AcceptExtraMouseButtons.java
@@ -23,6 +23,7 @@
 
 /*
   @test %I% %E%
+  @key headful
   @bug 6315717
   @summary verifies that Robot is accepting extra mouse buttons
   @author Andrei Dmitriev : area=awt.mouse

--- a/jdk/test/java/awt/Robot/ModifierRobotKey/ModifierRobotKeyTest.java
+++ b/jdk/test/java/awt/Robot/ModifierRobotKey/ModifierRobotKeyTest.java
@@ -36,6 +36,7 @@ import static jdk.testlibrary.Asserts.assertTrue;
 
 /*
  * @test 8155742
+ * @key headful
  * @summary Make sure that modifier key mask is set when robot press
  *          some key with one or more modifiers.
  * @library ../../../../lib/testlibrary/

--- a/jdk/test/java/awt/TextArea/TextAreaCaretVisibilityTest/bug7129742.java
+++ b/jdk/test/java/awt/TextArea/TextAreaCaretVisibilityTest/bug7129742.java
@@ -26,7 +26,9 @@
  */
 
 
-/* @test
+/*
+ * @test
+ * @key headful
  * @bug 7129742
  * @summary Focus in non-editable TextArea is not shown on Linux.
  * @author Sean Chou

--- a/jdk/test/java/awt/TextArea/TextAreaEditing/TextAreaEditing.java
+++ b/jdk/test/java/awt/TextArea/TextAreaEditing/TextAreaEditing.java
@@ -23,6 +23,7 @@
 
 /*
  @test
+ @key headful
  @bug 8040322
  @summary Test TextArea APIs replaceRange, insert, append & setText
  @run main TextAreaEditing

--- a/jdk/test/java/awt/Toolkit/AutoShutdown/ShowExitTest/ShowExitTest.sh
+++ b/jdk/test/java/awt/Toolkit/AutoShutdown/ShowExitTest/ShowExitTest.sh
@@ -25,6 +25,7 @@
 
 #
 #   @test       ShowExitTest.sh
+#   @key        headful
 #   @bug        6513421
 #   @summary    Java process does not terminate on closing the Main Application Frame
 #

--- a/jdk/test/java/awt/Toolkit/LockingKeyStateTest/LockingKeyStateTest.java
+++ b/jdk/test/java/awt/Toolkit/LockingKeyStateTest/LockingKeyStateTest.java
@@ -26,6 +26,7 @@ import java.awt.event.KeyEvent;
 
 /*
   @test
+  @key headful
   @summary verify LOCK buttons toogle
   @author Yuri.Nesterenko, Dmitriy.Ermashov
   @library ../../../../lib/testlibrary

--- a/jdk/test/java/awt/Toolkit/SecurityTest/SecurityTest2.java
+++ b/jdk/test/java/awt/Toolkit/SecurityTest/SecurityTest2.java
@@ -22,13 +22,14 @@
  */
 
 /*
-  @test
-  @bug 6599601
-  @summary tests that a simple GUI application runs without any
-exceptions thrown
-  @author Artem.Ananiev area=awt.Toolkit
-  @run main SecurityTest2
-*/
+ * @test
+ * @key headful
+ * @bug 6599601
+ * @summary tests that a simple GUI application runs without any
+ *          exceptions thrown
+ * @author Artem.Ananiev area=awt.Toolkit
+ * @run main SecurityTest2
+ */
 
 import java.awt.*;
 

--- a/jdk/test/java/awt/TrayIcon/PopupMenuLeakTest/PopupMenuLeakTest.java
+++ b/jdk/test/java/awt/TrayIcon/PopupMenuLeakTest/PopupMenuLeakTest.java
@@ -23,6 +23,7 @@
 
 /*
  @test
+ @key headful
   @bug 8007220
   @summary Reference to the popup leaks after the TrayIcon is removed
   @author Petr Pchelko

--- a/jdk/test/java/awt/Window/8027025/Test8027025.java
+++ b/jdk/test/java/awt/Window/8027025/Test8027025.java
@@ -21,7 +21,9 @@
  * questions.
  */
 
-/* @test
+/*
+ * @test
+ * @key headful
  * @bug 8027025
  * @summary [macosx] getLocationOnScreen returns 0 if parent invisible
  * @author Petr Pchelko

--- a/jdk/test/java/awt/Window/AlwaysOnTop/AlwaysOnTopFieldTest.java
+++ b/jdk/test/java/awt/Window/AlwaysOnTop/AlwaysOnTopFieldTest.java
@@ -26,6 +26,7 @@ import java.awt.Robot;
 import java.awt.Window;
 /**
  * @test
+ * @key headful
  * @bug 7081594
  * @author Alexander Scherbatiy
  * @summary Windows owned by an always-on-top window DO NOT automatically become always-on-top
@@ -37,7 +38,7 @@ public class AlwaysOnTopFieldTest {
         Robot robot;
         try {
             robot = new Robot();
-        }catch(Exception ex) {
+        } catch(Exception ex) {
             ex.printStackTrace();
             throw new RuntimeException("Unexpected failure");
         }

--- a/jdk/test/java/awt/Window/AlwaysOnTop/AutoTestOnTop.java
+++ b/jdk/test/java/awt/Window/AlwaysOnTop/AutoTestOnTop.java
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 4632143
   @summary Unit test for the RFE window/frame/dialog always on top
   @author dom@sparc.spb.su: area=awt.toplevel

--- a/jdk/test/java/awt/Window/MaximizeOffscreen/MaximizeOffscreenTest.java
+++ b/jdk/test/java/awt/Window/MaximizeOffscreen/MaximizeOffscreenTest.java
@@ -23,6 +23,7 @@
 
 /**
  * @test @summary JVM crash if the frame maximized from offscreen
+ * @key headful
  * @bug 8020210
  * @author Petr Pchelko
  * @library ../../regtesthelpers

--- a/jdk/test/java/awt/Window/OwnedWindowsSerialization/OwnedWindowsSerialization.java
+++ b/jdk/test/java/awt/Window/OwnedWindowsSerialization/OwnedWindowsSerialization.java
@@ -28,7 +28,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
-/* @test
+/*
+ * @test
+ * @key headful
  * @bug 8027152
  * @summary Checks that ownedWindowList is serialized and deserialized properly and alwaysOnTop works after deserialization
  * @author Petr Pchelko

--- a/jdk/test/java/awt/Window/TopLevelLocation/TopLevelLocation.java
+++ b/jdk/test/java/awt/Window/TopLevelLocation/TopLevelLocation.java
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key headful
  * @bug 8027628
  * @author Oleg Pekhovskiy
  * @summary JWindow jumps to (0, 0) after mouse clicked

--- a/jdk/test/java/awt/Window/WindowGCInFullScreen/WindowGCInFullScreen.java
+++ b/jdk/test/java/awt/Window/WindowGCInFullScreen/WindowGCInFullScreen.java
@@ -32,6 +32,7 @@ import javax.swing.SwingUtilities;
 
 /**
  * @test
+ * @key headful
  * @bug 8019591
  * @author Sergey Bylokhov
  */

--- a/jdk/test/java/awt/Window/WindowJumpingTest/WindowJumpingTest.java
+++ b/jdk/test/java/awt/Window/WindowJumpingTest/WindowJumpingTest.java
@@ -21,7 +21,9 @@
  * questions.
  */
 
-/* @test
+/*
+ * @test
+ * @key headful
  * @bug 8080729
  * @summary Dialogs on multiscreen jump to parent frame on focus gain
  * @author Dmitry Markov

--- a/jdk/test/java/awt/Window/WindowsLeak/WindowsLeak.java
+++ b/jdk/test/java/awt/Window/WindowsLeak/WindowsLeak.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8013563 8028486
  * @summary Tests that windows are removed from windows list
  * @library /javax/swing/regtesthelpers

--- a/jdk/test/java/awt/datatransfer/DataFlavor/NullDataFlavorTest.java
+++ b/jdk/test/java/awt/datatransfer/DataFlavor/NullDataFlavorTest.java
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 4682039
   @summary Tests that DataTransferer.getFormatsForFlavors() does not throw
            NullPointerException if some of given as parameter data flavors

--- a/jdk/test/java/awt/dnd/AcceptDropMultipleTimes/AcceptDropMultipleTimes.java
+++ b/jdk/test/java/awt/dnd/AcceptDropMultipleTimes/AcceptDropMultipleTimes.java
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key headful
  * @bug 8029979
  * @summary Checks if acceptDrop() can be called several times
  * @library ../../regtesthelpers

--- a/jdk/test/java/awt/dnd/DropTargetEnterExitTest/ExtraDragEnterTest.java
+++ b/jdk/test/java/awt/dnd/DropTargetEnterExitTest/ExtraDragEnterTest.java
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key headful
  * @bug 8024163
  * @summary Checks the dragEnter event is correctly generated
  * @library ../../regtesthelpers

--- a/jdk/test/java/awt/dnd/DropTargetEnterExitTest/MissedDragExitTest.java
+++ b/jdk/test/java/awt/dnd/DropTargetEnterExitTest/MissedDragExitTest.java
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key headful
  * @bug 8024163
  * @summary Checks that dragExit is generated when the new DropTarget is created under the drag
  * @library ../../regtesthelpers

--- a/jdk/test/java/awt/dnd/MissingDragExitEventTest/MissingDragExitEventTest.java
+++ b/jdk/test/java/awt/dnd/MissingDragExitEventTest/MissingDragExitEventTest.java
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key headful
  * @bug 8027913
  * @library ../../regtesthelpers
  * @build Util

--- a/jdk/test/java/awt/event/KeyEvent/AltCharAcceleratorTest/AltCharAcceleratorTest.java
+++ b/jdk/test/java/awt/event/KeyEvent/AltCharAcceleratorTest/AltCharAcceleratorTest.java
@@ -22,12 +22,14 @@
  */
 
 /*
-@test
-@bug 8068283
-@summary Checks that <Alt>+Char accelerators work when pressed in a text component
-@author Anton Nashatyrev
-@run main AltCharAcceleratorTest
-*/
+ * @test
+ * @key headful
+ * @bug 8068283
+ * @summary Checks that <Alt>+Char accelerators work when pressed in a text component
+ * @author Anton Nashatyrev
+ * @modules java.desktop/sun.awt
+ * @run main AltCharAcceleratorTest
+ */
 
 import javax.swing.*;
 import java.awt.*;

--- a/jdk/test/java/awt/event/KeyEvent/CorrectTime/CorrectTime.java
+++ b/jdk/test/java/awt/event/KeyEvent/CorrectTime/CorrectTime.java
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6451578
   @library ../../../regtesthelpers
   @build Sysout AbstractTest Util

--- a/jdk/test/java/awt/event/KeyEvent/ExtendedKeyCode/ExtendedKeyCodeTest.java
+++ b/jdk/test/java/awt/event/KeyEvent/ExtendedKeyCode/ExtendedKeyCodeTest.java
@@ -28,6 +28,7 @@ import java.awt.event.KeyAdapter;
 
 /*
  * @test
+ * @key headful
  * @bug 8007156 8025126
  * @summary Extended key code is not set for a key event
  * @author Alexandr Scherbatiy

--- a/jdk/test/java/awt/event/KeyEvent/ExtendedModifiersTest/ExtendedModifiersTest.java
+++ b/jdk/test/java/awt/event/KeyEvent/ExtendedModifiersTest/ExtendedModifiersTest.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8043126
  * @summary Check whether
  *          1. correct extended modifiers are returned

--- a/jdk/test/java/awt/event/KeyEvent/KeyMaskTest/KeyMaskTest.java
+++ b/jdk/test/java/awt/event/KeyEvent/KeyMaskTest/KeyMaskTest.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8043126
  * @summary Check whether KeyEvent.getModifiers() returns correct modifiers
  *          when Ctrl, Alt or Shift keys are pressed.

--- a/jdk/test/java/awt/event/KeyEvent/SwallowKeyEvents/SwallowKeyEvents.java
+++ b/jdk/test/java/awt/event/KeyEvent/SwallowKeyEvents/SwallowKeyEvents.java
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug       7154072 7161320
   @summary   Tests that key events with modifiers are not swallowed.
   @author    anton.tarasov: area=awt.focus

--- a/jdk/test/java/awt/event/MouseEvent/DisabledComponents/DisabledComponentsTest.java
+++ b/jdk/test/java/awt/event/MouseEvent/DisabledComponents/DisabledComponentsTest.java
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 4173714
   @summary java.awt.button behaves differently under Win32/Solaris
   @author tdv@sparc.spb.su

--- a/jdk/test/java/awt/event/MouseEvent/EnterAsGrabbedEvent/EnterAsGrabbedEvent.java
+++ b/jdk/test/java/awt/event/MouseEvent/EnterAsGrabbedEvent/EnterAsGrabbedEvent.java
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6317481 8012325
   @summary REG:Pressing the mouse, dragging and releasing it outside the button triggers ActionEvent, XAWT
   @author Dmitry.Cherepanov@SUN.COM area=awt.event

--- a/jdk/test/java/awt/event/MouseEvent/MouseButtonsAndKeyMasksTest/MouseButtonsAndKeyMasksTest.java
+++ b/jdk/test/java/awt/event/MouseEvent/MouseButtonsAndKeyMasksTest/MouseButtonsAndKeyMasksTest.java
@@ -40,6 +40,7 @@ import test.java.awt.event.helpers.lwcomponents.LWList;
 
 /*
  * @test
+ * @key headful
  * @bug 8043126
  * @summary Check whether MouseEvent.getModifiers(), MouseEvent.getModifiersEx()
  *          and KeyEvent.getModifiers() return correct modifiers when pressing

--- a/jdk/test/java/awt/event/MouseEvent/MouseButtonsTest/MouseButtonsTest.java
+++ b/jdk/test/java/awt/event/MouseEvent/MouseButtonsTest/MouseButtonsTest.java
@@ -38,6 +38,7 @@ import static jdk.testlibrary.Asserts.*;
 
 /*
  * @test
+ * @key headful
  * @bug 8043126
  * @summary Check whether getButton() returns correct mouse button
  *          number when the mouse buttons are pressed and getModifiers()

--- a/jdk/test/java/awt/event/MouseEvent/MultipleMouseButtonsTest/MultipleMouseButtonsTest.java
+++ b/jdk/test/java/awt/event/MouseEvent/MultipleMouseButtonsTest/MultipleMouseButtonsTest.java
@@ -32,6 +32,7 @@ import static jdk.testlibrary.Asserts.*;
 
 /*
  * @test
+ * @key headful
  * @bug 8043126
  * @summary Check whether correct modifiers set when multiple mouse buttons were pressed;
  *          check number of received events.

--- a/jdk/test/java/awt/event/MouseEvent/SpuriousExitEnter/SpuriousExitEnter_3.java
+++ b/jdk/test/java/awt/event/MouseEvent/SpuriousExitEnter/SpuriousExitEnter_3.java
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6479820
   @library ../../../regtesthelpers
   @build Util

--- a/jdk/test/java/awt/event/MouseWheelEvent/InfiniteRecursion/InfiniteRecursion.java
+++ b/jdk/test/java/awt/event/MouseWheelEvent/InfiniteRecursion/InfiniteRecursion.java
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6480024
   @library ../../../regtesthelpers
   @build Util Sysout AbstractTest

--- a/jdk/test/java/awt/event/MouseWheelEvent/InfiniteRecursion/InfiniteRecursion_1.java
+++ b/jdk/test/java/awt/event/MouseWheelEvent/InfiniteRecursion/InfiniteRecursion_1.java
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6480024
   @library ../../../regtesthelpers
   @build Util Sysout AbstractTest

--- a/jdk/test/java/awt/event/MouseWheelEvent/InfiniteRecursion/InfiniteRecursion_4.java
+++ b/jdk/test/java/awt/event/MouseWheelEvent/InfiniteRecursion/InfiniteRecursion_4.java
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6480024
   @library ../../../regtesthelpers
   @build Util Sysout AbstractTest

--- a/jdk/test/java/awt/event/MouseWheelEvent/WheelModifier/WheelModifier.java
+++ b/jdk/test/java/awt/event/MouseWheelEvent/WheelModifier/WheelModifier.java
@@ -21,11 +21,14 @@
  * questions.
  */
 
-/* @test
+/*
+   @test
+   @key headful
    @bug 8041470
    @summary JButtons stay pressed after they have lost focus if you use the mouse wheel
    @author Anton Nashatyrev
-*/
+ */
+
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.*;

--- a/jdk/test/java/awt/event/TextEvent/TextEventSequenceTest/TextEventSequenceTest.java
+++ b/jdk/test/java/awt/event/TextEvent/TextEventSequenceTest/TextEventSequenceTest.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 4028580
  * @summary TextArea does not send TextEvent when setText. Does for insert
  * @author kdm@sparc.spb.su: area= awt.TextAvent

--- a/jdk/test/java/awt/grab/GrabOnUnfocusableToplevel/GrabOnUnfocusableToplevel.java
+++ b/jdk/test/java/awt/grab/GrabOnUnfocusableToplevel/GrabOnUnfocusableToplevel.java
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6539458
   @summary JPopupMenu does not display if invoker is instance of JWindow
   @author oleg.sukhodolsky area=awt.grab

--- a/jdk/test/java/awt/im/memoryleak/InputContextMemoryLeakTest.java
+++ b/jdk/test/java/awt/im/memoryleak/InputContextMemoryLeakTest.java
@@ -36,6 +36,7 @@ import test.java.awt.regtesthelpers.Util;
 
 /*
  @test
+ @key headful
  @bug 7079260
  @summary XInputContext leaks memory by needRecetXXIClient field
  @author Petr Pchelko

--- a/jdk/test/javax/swing/AbstractButton/6711682/bug6711682.java
+++ b/jdk/test/javax/swing/AbstractButton/6711682/bug6711682.java
@@ -21,12 +21,14 @@
  * questions.
  */
 
-/* @test
-   @bug 6711682
-   @summary  JCheckBox in JTable: checkbox doesn't alaways respond to the first mouse click
-   @author Alexander Potochkin
-   @run main bug6711682
-*/
+/*
+ * @test
+ * @key headful
+ * @bug 6711682
+ * @summary  JCheckBox in JTable: checkbox doesn't alaways respond to the first mouse click
+ * @author Alexander Potochkin
+ * @run main bug6711682
+ */
 
 import javax.swing.*;
 import javax.swing.event.CellEditorListener;

--- a/jdk/test/javax/swing/AncestorNotifier/7193219/bug7193219.java
+++ b/jdk/test/javax/swing/AncestorNotifier/7193219/bug7193219.java
@@ -21,11 +21,13 @@
  * questions.
  */
 
-/* @test
-   @bug 7193219
-   @summary JComboBox serialization fails in JDK 1.7
-   @author Anton Litvinov
-*/
+/*
+ * @test
+ * @key headful
+ * @bug 7193219
+ * @summary JComboBox serialization fails in JDK 1.7
+ * @author Anton Litvinov
+ */
 
 import java.io.*;
 

--- a/jdk/test/javax/swing/JButton/4368790/bug4368790.java
+++ b/jdk/test/javax/swing/JButton/4368790/bug4368790.java
@@ -21,12 +21,14 @@
  * questions.
  */
 
-/* @test
-   @bug 4368790
-   @summary JButton stays pressed when focus stolen
-   @author Alexander Potochkin
-   @run main bug4368790
-*/
+/*
+ * @test
+ * @key headful
+ *    @bug 4368790
+ *    @summary JButton stays pressed when focus stolen
+ *    @author Alexander Potochkin
+ *    @run main bug4368790
+ */
 
 import javax.swing.*;
 import java.awt.*;

--- a/jdk/test/javax/swing/JButton/JButtonPaintNPE/JButtonPaintNPE.java
+++ b/jdk/test/javax/swing/JButton/JButtonPaintNPE/JButtonPaintNPE.java
@@ -33,6 +33,7 @@ import javax.swing.SwingUtilities;
 
 /**
  * @test
+ * @key headful
  * @bug 8009919
  * @author Sergey Bylokhov
  * @library ../../../../lib/testlibrary/

--- a/jdk/test/javax/swing/JColorChooser/Test6541987.java
+++ b/jdk/test/javax/swing/JColorChooser/Test6541987.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6541987
  * @summary Tests closing by ESC
  * @author Sergey Malenkov

--- a/jdk/test/javax/swing/JColorChooser/Test6559154.java
+++ b/jdk/test/javax/swing/JColorChooser/Test6559154.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6559154
  * @summary Tests EDT hanging
  * @author Sergey Malenkov

--- a/jdk/test/javax/swing/JColorChooser/Test6827032.java
+++ b/jdk/test/javax/swing/JColorChooser/Test6827032.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6827032
  * @summary Color chooser with drag enabled shouldn't throw NPE
  * @author Peter Zhelezniakov

--- a/jdk/test/javax/swing/JColorChooser/Test7194184.java
+++ b/jdk/test/javax/swing/JColorChooser/Test7194184.java
@@ -27,6 +27,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 7194184
  * @summary Tests JColorChooser Swatch keyboard accessibility.
  * @author Sean Chou

--- a/jdk/test/javax/swing/JComboBox/4199622/bug4199622.java
+++ b/jdk/test/javax/swing/JComboBox/4199622/bug4199622.java
@@ -21,14 +21,16 @@
  * questions.
  */
 
-/* @test
+/*
+   @test
+   @key headful
    @bug 4199622
    @summary RFE: JComboBox shouldn't send ActionEvents for keyboard navigation
    @author Vladislav Karnaukhov
    @library ../../../../lib/testlibrary
    @build jdk.testlibrary.OSInfo
    @run main bug4199622
-*/
+ */
 
 import com.sun.java.swing.plaf.windows.WindowsLookAndFeel;
 import jdk.testlibrary.OSInfo;

--- a/jdk/test/javax/swing/JComboBox/4515752/DefaultButtonTest.java
+++ b/jdk/test/javax/swing/JComboBox/4515752/DefaultButtonTest.java
@@ -27,6 +27,7 @@ import javax.swing.*;
 
 /**
  * @test
+ * @key headful
  * @bug 4515752 4337071
  * @author Mark Davidson
  * @summary Tests the invocation of the default button within the JComboBox.

--- a/jdk/test/javax/swing/JComboBox/4523758/bug4523758.java
+++ b/jdk/test/javax/swing/JComboBox/4523758/bug4523758.java
@@ -21,7 +21,9 @@
  * questions.
  */
 
-/* @test
+/*
+ * @test
+ * @key headful
  * @bug 4523758
  * @summary Directly check that torn-off combo works
  * @library ../../../../lib/testlibrary

--- a/jdk/test/javax/swing/JComboBox/4743225/bug4743225.java
+++ b/jdk/test/javax/swing/JComboBox/4743225/bug4743225.java
@@ -21,7 +21,9 @@
  * questions.
  */
 
-/* @test
+/*
+ * @test
+ * @key headful
  * @bug 4743225
  * @summary Size of JComboBox list is wrong when list is populated via PopupMenuListener
  * @author Alexander Potochkin

--- a/jdk/test/javax/swing/JComboBox/6236162/bug6236162.java
+++ b/jdk/test/javax/swing/JComboBox/6236162/bug6236162.java
@@ -20,16 +20,19 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-/* @test
-   @bug 6236162
-   @summary Checks that there is no an inconsistence in combo box
-            behavior when user points an item in combo popup
-            by mouse and then uses UP/DOWN keys.
-   @library ../../regtesthelpers
-   @build Util
-   @author Mikhail Lapshin
-   @run main bug6236162
-*/
+
+/*
+ * @test
+ * @key headful
+ * @bug 6236162
+ * @summary Checks that there is no an inconsistence in combo box
+ *          behavior when user points an item in combo popup
+ *          by mouse and then uses UP/DOWN keys.
+ * @library ../../regtesthelpers
+ * @build Util
+ * @author Mikhail Lapshin
+ * @run main bug6236162
+ */
 
 import javax.swing.*;
 import javax.swing.plaf.basic.*;

--- a/jdk/test/javax/swing/JComboBox/6406264/bug6406264.java
+++ b/jdk/test/javax/swing/JComboBox/6406264/bug6406264.java
@@ -23,11 +23,13 @@
  * questions.
  */
 
-/* @test
-   @bug 6406264
-   @summary Tests that JComboBox's focusable popup can be shown.
-   @author Mikhail Lapshin
-   @run main bug6406264
+/*
+ * @test
+ * @key headful
+ * @bug 6406264
+ * @summary Tests that JComboBox's focusable popup can be shown.
+ * @author Mikhail Lapshin
+ * @run main bug6406264
  */
 
 import javax.swing.JComboBox;

--- a/jdk/test/javax/swing/JComboBox/6559152/bug6559152.java
+++ b/jdk/test/javax/swing/JComboBox/6559152/bug6559152.java
@@ -20,15 +20,18 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-/* @test
-   @bug 6559152
-   @summary Checks that you can select an item in JComboBox with keyboard
-            when it is a JTable cell editor.
-   @author Mikhail Lapshin
-   @library ../../../../lib/testlibrary
-   @build ExtendedRobot
-   @run main bug6559152
-*/
+
+/*
+ * @test
+ * @key headful
+ * @bug 6559152
+ * @summary Checks that you can select an item in JComboBox with keyboard
+ *          when it is a JTable cell editor.
+ * @author Mikhail Lapshin
+ * @library ../../../../lib/testlibrary
+ * @build ExtendedRobot
+ * @run main bug6559152
+ */
 
 import javax.swing.*;
 import javax.swing.table.DefaultTableModel;

--- a/jdk/test/javax/swing/JComboBox/6607130/bug6607130.java
+++ b/jdk/test/javax/swing/JComboBox/6607130/bug6607130.java
@@ -21,7 +21,9 @@
  * questions.
  */
 
-/* @test
+/*
+ * @test
+ * @key headful
  * @bug 6607130
  * @summary Checks that JComboBox cell editor is hidden if the same
  *          item is selected with keyboard.

--- a/jdk/test/javax/swing/JComboBox/7195179/Test7195179.java
+++ b/jdk/test/javax/swing/JComboBox/7195179/Test7195179.java
@@ -35,6 +35,7 @@ import static javax.swing.SwingUtilities.invokeAndWait;
 
 /*
  * @test
+ * @key headful
  * @bug 7195179
  * @summary Tests that combobox works with generified renderers
  * @author Sergey Malenkov

--- a/jdk/test/javax/swing/JComboBox/8015300/Test8015300.java
+++ b/jdk/test/javax/swing/JComboBox/8015300/Test8015300.java
@@ -38,8 +38,9 @@ import static javax.swing.WindowConstants.DISPOSE_ON_CLOSE;
 
 /*
  * @test
+ * @key headful
  * @bug 8015300
- * @summary Tests that editable combobox select all text
+ * @summary Tests that editable combobox selects all text.
  * @author Sergey Malenkov
  * @library ../../../../lib/testlibrary/
  * @build ExtendedRobot

--- a/jdk/test/javax/swing/JComboBox/8032878/bug8032878.java
+++ b/jdk/test/javax/swing/JComboBox/8032878/bug8032878.java
@@ -21,7 +21,9 @@
  * questions.
  */
 
-/* @test
+/*
+ * @test
+ * @key headful
  * @bug 8032878 8078855
  * @summary Checks that JComboBox as JTable cell editor processes key events
  *          even where setSurrendersFocusOnKeystroke flag in JTable is false and

--- a/jdk/test/javax/swing/JComboBox/8033069/bug8033069NoScrollBar.java
+++ b/jdk/test/javax/swing/JComboBox/8033069/bug8033069NoScrollBar.java
@@ -35,7 +35,9 @@ import javax.swing.UIManager;
 import javax.swing.UIManager.LookAndFeelInfo;
 import javax.swing.UnsupportedLookAndFeelException;
 
-/* @test
+/*
+ * @test
+ * @key headful
  * @bug 8033069
  * @summary Checks that JComboBox popup does not close when mouse wheel is
  *          rotated over combo box and over its popup. The case where popup

--- a/jdk/test/javax/swing/JComboBox/8033069/bug8033069ScrollBar.java
+++ b/jdk/test/javax/swing/JComboBox/8033069/bug8033069ScrollBar.java
@@ -23,7 +23,9 @@
 
 import java.awt.AWTException;
 
-/* @test
+/*
+ * @test
+ * @key headful
  * @bug 8033069
  * @summary Checks that JComboBox popup does not close when mouse wheel is
  *          rotated over combo box and over its popup. The case where

--- a/jdk/test/javax/swing/JComboBox/8057893/bug8057893.java
+++ b/jdk/test/javax/swing/JComboBox/8057893/bug8057893.java
@@ -33,6 +33,7 @@ import javax.swing.WindowConstants;
 
 /**
  * @test
+ * @key headful
  * @bug 8057893
  * @author Alexander Scherbatiy
  * @summary JComboBox actionListener never receives "comboBoxEdited"

--- a/jdk/test/javax/swing/JComboBox/8072767/bug8072767.java
+++ b/jdk/test/javax/swing/JComboBox/8072767/bug8072767.java
@@ -34,6 +34,7 @@ import javax.swing.SwingUtilities;
 
 /**
  * @test
+ * @key headful
  * @bug 8072767
  * @author Alexander Scherbatiy
  * @summary DefaultCellEditor for comboBox creates ActionEvent with wrong source

--- a/jdk/test/javax/swing/JComboBox/8136998/bug8136998.java
+++ b/jdk/test/javax/swing/JComboBox/8136998/bug8136998.java
@@ -38,7 +38,9 @@ import javax.swing.UIManager.LookAndFeelInfo;
 import javax.swing.UnsupportedLookAndFeelException;
 import javax.swing.WindowConstants;
 
-/* @test
+/*
+ * @test
+ * @key headful
  * @bug 8136998
  * @summary Checks that JComboBox does not prevent mouse-wheel scrolling JScrollPane.
  * @library ../../regtesthelpers

--- a/jdk/test/javax/swing/JComboBox/ConsumedKeyTest/ConsumedKeyTest.java
+++ b/jdk/test/javax/swing/JComboBox/ConsumedKeyTest/ConsumedKeyTest.java
@@ -30,6 +30,7 @@ import sun.awt.SunToolkit;
 
 /*
   @test
+  @key headful
   @bug 8031485 8058193
   @summary Combo box consuming escape and enter key events
   @author Petr Pchelko

--- a/jdk/test/javax/swing/JComboBox/ShowPopupAfterHidePopupTest/ShowPopupAfterHidePopupTest.java
+++ b/jdk/test/javax/swing/JComboBox/ShowPopupAfterHidePopupTest/ShowPopupAfterHidePopupTest.java
@@ -21,12 +21,14 @@
  * questions.
  */
 
-/* @test
-   @bug 8006417
-   @summary JComboBox.showPopup(), hidePopup() fails in JRE 1.7 on OS X
-   @author Anton Litvinov
-   @run main ShowPopupAfterHidePopupTest
-*/
+/*
+ * @test
+ * @key headful
+ * @bug 8006417
+ * @summary JComboBox.showPopup(), hidePopup() fails in JRE 1.7 on OS X
+ * @author Anton Litvinov
+ * @run main ShowPopupAfterHidePopupTest
+ */
 
 import java.awt.*;
 

--- a/jdk/test/javax/swing/JComponent/6989617/bug6989617.java
+++ b/jdk/test/javax/swing/JComponent/6989617/bug6989617.java
@@ -21,12 +21,14 @@
  * questions.
  */
 
-/* @test
-   @bug 6989617
-   @summary Enable JComponent to control repaintings of its children
-   @author Alexander Potochkin
-   @run main bug6989617
-*/
+/*
+ * @test
+ * @key headful
+ * @bug 6989617
+ * @summary Enable JComponent to control repaintings of its children
+ * @author Alexander Potochkin
+ * @run main bug6989617
+ */
 
 import javax.swing.*;
 import java.awt.*;

--- a/jdk/test/javax/swing/JComponent/7154030/bug7154030.java
+++ b/jdk/test/javax/swing/JComponent/7154030/bug7154030.java
@@ -40,7 +40,9 @@ import java.awt.Robot;
 import java.awt.Toolkit;
 import java.awt.image.BufferedImage;
 
-/* @test 1.1 2012/04/12
+/*
+ * @test
+ * @key headful
  * @bug 7154030
  * @summary Swing components fail to hide after calling hide()
  * @author Jonathan Lu

--- a/jdk/test/javax/swing/JDialog/WrongBackgroundColor/WrongBackgroundColor.java
+++ b/jdk/test/javax/swing/JDialog/WrongBackgroundColor/WrongBackgroundColor.java
@@ -33,6 +33,7 @@ import javax.swing.plaf.ColorUIResource;
 
 /**
  * @test
+ * @key headful
  * @bug 8033786
  * @summary JDialog should update background color of the native peer.
  * @author Sergey Bylokhov

--- a/jdk/test/javax/swing/JEditorPane/4492274/bug4492274.java
+++ b/jdk/test/javax/swing/JEditorPane/4492274/bug4492274.java
@@ -21,7 +21,9 @@
  * questions.
  */
 
-/* @test
+/*
+ * @test
+ * @key headful
  * @bug 4492274
  * @summary  Tests if JEditorPane.getPage() correctly returns anchor reference.
  * @author Denis Sharypov

--- a/jdk/test/javax/swing/JEditorPane/6917744/bug6917744.java
+++ b/jdk/test/javax/swing/JEditorPane/6917744/bug6917744.java
@@ -21,7 +21,9 @@
  * questions.
  */
 
-/* @test
+/*
+ * @test
+ * @key headful
  * @bug 6917744
  * @summary JScrollPane Page Up/Down keys do not handle correctly html tables with different cells contents
  * @author Pavel Porvatov

--- a/jdk/test/javax/swing/JFileChooser/4524490/bug4524490.java
+++ b/jdk/test/javax/swing/JFileChooser/4524490/bug4524490.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 4524490
  * @summary Tests if in JFileChooser, ALT+L does not bring focus to 'Files' selection list in Motif LAF
  * @author Konstantin Eremin

--- a/jdk/test/javax/swing/JFileChooser/6396844/TwentyThousandTest.java
+++ b/jdk/test/javax/swing/JFileChooser/6396844/TwentyThousandTest.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6396844
  * @summary Tests memory leak for 20000 files
  * @author Sergey Malenkov

--- a/jdk/test/javax/swing/JFileChooser/7199708/bug7199708.java
+++ b/jdk/test/javax/swing/JFileChooser/7199708/bug7199708.java
@@ -40,6 +40,7 @@ import javax.swing.UIManager;
 
 /**
  * @test
+ * @key headful
  * @bug 7199708
  * @author Alexander Scherbatiy
  * @summary FileChooser crashs when opening large folder

--- a/jdk/test/javax/swing/JFileChooser/8002077/bug8002077.java
+++ b/jdk/test/javax/swing/JFileChooser/8002077/bug8002077.java
@@ -30,6 +30,7 @@ import javax.swing.UIManager.LookAndFeelInfo;
 
 /**
  * @test
+ * @key headful
  * @bug 8002077
  * @author Alexander Scherbatiy
  * @summary Possible mnemonic issue on JFileChooser Save button on nimbus L&F

--- a/jdk/test/javax/swing/JFileChooser/8021253/bug8021253.java
+++ b/jdk/test/javax/swing/JFileChooser/8021253/bug8021253.java
@@ -35,6 +35,7 @@ import javax.swing.SwingUtilities;
 
 /**
  * @test
+ * @key headful
  * @bug 8021253
  * @author Alexander Scherbatiy
  * @summary JFileChooser does not react on pressing enter since java 7

--- a/jdk/test/javax/swing/JFrame/HangNonVolatileBuffer/HangNonVolatileBuffer.java
+++ b/jdk/test/javax/swing/JFrame/HangNonVolatileBuffer/HangNonVolatileBuffer.java
@@ -28,6 +28,7 @@ import javax.swing.SwingUtilities;
 
 /**
  * @test
+ * @key headful
  * @bug 8029455
  * @summary Swing should not hang if non-volatile image is used as a backbuffer.
  * @run main/othervm -Dswing.volatileImageBufferEnabled=false HangNonVolatileBuffer

--- a/jdk/test/javax/swing/JInternalFrame/5066752/bug5066752.java
+++ b/jdk/test/javax/swing/JInternalFrame/5066752/bug5066752.java
@@ -22,6 +22,7 @@
  */
 /*
   @test
+  @key headful
   @bug 5066752
   @summary  Transparent JDesktopPane impossible because isOpaque() returns true
   @author mb50250: area=JDesktopPane

--- a/jdk/test/javax/swing/JInternalFrame/6647340/bug6647340.java
+++ b/jdk/test/javax/swing/JInternalFrame/6647340/bug6647340.java
@@ -22,6 +22,7 @@
  */
 
 /* @test
+ * @key headful
  * @bug 6647340
  * @summary Checks that iconified internal frame follows
  *          the main frame borders properly.

--- a/jdk/test/javax/swing/JInternalFrame/6725409/bug6725409.java
+++ b/jdk/test/javax/swing/JInternalFrame/6725409/bug6725409.java
@@ -22,6 +22,7 @@
  */
 
 /* @test
+ * @key headful
  * @bug 6725409
  * @summary Checks that JInternalFrame's system menu
  *          can be localized during run-time

--- a/jdk/test/javax/swing/JInternalFrame/8020708/bug8020708.java
+++ b/jdk/test/javax/swing/JInternalFrame/8020708/bug8020708.java
@@ -36,6 +36,7 @@ import javax.swing.UIManager;
 /**
  * @test
  * @bug 8020708
+ * @key headful
  * @author Alexander Scherbatiy
  * @summary NLS: mnemonics missing in SwingSet2/JInternalFrame demo
  * @library ../../regtesthelpers

--- a/jdk/test/javax/swing/JInternalFrame/InternalFrameIsNotCollectedTest.java
+++ b/jdk/test/javax/swing/JInternalFrame/InternalFrameIsNotCollectedTest.java
@@ -21,11 +21,13 @@
  * questions.
  */
 
- /* @test
-    @bug 8012004
-    @summary JINTERNALFRAME NOT BEING FINALIZED AFTER CLOSING
-    @author mcherkas
-    @run main InternalFrameIsNotCollectedTest
+/*
+ * @test
+ * @key headful
+ * @bug 8012004
+ * @summary JINTERNALFRAME NOT BEING FINALIZED AFTER CLOSING
+ * @author mcherkas
+ * @run main InternalFrameIsNotCollectedTest
  */
 import javax.swing.*;
 import java.awt.*;

--- a/jdk/test/javax/swing/JInternalFrame/Test6505027.java
+++ b/jdk/test/javax/swing/JInternalFrame/Test6505027.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6505027
  * @summary Tests focus problem inside internal frame
  * @author Sergey Malenkov

--- a/jdk/test/javax/swing/JInternalFrame/Test6802868.java
+++ b/jdk/test/javax/swing/JInternalFrame/Test6802868.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6802868
  * @summary JInternalFrame is not maximized when maximized parent frame
  * @author Alexander Potochkin

--- a/jdk/test/javax/swing/JLabel/6596966/bug6596966.java
+++ b/jdk/test/javax/swing/JLabel/6596966/bug6596966.java
@@ -21,15 +21,17 @@
  * questions.
  */
 
-/* @test
-   @bug 6596966
-   @summary Some JFileChooser mnemonics do not work with sticky keys
-   @library ../../regtesthelpers
-   @library ../../../../lib/testlibrary
-   @build Util jdk.testlibrary.OSInfo
-   @run main bug6596966
-   @author Pavel Porvatov
-*/
+/*
+ * @test
+ * @key headful
+ * @bug 6596966
+ * @summary Some JFileChooser mnemonics do not work with sticky keys
+ * @library ../../regtesthelpers
+ * @library ../../../../lib/testlibrary
+ * @build Util jdk.testlibrary.OSInfo
+ * @run main bug6596966
+ * @author Pavel Porvatov
+ */
 
 import java.awt.*;
 import java.awt.event.KeyEvent;

--- a/jdk/test/javax/swing/JLabel/7004134/bug7004134.java
+++ b/jdk/test/javax/swing/JLabel/7004134/bug7004134.java
@@ -21,11 +21,14 @@
  * questions.
  */
 
-/* @test
-   @bug 7004134
-   @summary JLabel containing a ToolTipText does no longer show ToolTip after browser refresh
-   @author Pavel Porvatov
-*/
+/*
+ * @test
+ * @key headful
+ * @bug 7004134
+ * @summary JLabel containing a ToolTipText does no longer show ToolTip after browser refresh
+ * @author Pavel Porvatov
+ * @modules java.desktop/sun.awt
+ */
 
 import sun.awt.SunToolkit;
 

--- a/jdk/test/javax/swing/JLayer/6824395/bug6824395.java
+++ b/jdk/test/javax/swing/JLayer/6824395/bug6824395.java
@@ -23,6 +23,7 @@
 
  /*
  * @test
+ * @key headful
  * @summary Checks that JLayer inside JViewport works is correctly laid out
  * @author Alexander Potochkin
  * @library ../../../../lib/testlibrary/

--- a/jdk/test/javax/swing/JLayer/6872503/bug6872503.java
+++ b/jdk/test/javax/swing/JLayer/6872503/bug6872503.java
@@ -21,7 +21,9 @@
  * questions.
  */
 
-/* @test
+/*
+ * @test
+ * @key headful
  * @bug 6872503
  * @summary Checks that JLayer correctly works with its AWTEventListener
  * @author Alexander Potochkin

--- a/jdk/test/javax/swing/JList/6462008/bug6462008.java
+++ b/jdk/test/javax/swing/JList/6462008/bug6462008.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6462008
  * @summary Tests that mouse/keyboard work properly on JList with lead < 0 or > list.getModel().getSize()
  * @author Shannon Hickey

--- a/jdk/test/javax/swing/JList/6510999/bug6510999.java
+++ b/jdk/test/javax/swing/JList/6510999/bug6510999.java
@@ -20,12 +20,14 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-/* @test
-   @bug 6510999
-   @summary Selection in a JList with both scrollbars visible jumps on arrowkey-down
-   @author Alexander Potochkin
-   @run main bug6510999
-*/
+/*
+ * @test
+ * @key headful
+ * @bug 6510999
+ * @summary Selection in a JList with both scrollbars visible jumps on arrowkey-down
+ * @author Alexander Potochkin
+ * @run main bug6510999
+ */
 
 import javax.swing.*;
 import java.awt.*;

--- a/jdk/test/javax/swing/JMenu/4417601/bug4417601.java
+++ b/jdk/test/javax/swing/JMenu/4417601/bug4417601.java
@@ -20,14 +20,17 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-/* @test
-   @bug 4417601
-   @summary JMenus with no items paint a tiny menu.
-   @author Alexander Potochkin
-   @library ../../../../lib/testlibrary
-   @build ExtendedRobot
-   @run main bug4417601
-*/
+
+/*
+ * @test
+ * @key headful
+ * @bug 4417601
+ * @summary JMenus with no items paint a tiny menu.
+ * @author Alexander Potochkin
+ * @library ../../../../lib/testlibrary
+ * @build ExtendedRobot
+ * @run main bug4417601
+ */
 
 import javax.swing.*;
 import java.awt.event.*;

--- a/jdk/test/javax/swing/JMenu/4515762/bug4515762.java
+++ b/jdk/test/javax/swing/JMenu/4515762/bug4515762.java
@@ -27,6 +27,7 @@ import javax.swing.*;
 
 /**
  * @test
+ * @key headful
  * @bug 4515762
  * @author Mark Davidson
  * @summary Tests the ability to support duplicate mnemonics

--- a/jdk/test/javax/swing/JMenu/4692443/bug4692443.java
+++ b/jdk/test/javax/swing/JMenu/4692443/bug4692443.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @library ../../regtesthelpers
  * @build Util
  * @bug 4692443 7105030

--- a/jdk/test/javax/swing/JMenu/6359669/bug6359669.java
+++ b/jdk/test/javax/swing/JMenu/6359669/bug6359669.java
@@ -20,14 +20,16 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-/* @test
-   @bug 6359669
-   @summary REGRESSION: Submenu does not work if populated in PopupMenuListener.popupMenuWillBecomeVisible
-   @author Alexander Potochkin
-   @library ../../../../lib/testlibrary
-   @build ExtendedRobot
-   @run main bug6359669
-*/
+/*
+ * @test
+ * @key headful
+ * @bug 6359669
+ * @summary REGRESSION: Submenu does not work if populated in PopupMenuListener.popupMenuWillBecomeVisible
+ * @author Alexander Potochkin
+ * @library ../../../../lib/testlibrary
+ * @build ExtendedRobot
+ * @run main bug6359669
+ */
 
 import javax.swing.*;
 import javax.swing.event.PopupMenuListener;

--- a/jdk/test/javax/swing/JMenu/6470128/bug6470128.java
+++ b/jdk/test/javax/swing/JMenu/6470128/bug6470128.java
@@ -20,14 +20,18 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-/* @test
-   @bug 6470128
-   @summary Escape Key causes JMenu Selection to Disappear
-   @author Alexander Potochkin
-   @library ../../../../lib/testlibrary
-   @build jdk.testlibrary.OSInfo
-   @run main bug6470128
-*/
+
+/*
+ * @test
+ * @key headful
+ * @bug 6470128
+ * @summary Escape Key causes JMenu Selection to Disappear
+ * @author Alexander Potochkin
+ * @library ../../../../lib/testlibrary
+ * @build jdk.testlibrary.OSInfo
+ * @run main bug6470128
+ */
+
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.KeyEvent;

--- a/jdk/test/javax/swing/JMenu/8072900/WrongSelectionOnMouseOver.java
+++ b/jdk/test/javax/swing/JMenu/8072900/WrongSelectionOnMouseOver.java
@@ -22,12 +22,13 @@
  */
 
 /*
-@test
-@bug 8072900
-@summary Mouse events are captured by the wrong menu in OS X
-@author Anton Nashatyrev
-@run main WrongSelectionOnMouseOver
-*/
+ * @test
+ * @key headful
+ * @bug 8072900
+ * @summary Mouse events are captured by the wrong menu in OS X
+ * @author Anton Nashatyrev
+ * @run main WrongSelectionOnMouseOver
+ */
 
 import javax.swing.*;
 import javax.swing.event.MenuEvent;

--- a/jdk/test/javax/swing/JMenuBar/4750590/bug4750590.java
+++ b/jdk/test/javax/swing/JMenuBar/4750590/bug4750590.java
@@ -21,13 +21,15 @@
  * questions.
  */
 
-/* @test
- @library ../../regtesthelpers
- @build Util
- @bug 4750590 8015597
- @summary SwingSet: Cannot change Themes using menu accelerators
- @author Alexander Zuev
- @run main bug4750590
+/*
+ * @test
+ * @key headful
+ * @library ../../regtesthelpers
+ * @build Util
+ * @bug 4750590 8015597
+ * @summary SwingSet: Cannot change Themes using menu accelerators
+ * @author Alexander Zuev
+ * @run main bug4750590
  */
 
 import javax.swing.*;

--- a/jdk/test/javax/swing/JMenuBar/MisplacedBorder/MisplacedBorder.java
+++ b/jdk/test/javax/swing/JMenuBar/MisplacedBorder/MisplacedBorder.java
@@ -40,6 +40,7 @@ import static javax.swing.UIManager.getInstalledLookAndFeels;
 
 /**
  * @test
+ * @key headful
  * @bug 8073795
  * @summary JMenuBar has incorrect border when the window is on retina display.
  * @author Sergey Bylokhov

--- a/jdk/test/javax/swing/JMenuItem/4171437/bug4171437.java
+++ b/jdk/test/javax/swing/JMenuItem/4171437/bug4171437.java
@@ -20,13 +20,17 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-/* @test
-   @bug 4171437
-   @library ../../regtesthelpers
-   @build Util
-   @author Georges Saab
-   @run main bug4171437
-*/
+
+/*
+ * @test
+ * @key headful
+ * @bug 4171437
+ * @library ../../regtesthelpers
+ * @build Util
+ * @author Georges Saab
+ * @run main bug4171437
+ */
+
 import java.awt.*;
 import java.awt.event.*;
 import java.util.ArrayList;

--- a/jdk/test/javax/swing/JMenuItem/4654927/bug4654927.java
+++ b/jdk/test/javax/swing/JMenuItem/4654927/bug4654927.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 4654927
  * @summary Clicking on Greyed Menuitems closes the Menubar Dropdown
  * @author Alexander Potochkin

--- a/jdk/test/javax/swing/JMenuItem/6209975/bug6209975.java
+++ b/jdk/test/javax/swing/JMenuItem/6209975/bug6209975.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6209975
  * @summary regression: JMenuItem icons overimposed on JMenuItem labels under Metal LAF
  * @author Alexander Zuev

--- a/jdk/test/javax/swing/JMenuItem/6249972/bug6249972.java
+++ b/jdk/test/javax/swing/JMenuItem/6249972/bug6249972.java
@@ -20,13 +20,16 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-/* @test
-   @bug 6249972
-   @summary Tests that JMenuItem(String,int) handles lower-case mnemonics properly.
-   @library ../../../../lib/testlibrary
-   @build ExtendedRobot
-   @author Mikhail Lapshin
-   @run main bug6249972
+
+/*
+ * @test
+ * @key headful
+ * @bug 6249972
+ * @summary Tests that JMenuItem(String,int) handles lower-case mnemonics properly.
+ * @library ../../../../lib/testlibrary
+ * @build ExtendedRobot
+ * @author Mikhail Lapshin
+ * @run main bug6249972
  */
 
 import javax.swing.*;

--- a/jdk/test/javax/swing/JOptionPane/6428694/bug6428694.java
+++ b/jdk/test/javax/swing/JOptionPane/6428694/bug6428694.java
@@ -21,13 +21,14 @@
  * questions.
  */
 /*
-@test
-@bug 6428694
-@summary Checks that double click closes JOptionPane's input dialog.
-@library ../../../../lib/testlibrary
-@build ExtendedRobot
-@author Mikhail Lapshin
-@run main bug6428694
+ * @test
+ * @key headful
+ * @bug 6428694
+ * @summary Checks that double click closes JOptionPane's input dialog.
+ * @library ../../../../lib/testlibrary
+ * @build ExtendedRobot
+ * @author Mikhail Lapshin
+ * @run main bug6428694
 */
 
 import javax.swing.JFrame;

--- a/jdk/test/javax/swing/JOptionPane/6464022/bug6464022.java
+++ b/jdk/test/javax/swing/JOptionPane/6464022/bug6464022.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6464022
  * @summary Memory leak in JOptionPane.createDialog
  * @author Pavel Porvatov

--- a/jdk/test/javax/swing/JOptionPane/7138665/bug7138665.java
+++ b/jdk/test/javax/swing/JOptionPane/7138665/bug7138665.java
@@ -21,11 +21,13 @@
  * questions.
  */
 
-/* @test
-   @bug 7138665
-   @summary JOptionPane.getValue() unexpected change between JRE 1.6 and JRE 1.7
-   @author Pavel Porvatov
-*/
+/*
+ * @test
+ * @key headful
+ * @bug 7138665
+ * @summary JOptionPane.getValue() unexpected change between JRE 1.6 and JRE 1.7
+ * @author Pavel Porvatov
+ */
 
 import javax.swing.*;
 import java.awt.*;

--- a/jdk/test/javax/swing/JPopupMenu/4458079/bug4458079.java
+++ b/jdk/test/javax/swing/JPopupMenu/4458079/bug4458079.java
@@ -20,14 +20,18 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-/* @test
-   @bug 4458079
-   @library ../../regtesthelpers
-   @build Util
-   @summary Tests calling removeAll() from PopupMenuListener
-   @author Peter Zhelezniakov
-   @run main bug4458079
-*/
+
+/*
+ * @test
+ * @key headful
+ * @bug 4458079
+ * @library ../../regtesthelpers
+ * @build Util
+ * @summary Tests calling removeAll() from PopupMenuListener
+ * @author Peter Zhelezniakov
+ * @run main bug4458079
+ */
+
 import java.awt.Robot;
 import java.awt.Toolkit;
 import java.awt.event.*;

--- a/jdk/test/javax/swing/JPopupMenu/4966112/bug4966112.java
+++ b/jdk/test/javax/swing/JPopupMenu/4966112/bug4966112.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 4966112
  * @summary Some Composite components does not show the Context Popup.
  * @library ../../regtesthelpers

--- a/jdk/test/javax/swing/JPopupMenu/6415145/bug6415145.java
+++ b/jdk/test/javax/swing/JPopupMenu/6415145/bug6415145.java
@@ -21,14 +21,15 @@
  * questions.
  */
 /*
-@test
-@bug 6415145
-@summary REGRESSION: Selected item is not being updated while dragging above popup menu
-@library ../../../../lib/testlibrary
-@build ExtendedRobot
-@author Mikhail Lapshin
-@run main bug6415145
-*/
+ * @test
+ * @key headful
+ * @bug 6415145
+ * @summary REGRESSION: Selected item is not being updated while dragging above popup menu
+ * @library ../../../../lib/testlibrary
+ * @build ExtendedRobot
+ * @author Mikhail Lapshin
+ * @run main bug6415145
+ */
 
 import javax.swing.*;
 import java.awt.event.*;

--- a/jdk/test/javax/swing/JPopupMenu/6495920/bug6495920.java
+++ b/jdk/test/javax/swing/JPopupMenu/6495920/bug6495920.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6495920
  * @summary Tests that if the JPopupMenu.setVisible method throws an exception,
             interaction with GNOME is not crippled

--- a/jdk/test/javax/swing/JPopupMenu/6515446/bug6515446.java
+++ b/jdk/test/javax/swing/JPopupMenu/6515446/bug6515446.java
@@ -21,14 +21,15 @@
  * questions.
  */
 /*
-@test
-@bug 6515446
-@summary JMenuItems in JPopupMenus not receiving ActionEvents - incompat with 1.5
-@author Alexander Potochkin
-@library ../../../../lib/testlibrary
-@build ExtendedRobot
-@run main bug6515446
-*/
+ * @test
+ * @key headful
+ * @bug 6515446
+ * @summary JMenuItems in JPopupMenus not receiving ActionEvents - incompat with 1.5
+ * @author Alexander Potochkin
+ * @library ../../../../lib/testlibrary
+ * @build ExtendedRobot
+ * @run main bug6515446
+ */
 
 import javax.swing.*;
 import java.awt.event.*;

--- a/jdk/test/javax/swing/JPopupMenu/6544309/bug6544309.java
+++ b/jdk/test/javax/swing/JPopupMenu/6544309/bug6544309.java
@@ -20,7 +20,9 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-/* @test
+/*
+   @test
+  @key headful
    @bug 6544309
    @summary Checks that 'Select Input Method' popup menu allows to select
             items with keyboard.

--- a/jdk/test/javax/swing/JPopupMenu/6580930/bug6580930.java
+++ b/jdk/test/javax/swing/JPopupMenu/6580930/bug6580930.java
@@ -21,14 +21,15 @@
  * questions.
  */
 /*
-@test
-@bug 6580930 7184956
-@summary Swing Popups should overlap taskbar
-@author Alexander Potochkin
-@library ../../../../lib/testlibrary
-@build ExtendedRobot
-@run main bug6580930
-*/
+ * @test
+ * @key headful
+ * @bug 6580930 7184956
+ * @summary Swing Popups should overlap taskbar
+ * @author Alexander Potochkin
+ * @library ../../../../lib/testlibrary
+ * @build ExtendedRobot
+ * @run main bug6580930
+ */
 
 import javax.swing.*;
 import java.awt.*;

--- a/jdk/test/javax/swing/JPopupMenu/6583251/bug6583251.java
+++ b/jdk/test/javax/swing/JPopupMenu/6583251/bug6583251.java
@@ -24,12 +24,13 @@
  */
 
 /*
-@test
-@bug 6583251
-@summary One more ClassCastException in Swing with TrayIcon
-@author Alexander Potochkin
-@run main bug6583251
-*/
+ * @test
+ * @key headful
+ * @bug 6583251
+ * @summary One more ClassCastException in Swing with TrayIcon
+ * @author Alexander Potochkin
+ * @run main bug6583251
+ */
 
 import javax.swing.*;
 import java.awt.*;

--- a/jdk/test/javax/swing/JPopupMenu/6691503/bug6691503.java
+++ b/jdk/test/javax/swing/JPopupMenu/6691503/bug6691503.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6691503
  * @summary Checks that there is no opportunity for a malicious applet
  * to show a popup menu which has whole screen size.

--- a/jdk/test/javax/swing/JPopupMenu/6694823/bug6694823.java
+++ b/jdk/test/javax/swing/JPopupMenu/6694823/bug6694823.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6694823
  * @summary Checks that popup menu cannot be partially hidden
  * by the task bar in applets.

--- a/jdk/test/javax/swing/JPopupMenu/6800513/bug6800513.java
+++ b/jdk/test/javax/swing/JPopupMenu/6800513/bug6800513.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6800513
  * @summary GTK-LaF renders menus incompletely
  * @author Mario Torre

--- a/jdk/test/javax/swing/JPopupMenu/6827786/bug6827786.java
+++ b/jdk/test/javax/swing/JPopupMenu/6827786/bug6827786.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6827786
  * @summary Tests duplicate mnemonics
  * @author Peter Zhelezniakov

--- a/jdk/test/javax/swing/JPopupMenu/6987844/bug6987844.java
+++ b/jdk/test/javax/swing/JPopupMenu/6987844/bug6987844.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6987844
  * @summary Incorrect width of JComboBox drop down
  * @author Alexander Potochkin

--- a/jdk/test/javax/swing/JPopupMenu/7156657/bug7156657.java
+++ b/jdk/test/javax/swing/JPopupMenu/7156657/bug7156657.java
@@ -29,7 +29,9 @@ import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.util.concurrent.Callable;
 
-/* @test
+/*
+   @test
+  @key headful
    @bug 7156657
    @summary Version 7 doesn't support translucent popup menus against a translucent window
    @library ../../regtesthelpers

--- a/jdk/test/javax/swing/JRadioButton/8033699/bug8033699.java
+++ b/jdk/test/javax/swing/JRadioButton/8033699/bug8033699.java
@@ -23,6 +23,7 @@
 
  /*
  * @test
+ * @key headful
  * @library ../../regtesthelpers
  * @build Util
  * @bug 8033699 8226892

--- a/jdk/test/javax/swing/JRadioButton/8041561/bug8041561.java
+++ b/jdk/test/javax/swing/JRadioButton/8041561/bug8041561.java
@@ -36,6 +36,7 @@ import javax.swing.plaf.metal.MetalLookAndFeel;
 
 /**
  * @test
+ * @key headful
  * @bug 8041561
  * @author Alexander Scherbatiy
  * @summary Inconsistent opacity behaviour between JCheckBox and JRadioButton

--- a/jdk/test/javax/swing/JRadioButton/8075609/bug8075609.java
+++ b/jdk/test/javax/swing/JRadioButton/8075609/bug8075609.java
@@ -23,6 +23,7 @@
 
  /*
  * @test
+ * @key headful
  * @library ../../regtesthelpers
  * @build Util
  * @bug 8075609

--- a/jdk/test/javax/swing/JRootPane/4670486/bug4670486.java
+++ b/jdk/test/javax/swing/JRootPane/4670486/bug4670486.java
@@ -27,6 +27,7 @@ import javax.swing.*;
 
 /**
  * @test
+ * @key headful
  * @bug 4670486
  * @author Mark Davidson
  * @summary Regression: Popup menu bindings doesn't work when a default button has been defined.

--- a/jdk/test/javax/swing/JScrollBar/4708809/bug4708809.java
+++ b/jdk/test/javax/swing/JScrollBar/4708809/bug4708809.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 4708809
  * @summary JScrollBar functionality slightly different from native scrollbar
  * @author Andrey Pikalev

--- a/jdk/test/javax/swing/JScrollBar/4865918/bug4865918.java
+++ b/jdk/test/javax/swing/JScrollBar/4865918/bug4865918.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 4865918
  * @summary REGRESSION:JCK1.4a-runtime api/javax_swing/interactive/JScrollBarTests.html#JScrollBar
  * @author Andrey Pikalev

--- a/jdk/test/javax/swing/JScrollBar/6542335/bug6542335.java
+++ b/jdk/test/javax/swing/JScrollBar/6542335/bug6542335.java
@@ -21,12 +21,14 @@
  * questions.
  */
 
-/* @test
-   @bug 6542335
-   @summary different behavior on knob of scroll bar between 1.4.2 and 5.0
-   @author  Alexander Potochkin
-   @run main bug6542335
-*/
+/*
+ * @test
+ * @key headful
+ * @bug 6542335
+ * @summary different behavior on knob of scroll bar between 1.4.2 and 5.0
+ * @author  Alexander Potochkin
+ * @run main bug6542335
+ */
 
 import javax.swing.*;
 import javax.swing.plaf.basic.BasicScrollBarUI;

--- a/jdk/test/javax/swing/JScrollBar/7163696/Test7163696.java
+++ b/jdk/test/javax/swing/JScrollBar/7163696/Test7163696.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 7163696
  * @summary Tests that JScrollBar scrolls to the left
  * @author Sergey Malenkov

--- a/jdk/test/javax/swing/JScrollBar/bug4202954/bug4202954.java
+++ b/jdk/test/javax/swing/JScrollBar/bug4202954/bug4202954.java
@@ -20,14 +20,16 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-/* @test
+/*
+   @test
+   @key headful
    @bug 4202954
    @library ../../../../lib/testlibrary
    @library ../../regtesthelpers
    @build Util jdk.testlibrary.OSInfo
    @author Michael C. Albers
    @run main bug4202954
-*/
+ */
 
 import java.awt.*;
 import java.awt.event.InputEvent;

--- a/jdk/test/javax/swing/JScrollPane/6274267/bug6274267.java
+++ b/jdk/test/javax/swing/JScrollPane/6274267/bug6274267.java
@@ -23,13 +23,15 @@
  * questions.
  */
 
-/* @test
-   @bug 6274267
-   @summary Checks that ScrollPaneLayout properly calculates preferred
-   layout size.
-   @author Mikhail Lapshin
-   @run main bug6274267
-*/
+/*
+ * @test
+ * @key headful
+ * @bug 6274267
+ * @summary Checks that ScrollPaneLayout properly calculates preferred
+ * layout size.
+ * @author Mikhail Lapshin
+ * @run main bug6274267
+ */
 
 import javax.swing.*;
 import java.awt.*;

--- a/jdk/test/javax/swing/JScrollPane/HorizontalMouseWheelOnShiftPressed/HorizontalMouseWheelOnShiftPressed.java
+++ b/jdk/test/javax/swing/JScrollPane/HorizontalMouseWheelOnShiftPressed/HorizontalMouseWheelOnShiftPressed.java
@@ -35,6 +35,7 @@ import sun.awt.OSInfo;
 
 /**
  * @test
+ * @key headful
  * @bug 8033000 8147994
  * @author Alexander Scherbatiy
  * @summary No Horizontal Mouse Wheel Support In BasicScrollPaneUI

--- a/jdk/test/javax/swing/JScrollPane/Test6526631.java
+++ b/jdk/test/javax/swing/JScrollPane/Test6526631.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6526631
  * @summary Resizes right-oriented scroll pane
  * @author Sergey Malenkov

--- a/jdk/test/javax/swing/JSlider/6348946/bug6348946.java
+++ b/jdk/test/javax/swing/JSlider/6348946/bug6348946.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6348946
  * @summary Tests that JSlider's thumb moves in the right direction
  *          when it is used as a JTable cell editor.

--- a/jdk/test/javax/swing/JSlider/6401380/bug6401380.java
+++ b/jdk/test/javax/swing/JSlider/6401380/bug6401380.java
@@ -20,14 +20,17 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-/* @test
-   @bug 6401380
-   @summary JSlider - mouse click ont the left side of the knob is ignored.
-   @library ../../../../lib/testlibrary
-   @build ExtendedRobot
-   @author Alexander Potochkin
-   @run main bug6401380
-*/
+
+/*
+ * @test
+ * @key headful
+ * @bug 6401380
+ * @summary JSlider - mouse click ont the left side of the knob is ignored.
+ * @library ../../../../lib/testlibrary
+ * @build ExtendedRobot
+ * @author Alexander Potochkin
+ * @run main bug6401380
+ */
 
 import javax.swing.*;
 import javax.swing.plaf.basic.BasicSliderUI;

--- a/jdk/test/javax/swing/JSlider/6794831/bug6794831.java
+++ b/jdk/test/javax/swing/JSlider/6794831/bug6794831.java
@@ -21,7 +21,9 @@
  * questions.
  */
 
-/* @test
+/*
+ * @test
+ * @key headful
  * @bug 6794831
  * @summary Infinite loop while painting ticks on Slider with maximum=MAX_INT
  * @author Pavel Porvatov

--- a/jdk/test/javax/swing/JSlider/6848475/bug6848475.java
+++ b/jdk/test/javax/swing/JSlider/6848475/bug6848475.java
@@ -21,7 +21,9 @@
  * questions.
  */
 
-/* @test
+/*
+ * @test
+ * @key headful
  * @bug 6848475
  * @summary JSlider does not display the correct value of its BoundedRangeModel
  * @author Pavel Porvatov

--- a/jdk/test/javax/swing/JSlider/6918861/bug6918861.java
+++ b/jdk/test/javax/swing/JSlider/6918861/bug6918861.java
@@ -21,7 +21,9 @@
  * questions.
  */
 
-/* @test
+/*
+ * @test
+ * @key headful
  * @bug 6918861
  * @summary SynthSliderUI.uninstallDefaults() is not called when UI is uninstalled
  * @author Pavel Porvatov

--- a/jdk/test/javax/swing/JSlider/6923305/bug6923305.java
+++ b/jdk/test/javax/swing/JSlider/6923305/bug6923305.java
@@ -21,7 +21,9 @@
  * questions.
  */
 
-/* @test
+/*
+ * @test
+ * @key headful
  * @bug 6923305
  * @summary SynthSliderUI paints the slider track when the slider's "paintTrack" property is set to false
  * @author Pavel Porvatov

--- a/jdk/test/javax/swing/JSpinner/4973721/bug4973721.java
+++ b/jdk/test/javax/swing/JSpinner/4973721/bug4973721.java
@@ -20,14 +20,16 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-/* @test
+/*
+   @test
+   @key headful
    @bug 4973721
    @summary Up and Down Arrow key buttons are not working for the JSpinner in Synth LAF
    @library ../../regtesthelpers
    @build Util
    @author Oleg Mokhovikov
    @run main bug4973721
-*/
+ */
 
 import java.awt.Robot;
 import javax.swing.event.ChangeListener;

--- a/jdk/test/javax/swing/JSpinner/6532833/bug6532833.java
+++ b/jdk/test/javax/swing/JSpinner/6532833/bug6532833.java
@@ -21,7 +21,9 @@
  * questions.
  */
 
-/* @test
+/*
+ * @test
+ * @key headful
  * @bug 6532833 7077259
  * @summary PIT: Metal LAF - The right side border is not shown for the Spinner after the removing the buttons
  * @author Pavel Porvatov

--- a/jdk/test/javax/swing/JSpinner/8008657/bug8008657.java
+++ b/jdk/test/javax/swing/JSpinner/8008657/bug8008657.java
@@ -35,6 +35,7 @@ import javax.swing.SwingUtilities;
 
 /**
  * @test
+ * @key headful
  * @bug 8008657
  * @summary JSpinner setComponentOrientation doesn't affect on text orientation
  * @run main bug8008657

--- a/jdk/test/javax/swing/JSplitPane/4816114/bug4816114.java
+++ b/jdk/test/javax/swing/JSplitPane/4816114/bug4816114.java
@@ -20,12 +20,15 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-/* @test
-   @bug 4816114
-   @summary REGRESSION: Regression in divider location behavior when JSplitPane is resized
-   @author Andrey Pikalev
-   @run main bug4816114
-*/
+
+/*
+ * @test
+ * @key headful
+ * @bug 4816114
+ * @summary REGRESSION: Regression in divider location behavior when JSplitPane is resized
+ * @author Andrey Pikalev
+ * @run main bug4816114
+ */
 
 import javax.swing.*;
 import java.awt.*;

--- a/jdk/test/javax/swing/JSplitPane/4885629/bug4885629.java
+++ b/jdk/test/javax/swing/JSplitPane/4885629/bug4885629.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 4885629
  * @summary With JSplitPane in VERTICAL_SPLIT, SplitPaneBorder draws bottom edge of divider
  * @author Andrey Pikalev

--- a/jdk/test/javax/swing/JTabbedPane/4361477/bug4361477.java
+++ b/jdk/test/javax/swing/JTabbedPane/4361477/bug4361477.java
@@ -28,6 +28,7 @@ import javax.swing.event.*;
 
 /*
  * @test
+ * @key headful
  * @bug 4361477
  * @summary JTabbedPane throws ArrayOutOfBoundsException
  * @author Oleg Mokhovikov

--- a/jdk/test/javax/swing/JTabbedPane/4624207/bug4624207.java
+++ b/jdk/test/javax/swing/JTabbedPane/4624207/bug4624207.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 4624207
  * @summary JTabbedPane mnemonics don't work from outside the tabbed pane
  * @author Oleg Mokhovikov

--- a/jdk/test/javax/swing/JTabbedPane/6495408/bug6495408.java
+++ b/jdk/test/javax/swing/JTabbedPane/6495408/bug6495408.java
@@ -25,6 +25,7 @@ import javax.swing.*;
 import java.awt.*;
 /*
  * @test
+ * @key headful
  * @bug 6495408
  * @summary REGRESSION: JTabbedPane throws ArrayIndexOutOfBoundsException
  * @author Alexander Potochkin

--- a/jdk/test/javax/swing/JTabbedPane/7024235/Test7024235.java
+++ b/jdk/test/javax/swing/JTabbedPane/7024235/Test7024235.java
@@ -38,6 +38,7 @@ import javax.swing.UIManager.LookAndFeelInfo;
 
 /*
  * @test
+ * @key headful
  * @bug 7024235
  * @summary Tests JFrame.pack() with the JTabbedPane
  * @library ../../../../lib/testlibrary/

--- a/jdk/test/javax/swing/JTabbedPane/7161568/bug7161568.java
+++ b/jdk/test/javax/swing/JTabbedPane/7161568/bug7161568.java
@@ -26,6 +26,7 @@ import java.awt.event.*;
 
 /**
  * @test
+ * @key headful
  * @bug 7161568
  * @author Alexander Scherbatiy
  * @summary Tests that navigating tabs in the JTAbbedPane does not throw NPE

--- a/jdk/test/javax/swing/JTabbedPane/8007563/Test8007563.java
+++ b/jdk/test/javax/swing/JTabbedPane/8007563/Test8007563.java
@@ -33,6 +33,7 @@ import static javax.swing.SwingUtilities.*;
 
 /*
  * @test
+ * @key headful
  * @bug 8007563
  * @summary Tests JTabbedPane background
  * @author Sergey Malenkov

--- a/jdk/test/javax/swing/JTable/4220171/bug4220171.java
+++ b/jdk/test/javax/swing/JTable/4220171/bug4220171.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 4220171
  * @author Konstantin Eremin
  * @summary Tests

--- a/jdk/test/javax/swing/JTable/6263446/bug6263446.java
+++ b/jdk/test/javax/swing/JTable/6263446/bug6263446.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6263446
  * @summary Tests that double-clicking to edit a cell doesn't select the content.
  * @author Shannon Hickey

--- a/jdk/test/javax/swing/JTable/6777378/bug6777378.java
+++ b/jdk/test/javax/swing/JTable/6777378/bug6777378.java
@@ -21,7 +21,9 @@
  * questions.
  */
 
-/* @test
+/*
+   @test
+  @key headful
    @bug 6777378
    @summary NullPointerException in XPDefaultRenderer.paint()
    @author Alexander Potochkin

--- a/jdk/test/javax/swing/JTable/6913768/bug6913768.java
+++ b/jdk/test/javax/swing/JTable/6913768/bug6913768.java
@@ -21,7 +21,9 @@
  * questions.
  */
 
-/* @test
+/*
+ * @test
+ * @key headful
  * @bug 6913768
  * @summary With default SynthLookAndFeel instance installed new JTable creation leads to throwing NPE
  * @author Pavel Porvatov

--- a/jdk/test/javax/swing/JTable/7055065/bug7055065.java
+++ b/jdk/test/javax/swing/JTable/7055065/bug7055065.java
@@ -25,7 +25,9 @@
  * Portions Copyright (c) 2012 IBM Corporation
  */
 
-/* @test 1.1 2012/04/19
+/*
+ * @test
+ * @key headful
  * @bug 7055065
  * @summary NullPointerException when sorting JTable with empty cell
  * @author Jonathan Lu

--- a/jdk/test/javax/swing/JTable/7068740/bug7068740.java
+++ b/jdk/test/javax/swing/JTable/7068740/bug7068740.java
@@ -21,12 +21,14 @@
  * questions.
  */
 
-/* @test
-   @bug 7068740
-   @summary JTable wrapped in JLayer can't use PGUP/PGDOWN keys
-   @author Vladislav Karnaukhov
-   @run main bug7068740
-*/
+/*
+ * @test
+ * @key headful
+ * @bug 7068740
+ * @summary JTable wrapped in JLayer can't use PGUP/PGDOWN keys
+ * @author Vladislav Karnaukhov
+ * @run main bug7068740
+ */
 
 import javax.swing.*;
 import javax.swing.plaf.LayerUI;

--- a/jdk/test/javax/swing/JTable/7124218/SelectEditTableCell.java
+++ b/jdk/test/javax/swing/JTable/7124218/SelectEditTableCell.java
@@ -21,7 +21,9 @@
  * questions.
  */
 
-/* @test
+/*
+ * @test
+ * @key headful
  * @bug 7124218
  * @summary verifies different behaviour of SPACE and ENTER in JTable
  * @library ../../regtesthelpers

--- a/jdk/test/javax/swing/JTable/7188612/JTableAccessibleGetLocationOnScreen.java
+++ b/jdk/test/javax/swing/JTable/7188612/JTableAccessibleGetLocationOnScreen.java
@@ -25,7 +25,9 @@
  * Portions Copyright (c) 2012 IBM Corporation
  */
 
-/* @test
+/*
+ * @test
+ * @key headful
  * @bug 7188612
  * @summary AccessibleTableHeader and AccessibleJTableCell should stick to
  *    AccessibleComponent.getLocationOnScreen api.

--- a/jdk/test/javax/swing/JTable/8032874/bug8032874.java
+++ b/jdk/test/javax/swing/JTable/8032874/bug8032874.java
@@ -21,7 +21,9 @@
  * questions.
  */
 
-/* @test
+/*
+ * @test
+ * @key headful
  * @bug 8032874
  * @summary Test whether ArrayIndexOutOfBoundsException is thrown or not,
  *          once selected row is removed from JTable with Sorter and Filter

--- a/jdk/test/javax/swing/JTableHeader/6884066/bug6884066.java
+++ b/jdk/test/javax/swing/JTableHeader/6884066/bug6884066.java
@@ -21,7 +21,9 @@
  * questions.
  */
 
-/* @test
+/*
+   @test
+  @key headful
    @bug 6884066
    @summary JTableHeader listens mouse in disabled state and doesn't work when not attached to a table
    @author Alexander Potochkin

--- a/jdk/test/javax/swing/JTableHeader/6889007/bug6889007.java
+++ b/jdk/test/javax/swing/JTableHeader/6889007/bug6889007.java
@@ -21,7 +21,9 @@
  * questions.
  */
 
-/* @test
+/*
+   @test
+  @key headful
    @bug 6889007
    @summary No resize cursor during hovering mouse over JTable
    @author Alexander Potochkin

--- a/jdk/test/javax/swing/JTextArea/4697612/bug4697612.java
+++ b/jdk/test/javax/swing/JTextArea/4697612/bug4697612.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 4697612 6244705
  * @author Peter Zhelezniakov
  * @library ../../regtesthelpers

--- a/jdk/test/javax/swing/JTextArea/7049024/bug7049024.java
+++ b/jdk/test/javax/swing/JTextArea/7049024/bug7049024.java
@@ -25,7 +25,9 @@
  * Portions Copyright (c) 2011 IBM Corporation
  */
 
-/* @test
+/*
+ * @test
+ * @key headful
  * @bug 7049024
  * @summary DnD fails with JTextArea and JTextField
  * @author Sean Chou

--- a/jdk/test/javax/swing/JTextArea/Test6593649.java
+++ b/jdk/test/javax/swing/JTextArea/Test6593649.java
@@ -21,12 +21,14 @@
  * questions.
  */
 
-/* @test
-   @bug 6593649
-   @summary Word wrap does not work in JTextArea: long lines are not wrapped
-   @author Lillian Angel
-   @run main Test6593649
-*/
+/*
+ * @test
+ * @key headful
+ * @bug 6593649
+ * @summary Word wrap does not work in JTextArea: long lines are not wrapped
+ * @author Lillian Angel
+ * @run main Test6593649
+ */
 
 import javax.swing.*;
 import java.awt.*;

--- a/jdk/test/javax/swing/JTextArea/TextViewOOM/TextViewOOM.java
+++ b/jdk/test/javax/swing/JTextArea/TextViewOOM/TextViewOOM.java
@@ -29,6 +29,7 @@ import javax.swing.JTextArea;
 
 /**
  * @test
+ * @key headful
  * @bug 8072775
  * @run main/othervm -Xmx80m TextViewOOM
  */

--- a/jdk/test/javax/swing/JTextField/8036819/bug8036819.java
+++ b/jdk/test/javax/swing/JTextField/8036819/bug8036819.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @library ../../regtesthelpers
  * @build Util
  * @bug 8036819

--- a/jdk/test/javax/swing/JTextPane/JTextPaneDocumentAlignment.java
+++ b/jdk/test/javax/swing/JTextPane/JTextPaneDocumentAlignment.java
@@ -21,11 +21,13 @@
  * questions.
  */
 
-/* @test
-   @bug 8132136
-   @summary [PIT] RTL orientation in JEditorPane is broken
-   @author Semyon Sadetsky
-  */
+/*
+ * @test
+ * @key headful
+ * @bug 8132136
+ * @summary [PIT] RTL orientation in JEditorPane is broken
+ * @author Semyon Sadetsky
+ */
 
 import javax.swing.*;
 import javax.swing.text.BadLocationException;

--- a/jdk/test/javax/swing/JTextPane/JTextPaneDocumentWrapping.java
+++ b/jdk/test/javax/swing/JTextPane/JTextPaneDocumentWrapping.java
@@ -21,11 +21,13 @@
  * questions.
  */
 
-/* @test
-   @bug 8133108
-   @summary [PIT] Container size is wrong in JEditorPane
-   @author Semyon Sadetsky
-  */
+/*
+ * @test
+ * @key headful
+ * @bug 8133108
+ * @summary [PIT] Container size is wrong in JEditorPane
+ * @author Semyon Sadetsky
+ */
 
 import javax.swing.*;
 import javax.swing.text.BadLocationException;

--- a/jdk/test/javax/swing/JToolBar/4247996/bug4247996.java
+++ b/jdk/test/javax/swing/JToolBar/4247996/bug4247996.java
@@ -21,7 +21,9 @@
  * questions.
  */
 
-/* @test
+/*
+ * @test
+ * @key headful
  * @bug 4247996 4260485
  * @summary Test that rollover toolbar doesn't corrupt buttons
  * @author Peter Zhelezniakov

--- a/jdk/test/javax/swing/JToolBar/4529206/bug4529206.java
+++ b/jdk/test/javax/swing/JToolBar/4529206/bug4529206.java
@@ -23,12 +23,14 @@
  * questions.
  */
 
-/* @test
-   @bug     4529206
-   @summary JToolBar - setFloating does not work correctly
-   @author  Konstantin Eremin
-   @run     main bug4529206
-*/
+/*
+ * @test
+ * @key headful
+ * @bug     4529206
+ * @summary JToolBar - setFloating does not work correctly
+ * @author  Konstantin Eremin
+ * @run     main bug4529206
+ */
 
 import javax.swing.*;
 import java.awt.*;

--- a/jdk/test/javax/swing/JToolTip/4846413/bug4846413.java
+++ b/jdk/test/javax/swing/JToolTip/4846413/bug4846413.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 4846413
  * @summary Checks if No tooltip modification when no KeyStroke modifier
  * @library ../../regtesthelpers

--- a/jdk/test/javax/swing/JTree/4330357/bug4330357.java
+++ b/jdk/test/javax/swing/JTree/4330357/bug4330357.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 4330357
  * @summary Tests that real editor in JTree cleans up after editing was stopped
  * @library ../../regtesthelpers

--- a/jdk/test/javax/swing/JTree/4908142/bug4908142.java
+++ b/jdk/test/javax/swing/JTree/4908142/bug4908142.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 4908142
  * @summary JList doesn't handle search function appropriately
  * @author Andrey Pikalev

--- a/jdk/test/javax/swing/JTree/4927934/bug4927934.java
+++ b/jdk/test/javax/swing/JTree/4927934/bug4927934.java
@@ -20,7 +20,9 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-/* @test
+/*
+   @test
+  @key headful
    @bug 4927934
    @summary JTree traversal is unlike Native windows tree traversal
    @author Andrey Pikalev

--- a/jdk/test/javax/swing/JTree/6263446/bug6263446.java
+++ b/jdk/test/javax/swing/JTree/6263446/bug6263446.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6263446
  * @summary Tests that double-clicking to edit a cell doesn't select the content.
  * @author Shannon Hickey

--- a/jdk/test/javax/swing/JTree/6505523/bug6505523.java
+++ b/jdk/test/javax/swing/JTree/6505523/bug6505523.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6505523
  * @summary NullPointerException in BasicTreeUI when a node is removed by expansion listener
  * @author Alexandr Scherbatiy

--- a/jdk/test/javax/swing/JTree/6578666/bug6578666.java
+++ b/jdk/test/javax/swing/JTree/6578666/bug6578666.java
@@ -22,6 +22,7 @@
  */
 /*
  * @test
+ * @key headful
  * @bug 6578666
  * @summary REGRESSION: Exception occurs when updateUI for JTree is triggered by KeyEvent
  * @run main bug6578666

--- a/jdk/test/javax/swing/JTree/8003400/Test8003400.java
+++ b/jdk/test/javax/swing/JTree/8003400/Test8003400.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8003400
  * @summary Tests that JTree shows the last row
  * @author Sergey Malenkov

--- a/jdk/test/javax/swing/JTree/8004298/bug8004298.java
+++ b/jdk/test/javax/swing/JTree/8004298/bug8004298.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8004298
  * @summary NPE in WindowsTreeUI.ensureRowsAreVisible
  * @author Alexander Scherbatiy

--- a/jdk/test/javax/swing/JViewport/7107099/bug7107099.java
+++ b/jdk/test/javax/swing/JViewport/7107099/bug7107099.java
@@ -21,7 +21,9 @@
  * questions.
  */
 
-/* @test
+/*
+   @test
+  @key headful
    @bug 7107099
    @summary JScrollBar does not show up even if there are enough lebgth of textstring in textField
    @author Pavel Porvatov

--- a/jdk/test/javax/swing/JWindow/ShapedAndTranslucentWindows/PerPixelTranslucentCanvas.java
+++ b/jdk/test/javax/swing/JWindow/ShapedAndTranslucentWindows/PerPixelTranslucentCanvas.java
@@ -27,6 +27,7 @@ import java.awt.image.BufferedImage;
 
 /*
  * @test
+ * @key headful
  * @summary Check if a per-pixel translucent window shows up with correct translucency
  * @author mrkam
  * @library ../../../../lib/testlibrary

--- a/jdk/test/javax/swing/KeyboardManager/8013370/Test8013370.java
+++ b/jdk/test/javax/swing/KeyboardManager/8013370/Test8013370.java
@@ -41,6 +41,7 @@ import static javax.swing.SwingUtilities.invokeAndWait;
 
 /*
  * @test
+ * @key headful
  * @bug 8013370
  * @summary Ensure that key stroke is not null
  * @author Sergey Malenkov

--- a/jdk/test/javax/swing/Popup/6514582/bug6514582.java
+++ b/jdk/test/javax/swing/Popup/6514582/bug6514582.java
@@ -23,12 +23,14 @@
  * questions.
  */
 
-/* @test
-   @bug 6514582
-   @summary SubMenu of a JMenu with no items paints a single pixel tiny menu.
-   @author Alexander Potochkin
-   @run main bug6514582
-*/
+/*
+ * @test
+ * @key headful
+ * @bug 6514582
+ * @summary SubMenu of a JMenu with no items paints a single pixel tiny menu.
+ * @author Alexander Potochkin
+ * @run main bug6514582
+ */
 
 import javax.swing.*;
 import java.awt.*;

--- a/jdk/test/javax/swing/Popup/TaskbarPositionTest.java
+++ b/jdk/test/javax/swing/Popup/TaskbarPositionTest.java
@@ -28,6 +28,7 @@ import javax.swing.event.*;
 
 /**
  * @test @bug 4245587 4474813 4425878 4767478 8015599
+ * @key headful
  * @author Mark Davidson
  * @summary Tests the location of the heavy weight popup portion of JComboBox,
  * JMenu and JPopupMenu.

--- a/jdk/test/javax/swing/PopupFactory/6276087/NonOpaquePopupMenuTest.java
+++ b/jdk/test/javax/swing/PopupFactory/6276087/NonOpaquePopupMenuTest.java
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key headful
  * @bug 6276087
  * @author Romain Guy
  * @summary Tests opacity of a popup menu.

--- a/jdk/test/javax/swing/PopupFactory/8048506/bug8048506.java
+++ b/jdk/test/javax/swing/PopupFactory/8048506/bug8048506.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8048506
  * @summary Tests that popup with null-owner does not throw NPE
  * @author Dmitry Markov

--- a/jdk/test/javax/swing/RepaintManager/IconifyTest/IconifyTest.java
+++ b/jdk/test/javax/swing/RepaintManager/IconifyTest/IconifyTest.java
@@ -22,6 +22,7 @@
  */
 /*
  * @test
+ * @key headful
  * @bug 4665214
  * @summary Makes sure that RepaintManager doesn't attempt to repaint
  *          a frame when it is iconified.

--- a/jdk/test/javax/swing/Security/6657138/ComponentTest.java
+++ b/jdk/test/javax/swing/Security/6657138/ComponentTest.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6657138
  * @summary Verifies that buttons and labels work well after the fix for 6657138
  * @author Alexander Potochkin

--- a/jdk/test/javax/swing/SwingUtilities/4917669/bug4917669.java
+++ b/jdk/test/javax/swing/SwingUtilities/4917669/bug4917669.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 4917669
  * @summary 1.4 REGRESSION: MenuItem accelerator doesn't work if parent menu is in JDialog
  * @author Alexander Zuev

--- a/jdk/test/javax/swing/SwingUtilities/7088744/bug7088744.java
+++ b/jdk/test/javax/swing/SwingUtilities/7088744/bug7088744.java
@@ -21,11 +21,13 @@
  * questions.
  */
 
-/* @test
-   @bug 7088744
-   @summary SwingUtilities.isMiddleMouseButton does not work with ALT/Meta keys
-   @author Pavel Porvatov
-*/
+/*
+ * @test
+ * @key headful
+ * @bug 7088744
+ * @summary SwingUtilities.isMiddleMouseButton does not work with ALT/Meta keys
+ * @author Pavel Porvatov
+ */
 
 import sun.awt.SunToolkit;
 

--- a/jdk/test/javax/swing/SwingUtilities/7146377/bug7146377.java
+++ b/jdk/test/javax/swing/SwingUtilities/7146377/bug7146377.java
@@ -21,11 +21,13 @@
  * questions.
  */
 
-/* @test
-   @bug 7146377
-   @summary closed/javax/swing/DataTransfer/4876520/bug4876520.java failed since b08 in jdk 8
-   @author Pavel Porvatov
-*/
+/*
+ * @test
+ * @key headful
+ * @bug 7146377
+ * @summary closed/javax/swing/DataTransfer/4876520/bug4876520.java failed since b08 in jdk 8
+ * @author Pavel Porvatov
+ */
 
 import javax.swing.*;
 import java.awt.*;

--- a/jdk/test/javax/swing/SwingUtilities/TestBadBreak/TestBadBreak.java
+++ b/jdk/test/javax/swing/SwingUtilities/TestBadBreak/TestBadBreak.java
@@ -36,6 +36,7 @@ import static java.awt.image.BufferedImage.TYPE_INT_ARGB;
 
 /**
  * @test
+ * @key headful
  * @bug 8015085
  * @summary Shortening via " ... " is broken for Strings containing a combining
  *          diaeresis.

--- a/jdk/test/javax/swing/ToolTipManager/Test6256140.java
+++ b/jdk/test/javax/swing/ToolTipManager/Test6256140.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6256140
  * @summary Esc key doesn't restore old value in JFormattedtextField when ToolTip is set
  * @author Alexander Potochkin

--- a/jdk/test/javax/swing/dnd/7171812/bug7171812.java
+++ b/jdk/test/javax/swing/dnd/7171812/bug7171812.java
@@ -21,11 +21,13 @@
  * questions.
  */
 
-/* @test
-   @bug 7171812
-   @summary [macosx] Views keep scrolling back to the drag position after DnD
-   @author Alexander Zuev
-   @run main bug7171812
+/*
+ * @test
+ * @key headful
+ * @bug 7171812
+ * @summary [macosx] Views keep scrolling back to the drag position after DnD
+ * @author Alexander Zuev
+ * @run main bug7171812
  */
 
 import java.awt.*;

--- a/jdk/test/javax/swing/plaf/basic/BasicHTML/4251579/bug4251579.java
+++ b/jdk/test/javax/swing/plaf/basic/BasicHTML/4251579/bug4251579.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 4251579
  * @summary  Tests if style sheets are working in JLabel
  * @run main bug4251579

--- a/jdk/test/javax/swing/plaf/basic/BasicMenuUI/4983388/bug4983388.java
+++ b/jdk/test/javax/swing/plaf/basic/BasicMenuUI/4983388/bug4983388.java
@@ -21,14 +21,16 @@
  * questions.
  */
 
-/* @test
-   @bug 4983388 8015600
-   @summary shortcuts on menus do not work on JDS
-   @author Oleg Mokhovikov
-   @library ../../../../regtesthelpers
-   @build Util
-   @run main bug4983388
-*/
+/*
+ * @test
+ * @key headful
+ * @bug 4983388 8015600
+ * @summary shortcuts on menus do not work on JDS
+ * @author Oleg Mokhovikov
+ * @library ../../../../regtesthelpers
+ * @build Util
+ * @run main bug4983388
+ */
 
 import java.awt.*;
 import javax.swing.*;

--- a/jdk/test/javax/swing/plaf/basic/BasicTreeUI/8023474/bug8023474.java
+++ b/jdk/test/javax/swing/plaf/basic/BasicTreeUI/8023474/bug8023474.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8023474
  * @summary Tests that the first mouse press starts editing in JTree
  * @author Dmitry Markov

--- a/jdk/test/javax/swing/plaf/gtk/crash/RenderBadPictureCrash.java
+++ b/jdk/test/javax/swing/plaf/gtk/crash/RenderBadPictureCrash.java
@@ -23,6 +23,7 @@
 
 /*
  @test
+ @key headful
  @bug 8056151
  @summary Switching to GTK L&F on-the-fly leads to X Window System error RenderBadPicture
  @run main/othervm -Dswing.defaultlaf=javax.swing.plaf.metal.MetalLookAndFeel -Dsun.java2d.xrender=T RenderBadPictureCrash

--- a/jdk/test/javax/swing/plaf/nimbus/8041642/bug8041642.java
+++ b/jdk/test/javax/swing/plaf/nimbus/8041642/bug8041642.java
@@ -21,11 +21,13 @@
  * questions.
  */
 
-/* @test
-   @bug 8041642
-   @summary Incorrect paint of JProgressBar in Nimbus LF
-   @author Semyon Sadetsky
-*/
+/*
+ * @test
+ * @key headful
+ * @bug 8041642 8079450
+ * @summary Incorrect paint of JProgressBar in Nimbus LF
+ * @author Semyon Sadetsky
+ */
 
 import javax.swing.*;
 import java.awt.*;

--- a/jdk/test/javax/swing/plaf/nimbus/8041725/bug8041725.java
+++ b/jdk/test/javax/swing/plaf/nimbus/8041725/bug8041725.java
@@ -21,11 +21,13 @@
  * questions.
  */
 
-/* @test
-   @bug 8041725
-   @summary JList selection colors are not UIResource instances in Nimbus L&F
-   @author Anton Litvinov
-*/
+/*
+ * @test
+ * @key headful
+ * @bug 8041725
+ * @summary JList selection colors are not UIResource instances in Nimbus L&F
+ * @author Anton Litvinov
+ */
 
 import java.awt.*;
 import javax.swing.*;

--- a/jdk/test/javax/swing/plaf/nimbus/Test6919629.java
+++ b/jdk/test/javax/swing/plaf/nimbus/Test6919629.java
@@ -21,7 +21,9 @@
  * questions.
  */
 
-/* @test
+/*
+   @test
+   @key headful
    @bug 6919629
    @summary Tests that components with Nimbus.Overrides are GC'ed properly
    @author Peter Zhelezniakov

--- a/jdk/test/javax/swing/plaf/synth/7158712/bug7158712.java
+++ b/jdk/test/javax/swing/plaf/synth/7158712/bug7158712.java
@@ -21,12 +21,14 @@
  * questions.
  */
 
-/* @test
-   @bug 7158712
-   @summary Synth Property "ComboBox.popupInsets" is ignored
-   @library ../../../regtesthelpers
-   @author Pavel Porvatov
-*/
+/*
+ * @test
+ * @key headful
+ * @bug 7158712
+ * @summary Synth Property "ComboBox.popupInsets" is ignored
+ * @library ../../../regtesthelpers
+ * @author Pavel Porvatov
+ */
 
 import javax.swing.*;
 import javax.swing.plaf.basic.BasicComboPopup;

--- a/jdk/test/javax/swing/plaf/synth/SynthButtonUI/6276188/bug6276188.java
+++ b/jdk/test/javax/swing/plaf/synth/SynthButtonUI/6276188/bug6276188.java
@@ -22,6 +22,7 @@
  */
 /**
  * @test 1.4 08/08/05
+ * @key headful
  * @bug 6276188
  * @library ../../../../regtesthelpers
  * @build Util

--- a/jdk/test/javax/swing/plaf/synth/Test8015926.java
+++ b/jdk/test/javax/swing/plaf/synth/Test8015926.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8015926
  * @summary Tests that there are no NPE during painting
  * @author Sergey Malenkov

--- a/jdk/test/javax/swing/reliability/TaskUndJFrameProperties.java
+++ b/jdk/test/javax/swing/reliability/TaskUndJFrameProperties.java
@@ -26,6 +26,7 @@ import java.awt.*;
 
 /*
  * @test
+ * @key headful
  * @summary Construct a Undecorated JFrame, try to change the properties
  *          using setVisible() method.
  * @author Aruna Samji

--- a/jdk/test/javax/swing/reliability/TaskZoomJFrameChangeState.java
+++ b/jdk/test/javax/swing/reliability/TaskZoomJFrameChangeState.java
@@ -26,6 +26,7 @@ import java.awt.*;
 
 /*
  * @test
+ * @key headful
  * @summary Construct a JFrame, zoom it from the normal state and back forth
  *          using Frame.ZOOMED and Frame.NORMAL. Iconofy from the zoomed
  *          state and back forth using Frame.ICONIFIED and Frame.NORMAL and

--- a/jdk/test/javax/swing/reliability/TaskZoomJFrameRepaint.java
+++ b/jdk/test/javax/swing/reliability/TaskZoomJFrameRepaint.java
@@ -26,6 +26,7 @@ import java.awt.*;
 
 /*
  * @test
+ * @key headful
  * @summary Construct a jframe with some components and zoom the frame and bring it back to normal state.
  * @author Aruna Samji
  * @library ../../../lib/testlibrary

--- a/jdk/test/javax/swing/text/AbstractDocument/6968363/Test6968363.java
+++ b/jdk/test/javax/swing/text/AbstractDocument/6968363/Test6968363.java
@@ -42,6 +42,7 @@ import static javax.swing.SwingUtilities.invokeAndWait;
 
 /*
  * @test
+ * @key headful
  * @bug 6968363
  * @summary Ensures that a custom document may not extend AbstractDocument
  * @author Sergey Malenkov

--- a/jdk/test/javax/swing/text/CSSBorder/6796710/bug6796710.java
+++ b/jdk/test/javax/swing/text/CSSBorder/6796710/bug6796710.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6796710 7124242
  * @summary Html content in JEditorPane is overlapping on swing components while resizing the application.
  * @library ../../../regtesthelpers

--- a/jdk/test/javax/swing/text/DefaultEditorKit/4278839/bug4278839.java
+++ b/jdk/test/javax/swing/text/DefaultEditorKit/4278839/bug4278839.java
@@ -21,7 +21,9 @@
  * questions.
  */
 
-/* @test Jan 16, 2003
+/*
+ * @test
+ * @key headful
  * @bug 4278839
  * @summary Incorrect cursor movement between words at the end of line
  * @author Anton Nashatyrev

--- a/jdk/test/javax/swing/text/DefaultStyledDocument/6636983/bug6636983.java
+++ b/jdk/test/javax/swing/text/DefaultStyledDocument/6636983/bug6636983.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6636983
  * @summary test that composed text at the line starts is handled correctly
  * @author Sergey Groznyh

--- a/jdk/test/javax/swing/text/JTextComponent/5074573/bug5074573.java
+++ b/jdk/test/javax/swing/text/JTextComponent/5074573/bug5074573.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 5074573
  * @summary tests delte-next-word and delete-prev-word actions for all text compnents and all look&feels
  * @author Igor Kushnirskiy

--- a/jdk/test/javax/swing/text/NavigationFilter/6735293/bug6735293.java
+++ b/jdk/test/javax/swing/text/NavigationFilter/6735293/bug6735293.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 6735293
  * @summary javax.swing.text.NavigationFilter.getNextVisualPositionFrom() not always throws BadLocationException
  * @author Pavel Porvatov

--- a/jdk/test/javax/swing/text/Utilities/bug7045593.java
+++ b/jdk/test/javax/swing/text/Utilities/bug7045593.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 7045593
  * @summary Possible Regression : JTextfield cursor placement behavior algorithm has changed
  * @author Pavel Porvatov

--- a/jdk/test/javax/swing/text/View/8014863/bug8014863.java
+++ b/jdk/test/javax/swing/text/View/8014863/bug8014863.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8014863
  * @bug 8024395
  * @summary  Tests the calculation of the line breaks when a text is inserted

--- a/jdk/test/javax/swing/text/View/8048110/bug8048110.java
+++ b/jdk/test/javax/swing/text/View/8048110/bug8048110.java
@@ -21,7 +21,9 @@
  * questions.
  */
 
-/* @test
+/*
+ * @test
+ * @key headful
  * @bug 8048110
  * @summary Using tables in JTextPane leads to infinite loop in FlowLayout.layoutRow
  * @author Dmitry Markov

--- a/jdk/test/javax/swing/text/html/7189299/bug7189299.java
+++ b/jdk/test/javax/swing/text/html/7189299/bug7189299.java
@@ -39,6 +39,7 @@ import javax.swing.text.html.HTMLEditorKit;
 
 /*
  * @test
+ * @key headful
  * @bug 8008289
  * @summary Shared ButtonModel instance should deregister previous listeners.
  * @author Frank Ding

--- a/jdk/test/javax/swing/text/html/8034955/bug8034955.java
+++ b/jdk/test/javax/swing/text/html/8034955/bug8034955.java
@@ -27,6 +27,7 @@ import javax.swing.SwingUtilities;
 
 /**
  * @test
+ * @key headful
  * @bug 8034955
  * @author Alexander Scherbatiy
  * @summary JLabel/JToolTip throw ClassCastException for "<html>a<title>"

--- a/jdk/test/javax/swing/text/html/CSS/4530474/bug4530474.java
+++ b/jdk/test/javax/swing/text/html/CSS/4530474/bug4530474.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 4530474
  * @summary  Tests if background-color CSS attribute in HTML font tag in class attribute
  * @author Denis Sharypov

--- a/jdk/test/javax/swing/text/html/HTMLDocument/8058120/bug8058120.java
+++ b/jdk/test/javax/swing/text/html/HTMLDocument/8058120/bug8058120.java
@@ -22,6 +22,7 @@
  */
 
 /* @test
+ * @key headful
  * @bug 8058120
  * @summary Rendering / caret errors with HTMLDocument
  * @author Dmitry Markov

--- a/jdk/test/javax/swing/text/html/HTMLEditorKit/4242228/bug4242228.java
+++ b/jdk/test/javax/swing/text/html/HTMLEditorKit/4242228/bug4242228.java
@@ -21,11 +21,13 @@
  * questions.
  */
 
-/* @test
-   @bug 4242228
-   @summary Tests that HTMLEditorKit.setText() doesn't throw exceptions
-   @author Peter Zhelezniakov
-*/
+/*
+ * @test
+ * @key headful
+ * @bug 4242228
+ * @summary Tests that HTMLEditorKit.setText() doesn't throw exceptions
+ * @author Peter Zhelezniakov
+ */
 
 import javax.swing.*;
 import javax.swing.event.ChangeEvent;

--- a/jdk/test/javax/swing/text/html/HTMLEditorKit/5043626/bug5043626.java
+++ b/jdk/test/javax/swing/text/html/HTMLEditorKit/5043626/bug5043626.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 5043626
  * @summary  Tests pressing Home or Ctrl+Home set cursor to invisible element <head>
  * @run main bug5043626

--- a/jdk/test/sun/awt/dnd/8024061/bug8024061.java
+++ b/jdk/test/sun/awt/dnd/8024061/bug8024061.java
@@ -21,7 +21,9 @@
  * questions.
  */
 
-/* @test
+/*
+ * @test
+ * @key headful
  * @bug 8024061
  * @summary Checks that no exception is thrown if dragGestureRecognized
  *          takes a while to complete.

--- a/jdk/test/sun/java2d/ClassCastExceptionForInvalidSurface.java
+++ b/jdk/test/sun/java2d/ClassCastExceptionForInvalidSurface.java
@@ -40,6 +40,7 @@ import static java.awt.image.BufferedImage.TYPE_INT_ARGB;
 
 /**
  * @test
+ * @key headful
  * @bug 8158072 7172749
  */
 public final class ClassCastExceptionForInvalidSurface {

--- a/jdk/test/sun/java2d/SunGraphics2D/SourceClippingBlitTest/SourceClippingBlitTest.java
+++ b/jdk/test/sun/java2d/SunGraphics2D/SourceClippingBlitTest/SourceClippingBlitTest.java
@@ -23,6 +23,7 @@
 
 /*
   @test
+  @key headful
   @bug 6244574
   @bug 6258142
   @bug 6395165

--- a/jdk/test/sun/java2d/X11SurfaceData/SharedMemoryPixmapsTest/SharedMemoryPixmapsTest.sh
+++ b/jdk/test/sun/java2d/X11SurfaceData/SharedMemoryPixmapsTest/SharedMemoryPixmapsTest.sh
@@ -23,6 +23,7 @@
 #
 
 # @test
+# @key headful
 # @bug 6363434 6588884
 # @summary Verify that shared memory pixmaps are not broken
 # by filling a VolatileImage with red color and copying it


### PR DESCRIPTION
This backport has modified the following aspects:

- there are 56 cases that do not exist:
 jdk/test/com/sun/java/accessibility/util/8051626/Bug8051626.java 
jdk/test/java/awt/Component/GetScreenLocTest/GetScreenLocTest.java 
jdk/test/java/awt/Dialog/ChildProperties/ChildDialogProperties.java 
jdk/test/java/awt/LightweightComponent/LightweightEventTest/LightweightEventTest.java 
jdk/test/java/awt/PrintJob/PrinterException.java
jdk/test/java/awt/TextField/TextFieldEditing/TextFieldEditing.java 
jdk/test/java/awt/Window/ChildProperties/ChildWindowProperties.java 
jdk/test/java/awt/datatransfer/UnicodeTransferTest/UnicodeTransferTest.java 
jdk/test/java/awt/image/multiresolution/MenuMultiresolutionIconTest.java 
jdk/test/java/awt/image/multiresolution/MultiResolutionJOptionPaneIconTest.java 
jdk/test/java/awt/print/PrintJob/PrinterException.java
jdk/test/javax/swing/Action/8133039/bug8133039.java 
jdk/test/javax/swing/GroupLayout/8013566/bug8013566.java 
jdk/test/javax/swing/GroupLayout/8079640/bug8079640.java 
jdk/test/javax/swing/InputVerifier/VerifyTarget/VerifyTargetTest.java 
jdk/test/javax/swing/JButton/PressedButtonRightClickTest.java 
jdk/test/javax/swing/JColorChooser/Test8051548.java 
jdk/test/javax/swing/JDialog/Transparency/TransparencyTest.java 
jdk/test/javax/swing/JEditorPane/8146319/JEditorPaneTest.java 
jdk/test/javax/swing/JFileChooser/8016665/JFileChooserOrientation.java 
jdk/test/javax/swing/JFileChooser/8041694/bug8041694.java 
jdk/test/javax/swing/JFileChooser/DeserializedJFileChooser/DeserializedJFileChooserTest.java 
jdk/test/javax/swing/JInternalFrame/4769772/TestJInternalFrameIconify.java 
jdk/test/javax/swing/JInternalFrame/8069348/bug8069348.java 
jdk/test/javax/swing/JInternalFrame/8145896/TestJInternalFrameMaximize.java 
jdk/test/javax/swing/JInternalFrame/8146321/JInternalFrameIconTest.java 
jdk/test/javax/swing/JInternalFrame/NormalBoundsTest.java 
jdk/test/javax/swing/JMenu/4213634/bug4213634.java 
jdk/test/javax/swing/JOptionPane/8139213/OptionPaneTest.java 
jdk/test/javax/swing/JPopupMenu/8147521/PopupMenuTest.java 
jdk/test/javax/swing/JProgressBar/8015748/JProgressBarOrientationRobotTest.java 
jdk/test/javax/swing/JRadioButton/FocusTraversal/FocusTraversal.java 
jdk/test/javax/swing/JRootPane/SilenceOfDeprecatedMenuBar/SilenceOfDeprecatedMenuBar.java 
jdk/test/javax/swing/JScrollPane/bug8044371.java 
jdk/test/javax/swing/JSpinner/6421058/bug6421058.java 
jdk/test/javax/swing/JSpinner/WrongEditorTextFieldFont/WrongEditorTextFieldFont.java 
jdk/test/javax/swing/JTabbedPane/8017284/bug8017284.java 
jdk/test/javax/swing/JTabbedPane/8134116/Bug8134116.java 
jdk/test/javax/swing/JTabbedPane/8137169/ScrollableTabbedPaneTest.java 
jdk/test/javax/swing/JTable/6894632/bug6894632.java 
jdk/test/javax/swing/JTableHeader/4473075/bug4473075.java 
jdk/test/javax/swing/JTextArea/8149849/DNDTextToScaledArea.java 
jdk/test/javax/swing/JTextPane/bug8025082.java 
jdk/test/javax/swing/JToolTip/6219960/bug6219960.java 
jdk/test/javax/swing/JTree/DnD/LastNodeLowerHalfDrop.java 
jdk/test/javax/swing/LookAndFeel/6897701/JMenuItemsTest.java 
jdk/test/javax/swing/LookAndFeel/8146276/NimbusGlueTest.java 
jdk/test/javax/swing/plaf/basic/BasicComboPopup/7072653/bug7072653.java 
jdk/test/javax/swing/plaf/basic/BasicRootPaneUI/HiddenDefaultButtonTest.java 
jdk/test/javax/swing/plaf/basic/BasicTextUI/8001470/bug8001470.java 
jdk/test/javax/swing/plaf/synth/8040328/bug8040328.java 
jdk/test/javax/swing/plaf/synth/SynthScrollbarThumbPainter/SynthScrollbarThumbPainterTest.java 
jdk/test/javax/swing/text/NavigationFilter/8058305/bug8058305.java 
jdk/test/javax/swing/text/TableView/I18nLayoutTest.java 
jdk/test/javax/swing/text/html/8031109/bug8031109.java 
jdk/test/javax/swing/text/rtf/RTFWriteParagraphAlignTest.java
- The following two cases have been added @key headful
jdk/test/java/awt/dnd/DisposeFrameOnDragCrash/DisposeFrameOnDragTest.java
jdk/test/javax/swing/ToolTipManager/7123767/bug7123767.java 
- context is adapted where needed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] [JDK-8160974](https://bugs.openjdk.org/browse/JDK-8160974) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8160974](https://bugs.openjdk.org/browse/JDK-8160974): [TESTBUG] Mark more headful tests with @<!---->key headful. (**Bug** - P4 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/607/head:pull/607` \
`$ git checkout pull/607`

Update a local copy of the PR: \
`$ git checkout pull/607` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/607/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 607`

View PR using the GUI difftool: \
`$ git pr show -t 607`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/607.diff">https://git.openjdk.org/jdk8u-dev/pull/607.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/607#issuecomment-2485463659)
</details>
