### PR TITLE
8345358: Some DLL Files are missing Windows Properties

### DIFF
--- a/jdk/make/lib/SecurityLibraries.gmk
+++ b/jdk/make/lib/SecurityLibraries.gmk
@@ -107,6 +107,11 @@ $(eval $(call SetupNativeCompilation,BUILD_LIBJ2GSS, \
         $(call SET_SHARED_LIBRARY_ORIGIN), \
     LDFLAGS_SUFFIX := $(LIBDL), \
     LDFLAGS_SUFFIX_solaris := -lc, \
+    VERSIONINFO_RESOURCE := $(JDK_TOPDIR)/src/windows/resource/version.rc, \
+    RC_FLAGS := $(RC_FLAGS) \
+        -D "JDK_FNAME=j2gss.dll" \
+        -D "JDK_INTERNAL_NAME=j2gss" \
+        -D "JDK_FTYPE=0x2L", \
     OBJECT_DIR := $(JDK_OUTPUTDIR)/objs/libj2gss, \
     DEBUG_SYMBOLS := $(DEBUG_ALL_BINARIES)))
 
@@ -124,6 +129,11 @@ ifeq ($(OPENJDK_TARGET_OS), windows)
     LDFLAGS := $(LDFLAGS_JDKLIB) \
         $(call SET_SHARED_LIBRARY_ORIGIN), \
     LDFLAGS_SUFFIX := $(LIBDL), \
+    VERSIONINFO_RESOURCE := $(JDK_TOPDIR)/src/windows/resource/version.rc, \
+    RC_FLAGS := $(RC_FLAGS) \
+        -D "JDK_FNAME=sspi_bridge.dll" \
+        -D "JDK_INTERNAL_NAME=sspi_bridge" \
+        -D "JDK_FTYPE=0x2L", \
     OBJECT_DIR := $(JDK_OUTPUTDIR)/objs/libsspi_bridge, \
     DEBUG_SYMBOLS := $(DEBUG_ALL_BINARIES)))
 


### PR DESCRIPTION
Add missing properties for the j2gss.dll and sspi_bridge.dll files