### PR TITLE
8285756: clean up use of bad arguments for `@clean` in langtools tests

### DIFF
--- a/langtools/test/tools/javac/6257443/T6257443.java
+++ b/langtools/test/tools/javac/6257443/T6257443.java
@@ -29,7 +29,7 @@
  * @compile package-info.java
  * @run main/othervm T6257443 -yes foo/package-info.class
  *
- * @clean foo.package-info
+ * @clean foo.*
  *
  * @compile -XD-printflat package-info.java
  * @run main/othervm T6257443 -no foo/package-info.class

--- a/langtools/test/tools/javac/warnings/suppress/PackageInfo.java
+++ b/langtools/test/tools/javac/warnings/suppress/PackageInfo.java
@@ -25,6 +25,6 @@
  * @test
  * @bug 8021112
  * @summary Verify that deprecated warnings are printed correctly for package-info.java
- * @clean pack.package-info pack.DeprecatedClass
+ * @clean pack.*
  * @compile/ref=PackageInfo.out -XDrawDiagnostics -Xlint:deprecation pack/package-info.java pack/DeprecatedClass.java
  */


### PR DESCRIPTION
Backporting JDK-8285756: clean up use of bad arguments for `@clean` in langtools tests. This adjusts test tags to be compatible with newer versions of jtreg. Backport is not clean due to not having some of the newer tests, and not providing the --source 8 arg. Ran GHA Sanity Checks and local Tier 1 and Tier 2 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8285756](https://bugs.openjdk.org/browse/JDK-8285756) needs maintainer approval

### Issue
 * [JDK-8285756](https://bugs.openjdk.org/browse/JDK-8285756): clean up use of bad arguments for `@<!---->clean` in langtools tests (**Bug** - P3 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/618/head:pull/618` \
`$ git checkout pull/618`

Update a local copy of the PR: \
`$ git checkout pull/618` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/618/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 618`

View PR using the GUI difftool: \
`$ git pr show -t 618`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/618.diff">https://git.openjdk.org/jdk8u-dev/pull/618.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/618#issuecomment-2618037998)
</details>
