### PR TITLE
8346887: DrawFocusRect() may cause an assertion failure

### DIFF
--- a/jdk/src/windows/native/sun/windows/awt_Button.cpp
+++ b/jdk/src/windows/native/sun/windows/awt_Button.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -242,7 +242,8 @@ AwtButton::OwnerDrawItem(UINT /*ctrlId*/, DRAWITEMSTRUCT& drawInfo)
         RECT focusRect;
         VERIFY(::CopyRect(&focusRect, &rect));
         VERIFY(::InflateRect(&focusRect,-inf,-inf));
-        VERIFY(::DrawFocusRect(hDC, &focusRect));
+        if (!::IsRectEmpty(&focusRect) && (::DrawFocusRect(hDC, &focusRect) == 0))
+            VERIFY(::GetLastError() == 0);
     }
 
     /* Notify any subclasses */

--- a/jdk/src/windows/native/sun/windows/awt_Checkbox.cpp
+++ b/jdk/src/windows/native/sun/windows/awt_Checkbox.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -290,12 +290,14 @@ AwtCheckbox::OwnerDrawItem(UINT /*ctrlId*/, DRAWITEMSTRUCT& drawInfo)
     if ((drawInfo.itemState & ODS_FOCUS) &&
         ((drawInfo.itemAction & ODA_FOCUS)||
          (drawInfo.itemAction &ODA_DRAWENTIRE))) {
-        VERIFY(::DrawFocusRect(hDC, &focusRect));
+        if (!::IsRectEmpty(&focusRect) && (::DrawFocusRect(hDC, &focusRect) == 0))
+            VERIFY(::GetLastError() == 0);
     }
     /*  erase focus rect */
     else if (!(drawInfo.itemState & ODS_FOCUS) &&
              (drawInfo.itemAction & ODA_FOCUS)) {
-        VERIFY(::DrawFocusRect(hDC, &focusRect));
+        if (!::IsRectEmpty(&focusRect) && (::DrawFocusRect(hDC, &focusRect) == 0))
+            VERIFY(::GetLastError() == 0);
     }
 
     /*  Notify any subclasses */

--- a/jdk/src/windows/native/sun/windows/awt_Component.cpp
+++ b/jdk/src/windows/native/sun/windows/awt_Component.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -4446,7 +4446,8 @@ void AwtComponent::DrawListItem(JNIEnv *env, DRAWITEMSTRUCT &drawInfo)
     if ((drawInfo.itemState & ODS_FOCUS)  &&
         (drawInfo.itemAction & (ODA_FOCUS | ODA_DRAWENTIRE))) {
       if (!unfocusableChoice){
-          VERIFY(::DrawFocusRect(hDC, &rect));
+          if (!::IsRectEmpty(&rect) && (::DrawFocusRect(hDC, &rect) == 0))
+              VERIFY(::GetLastError() == 0);
       }
     }
     env->DeleteLocalRef(target);


### PR DESCRIPTION
Backporting JDK-8346887: DrawFocusRect() may cause an assertion failure. Minor change that adds an additional check before running an assertion for windows. Ran GHA Sanity Checks and local Tier 1 and Tier 2 tests. Patch is nearly clean, adjusting header comments.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8346887](https://bugs.openjdk.org/browse/JDK-8346887) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346887](https://bugs.openjdk.org/browse/JDK-8346887): DrawFocusRect() may cause an assertion failure (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/614/head:pull/614` \
`$ git checkout pull/614`

Update a local copy of the PR: \
`$ git checkout pull/614` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/614/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 614`

View PR using the GUI difftool: \
`$ git pr show -t 614`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/614.diff">https://git.openjdk.org/jdk8u-dev/pull/614.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/614#issuecomment-2583353084)
</details>
