### PR TITLE
8339644: Improve parsing of Day/Month in tzdata rules

### DIFF
--- a/jdk/make/src/classes/build/tools/tzdb/TzdbZoneRulesCompiler.java
+++ b/jdk/make/src/classes/build/tools/tzdb/TzdbZoneRulesCompiler.java
@@ -270,8 +270,6 @@ public final class TzdbZoneRulesCompiler {
     }
 
     private static final Pattern YEAR = Pattern.compile("(?i)(?<min>min)|(?<max>max)|(?<only>only)|(?<year>[0-9]+)");
-    private static final Pattern MONTH = Pattern.compile("(?i)(jan)|(feb)|(mar)|(apr)|(may)|(jun)|(jul)|(aug)|(sep)|(oct)|(nov)|(dec)");
-    private static final Matcher DOW = Pattern.compile("(?i)(mon)|(tue)|(wed)|(thu)|(fri)|(sat)|(sun)").matcher("");
     private static final Matcher TIME = Pattern.compile("(?<neg>-)?+(?<hour>[0-9]{1,2})(:(?<minute>[0-5][0-9]))?+(:(?<second>[0-5][0-9]))?+").matcher("");
 
     /** The TZDB rules. */
@@ -495,26 +493,37 @@ public final class TzdbZoneRulesCompiler {
     }
 
     private int parseMonth(Scanner s) {
-        if (s.hasNext(MONTH)) {
-            s.next(MONTH);
-            for (int moy = 1; moy < 13; moy++) {
-                if (s.match().group(moy) != null) {
-                    return moy;
-                }
-            }
-        }
-        throw new IllegalArgumentException("Unknown month: " + s.next());
+        String mon = s.next();
+        int len = mon.length();
+
+        if (mon.regionMatches(true, 0, "January", 0, len)) return 1;
+        if (mon.regionMatches(true, 0, "February", 0, len)) return 2;
+        if (mon.regionMatches(true, 0, "March", 0, len)) return 3;
+        if (mon.regionMatches(true, 0, "April", 0, len)) return 4;
+        if (mon.regionMatches(true, 0, "May", 0, len)) return 5;
+        if (mon.regionMatches(true, 0, "June", 0, len)) return 6;
+        if (mon.regionMatches(true, 0, "July", 0, len)) return 7;
+        if (mon.regionMatches(true, 0, "August", 0, len)) return 8;
+        if (mon.regionMatches(true, 0, "September", 0, len)) return 9;
+        if (mon.regionMatches(true, 0, "October", 0, len)) return 10;
+        if (mon.regionMatches(true, 0, "November", 0, len)) return 11;
+        if (mon.regionMatches(true, 0, "December", 0, len)) return 12;
+
+        throw new IllegalArgumentException("Unknown month: " + mon);
     }
 
