### PR TITLE
8345149: [8u] javax/sound/midi/Soundbanks/GetSoundBankSecurityException/GetSoundBankSecurityException.java fails with FileSystemException

### DIFF
--- a/jdk/test/ProblemList.txt
+++ b/jdk/test/ProblemList.txt
@@ -335,7 +335,7 @@ javax/sound/sampled/Clip/Drain/ClipDrain.java          7062792 generic-all
 
 javax/sound/sampled/Mixers/DisabledAssertionCrash.java 7067310 generic-all
 
-javax/sound/midi/Soundbanks/GetSoundBankSecurityException/GetSoundBankSecurityException.java 8345149 windows-all
+javax/sound/midi/Soundbanks/GetSoundBankSecurityException/GetSoundBankSecurityException.java 8178401 windows-all
 
 ############################################################################
 

--- a/jdk/test/ProblemList.txt
+++ b/jdk/test/ProblemList.txt
@@ -335,6 +335,8 @@ javax/sound/sampled/Clip/Drain/ClipDrain.java          7062792 generic-all
 
 javax/sound/sampled/Mixers/DisabledAssertionCrash.java 7067310 generic-all
 
+javax/sound/midi/Soundbanks/GetSoundBankSecurityException/GetSoundBankSecurityException.java 8345149 windows-all
+
 ############################################################################
 
 # jdk_swing


### PR DESCRIPTION
Added javax/sound/midi/Soundbanks/GetSoundBankSecurityException/GetSoundBankSecurityException.java
to ProblemList.txt to exclude on Windows Machines.

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8345149](https://bugs.openjdk.org/browse/JDK-8345149) needs maintainer approval

### Issue
 * [JDK-8345149](https://bugs.openjdk.org/browse/JDK-8345149): [8u] javax/sound/midi/Soundbanks/GetSoundBankSecurityException/GetSoundBankSecurityException.java fails with FileSystemException (**Bug** - P4 - Approved)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/613/head:pull/613` \
`$ git checkout pull/613`

Update a local copy of the PR: \
`$ git checkout pull/613` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/613/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 613`

View PR using the GUI difftool: \
`$ git pr show -t 613`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/613.diff">https://git.openjdk.org/jdk8u-dev/pull/613.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/613#issuecomment-3264596079)
</details>
