### PR TITLE
8348211: [8u] sun/management/jmxremote/startstop/JMXStartStopTest.java fails after backport of JDK-8066708

### DIFF
--- a/jdk/test/sun/management/jmxremote/startstop/JMXStartStopTest.java
+++ b/jdk/test/sun/management/jmxremote/startstop/JMXStartStopTest.java
@@ -500,7 +500,7 @@ public class JMXStartStopTest {
             testConnect(ports[0]);
 
             jcmd(CMD_STOP);
-            testConnect(ports[0]);
+            testNoConnect(ports[0]);
 
             jcmd(CMD_START, "jmxremote.port=" + ports[1]);
             testConnect(ports[1]);


### PR DESCRIPTION
`sun/management/jmxremote/startstop/JMXStartStopTest.java` fails on 8u after [backport](https://github.com/openjdk/jdk8u-dev/pull/430) of JDK-8066708

**Problem:**
```
test_01 failed
java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at JMXStartStopTest.main(JMXStartStopTest.java:294)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.sun.javatest.regtest.agent.MainWrapper$MainThread.run(MainWrapper.java:127)
	at java.lang.Thread.run(Thread.java:750)
Caused by: java.rmi.NoSuchObjectException: no such object in table
	at sun.rmi.transport.StreamRemoteCall.exceptionReceivedFromServer(StreamRemoteCall.java:303)
	at sun.rmi.transport.StreamRemoteCall.executeCall(StreamRemoteCall.java:279)
	at sun.rmi.server.UnicastRef.invoke(UnicastRef.java:380)
	at sun.rmi.registry.RegistryImpl_Stub.list(RegistryImpl_Stub.java:91)
	at JMXStartStopTest.testConnect(JMXStartStopTest.java:201)
	at JMXStartStopTest.testConnect(JMXStartStopTest.java:187)
	at JMXStartStopTest.test_01(JMXStartStopTest.java:503)
	... 11 more
java.lang.Error
	at JMXStartStopTest.main(JMXStartStopTest.java:318)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.sun.javatest.regtest.agent.MainWrapper$MainThread.run(MainWrapper.java:127)
	at java.lang.Thread.run(Thread.java:750)

JavaTest Message: Test threw exception: java.lang.Error
JavaTest Message: shutting down test
```

**Fix:**
There was a mistake in JDK-8066708 backport, where `testConnect` is called instead of `testNoConnect`. This PR fixes this.

**Testing:**
- tested locally, JMXStartStopTest.java passed with this change
- GHA test failures are unrelated

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8348211](https://bugs.openjdk.org/browse/JDK-8348211) needs maintainer approval

### Issue
 * [JDK-8348211](https://bugs.openjdk.org/browse/JDK-8348211): [8u] sun/management/jmxremote/startstop/JMXStartStopTest.java fails after backport of JDK-8066708 (**Bug** - P4 - Approved)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/616/head:pull/616` \
`$ git checkout pull/616`

Update a local copy of the PR: \
`$ git checkout pull/616` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/616/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 616`

View PR using the GUI difftool: \
`$ git pr show -t 616`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/616.diff">https://git.openjdk.org/jdk8u-dev/pull/616.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/616#issuecomment-2605638708)
</details>