-    private int parseDayOfWeek(String str) {
-        if (DOW.reset(str).matches()) {
-            for (int dow = 1; dow < 8; dow++) {
-                if (DOW.group(dow) != null) {
-                    return dow;
-                }
-            }
-        }
-        throw new IllegalArgumentException("Unknown day-of-week: " + str);
+    private int parseDayOfWeek(String dow) {
+        int len = dow.length();
+
+        if (dow.regionMatches(true, 0, "Monday", 0, len)) return 1;
+        if (dow.regionMatches(true, 0, "Tuesday", 0, len)) return 2;
+        if (dow.regionMatches(true, 0, "Wednesday", 0, len)) return 3;
+        if (dow.regionMatches(true, 0, "Thursday", 0, len)) return 4;
+        if (dow.regionMatches(true, 0, "Friday", 0, len)) return 5;
+        if (dow.regionMatches(true, 0, "Saturday", 0, len)) return 6;
+        if (dow.regionMatches(true, 0, "Sunday", 0, len)) return 7;
+
+        throw new IllegalArgumentException("Unknown day-of-week: " + dow);
     }
 
     private String parseOptional(String str) {

--- a/jdk/test/sun/util/calendar/zi/Month.java
+++ b/jdk/test/sun/util/calendar/zi/Month.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,11 +23,6 @@
  * questions.
  */
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 /**
  * Month enum handles month related manipulation.
  *
@@ -49,15 +44,6 @@ enum Month {
 
     private final String abbr;
 
-    private static final Map<String,Month> abbreviations
-                                = new HashMap<String,Month>(12);
-
-    static {
-        for (Month m : Month.values()) {
-            abbreviations.put(m.abbr, m);
-        }
-    }
-
     private Month(String abbr) {
         this.abbr = abbr;
     }
@@ -72,11 +58,22 @@ enum Month {
      * @return the Month value
      */
     static Month parse(String name) {
-        Month m = abbreviations.get(name);
-        if (m != null) {
-            return m;
-        }
-        return null;
+        int len = name.length();
+
+        if (name.regionMatches(true, 0, "January", 0, len)) return Month.JANUARY;
+        if (name.regionMatches(true, 0, "February", 0, len)) return Month.FEBRUARY;
+        if (name.regionMatches(true, 0, "March", 0, len)) return Month.MARCH;
+        if (name.regionMatches(true, 0, "April", 0, len)) return Month.APRIL;
+        if (name.regionMatches(true, 0, "May", 0, len)) return Month.MAY;
+        if (name.regionMatches(true, 0, "June", 0, len)) return Month.JUNE;
+        if (name.regionMatches(true, 0, "July", 0, len)) return Month.JULY;
+        if (name.regionMatches(true, 0, "August", 0, len)) return Month.AUGUST;
+        if (name.regionMatches(true, 0, "September", 0, len)) return Month.SEPTEMBER;
+        if (name.regionMatches(true, 0, "October", 0, len)) return Month.OCTOBER;
+        if (name.regionMatches(true, 0, "November", 0, len)) return Month.NOVEMBER;
+        if (name.regionMatches(true, 0, "December", 0, len)) return Month.DECEMBER;
+
+        throw new IllegalArgumentException("Unknown month: " + name);
     }
 
     /**

--- a/jdk/test/sun/util/calendar/zi/RuleDay.java
+++ b/jdk/test/sun/util/calendar/zi/RuleDay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,11 +23,6 @@
  * questions.
  */
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 /**
  * RuleDay class represents the value of the "ON" field.  The day of
  * week values start from 1 following the {@link java.util.Calendar}
@@ -36,13 +31,6 @@ import java.util.Map;
  * @since 1.4
  */
 class RuleDay {
-    private static final Map<String,DayOfWeek> abbreviations = new HashMap<String,DayOfWeek>(7);
-    static {
-        for (DayOfWeek day : DayOfWeek.values()) {
-            abbreviations.put(day.getAbbr(), day);
-        }
-    }
-
     private String dayName = null;
     private DayOfWeek dow;
     private boolean lastOne = false;
@@ -168,13 +156,23 @@ class RuleDay {
         return sign + toString(d);
     }
 
-    private static DayOfWeek getDOW(String abbr) {
-        return abbreviations.get(abbr);
+    private static DayOfWeek getDOW(String name) {
+        int len = name.length();
+
+        if (name.regionMatches(true, 0, "Monday", 0, len)) return DayOfWeek.MONDAY;
+        if (name.regionMatches(true, 0, "Tuesday", 0, len)) return DayOfWeek.TUESDAY;
+        if (name.regionMatches(true, 0, "Wednesday", 0, len)) return DayOfWeek.WEDNESDAY;
+        if (name.regionMatches(true, 0, "Thursday", 0, len)) return DayOfWeek.THURSDAY;
+        if (name.regionMatches(true, 0, "Friday", 0, len)) return DayOfWeek.FRIDAY;
+        if (name.regionMatches(true, 0, "Saturday", 0, len)) return DayOfWeek.SATURDAY;
+        if (name.regionMatches(true, 0, "Sunday", 0, len)) return DayOfWeek.SUNDAY;
+
+        throw new IllegalArgumentException("Unknown day-of-week: " + name);
     }
 
     /**
      * Converts the specified day of week value to the day-of-week
-     * name defined in {@link java.util.Calenda}.
+     * name defined in {@link java.util.Calendar}.
      * @param dow 1-based day of week value
      * @return the Calendar day of week name with "Calendar." prefix.
      * @throws IllegalArgumentException if the specified dow value is out of range.


### PR DESCRIPTION
The backport is a prerequisite for timezone data update to 2024b. Targeting the PR to jdk8u-dev repo (April release).

The changes are the same as the changes proposed in https://github.com/openjdk/jdk8u/pull/64 but now targeted to https://github.com/openjdk/jdk8u-dev

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8339644](https://bugs.openjdk.org/browse/JDK-8339644) needs maintainer approval

### Issue
 * [JDK-8339644](https://bugs.openjdk.org/browse/JDK-8339644): Improve parsing of Day/Month in tzdata rules (**Bug** - P4 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/615/head:pull/615` \
`$ git checkout pull/615`

Update a local copy of the PR: \
`$ git checkout pull/615` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/615/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 615`

View PR using the GUI difftool: \
`$ git pr show -t 615`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/615.diff">https://git.openjdk.org/jdk8u-dev/pull/615.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/615#issuecomment-2586686746)
</details>
