### PR TITLE
8349166: Bad indentation in backport of JDK-8250825

### DIFF
--- a/hotspot/src/share/vm/opto/type.cpp
+++ b/hotspot/src/share/vm/opto/type.cpp
@@ -2558,7 +2558,7 @@ TypeOopPtr::TypeOopPtr(TYPES t, PTR ptr, ciKlass* k, bool xk, ciObject* o, int o
           if (field != NULL) {
             BasicType basic_elem_type = field->layout_type();
             _is_ptr_to_narrowoop = UseCompressedOops && (basic_elem_type == T_OBJECT ||
-                                                       basic_elem_type == T_ARRAY);
+                                                         basic_elem_type == T_ARRAY);
           } else {
             // unsafe access
             _is_ptr_to_narrowoop = UseCompressedOops;


### PR DESCRIPTION
Hi all,
This PR fix the bad indentation in [backport](https://github.com/openjdk/jdk8u-dev/pull/552) of [JDK-8250825](https://bugs.openjdk.org/browse/JDK-8250825).
Trivial fix, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8349166](https://bugs.openjdk.org/browse/JDK-8349166) needs maintainer approval

### Issue
 * [JDK-8349166](https://bugs.openjdk.org/browse/JDK-8349166): Bad indentation in backport of JDK-8250825 (**Bug** - P4 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/619/head:pull/619` \
`$ git checkout pull/619`

Update a local copy of the PR: \
`$ git checkout pull/619` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/619/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 619`

View PR using the GUI difftool: \
`$ git pr show -t 619`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/619.diff">https://git.openjdk.org/jdk8u-dev/pull/619.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/619#issuecomment-2628745670)
</details>
