### PR TITLE
Backport 907f9ee7083df384a7433cb933522680e70dcb1f

### DIFF
--- a/jdk/test/tools/launcher/TestHelper.java
+++ b/jdk/test/tools/launcher/TestHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -103,10 +103,12 @@ public class TestHelper {
     // make a note of the golden default locale
     static final Locale DefaultLocale = Locale.getDefault();
 
-    static final String JAVA_FILE_EXT  = ".java";
-    static final String CLASS_FILE_EXT = ".class";
-    static final String JAR_FILE_EXT   = ".jar";
-    static final String EXE_FILE_EXT   = ".exe";
+    static final String JAVA_FILE_EXT   = ".java";
+    static final String CLASS_FILE_EXT  = ".class";
+    static final String JAR_FILE_EXT    = ".jar";
+    static final String EXE_FILE_EXT    = ".exe";
+    static final String MAC_DSYM_EXT    = ".dsym";
+    static final String NIX_DBGINFO_EXT = ".debuginfo";
     static final String JLDEBUG_KEY     = "_JAVA_LAUNCHER_DEBUG";
     static final String EXPECTED_MARKER = "TRACER_MARKER:About to EXEC";
     static final String TEST_PREFIX     = "###TestError###: ";
@@ -504,6 +506,43 @@ public class TestHelper {
 
     static boolean isEnglishLocale() {
         return Locale.getDefault().getLanguage().equals("en");
+    }
+
+    static class ToolFilter implements FileFilter {
+        final List<String> exclude = new ArrayList<>();
+        protected ToolFilter(String... exclude) {
+            for (String x : exclude) {
+                String str = x + ((isWindows) ? EXE_FILE_EXT : "");
+                this.exclude.add(str.toLowerCase());
+            }
+        }
+
+        @Override
+        public boolean accept(File pathname) {
+            if (!pathname.isFile() || !pathname.canExecute()) {
+                return false;
+            }
+            String name = pathname.getName().toLowerCase();
+            if (isWindows) {
+                if (!name.endsWith(EXE_FILE_EXT)) {
+                    return false;
+                }
+            } else if (isMacOSX) {
+                if (name.endsWith(MAC_DSYM_EXT)) {
+                    return false;
+                }
+            } else {
+                if (name.endsWith(NIX_DBGINFO_EXT)) {
+                    return false;
+                }
+            }
+            for (String x : exclude) {
+                if (name.endsWith(x)) {
+                    return false;
+                }
+            }
+            return true;
+        }
     }
 
     /*

--- a/jdk/test/tools/launcher/VersionCheck.java
+++ b/jdk/test/tools/launcher/VersionCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,11 +31,12 @@
  */
 
 import java.io.File;
-import java.io.FileFilter;
-import java.util.Map;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class VersionCheck extends TestHelper {
 
@@ -225,34 +226,6 @@ public class VersionCheck extends TestHelper {
             System.out.println("All Version string comparisons: PASS");
         } else {
             throw new AssertionError("Some tests failed");
-        }
-    }
-
-    static class ToolFilter implements FileFilter {
-        final Iterable<String> exclude ;
-        protected ToolFilter(String... exclude) {
-            List<String> tlist = new ArrayList<>();
-            this.exclude = tlist;
-            for (String x : exclude) {
-                String str = x + ((isWindows) ? EXE_FILE_EXT : "");
-                tlist.add(str.toLowerCase());
-            }
-        }
-        @Override
-        public boolean accept(File pathname) {
-            if (!pathname.isFile() || !pathname.canExecute()) {
-                return false;
-            }
-            String name = pathname.getName().toLowerCase();
-            if (isWindows && !name.endsWith(EXE_FILE_EXT)) {
-                return false;
-            }
-            for (String x : exclude) {
-                if (name.endsWith(x)) {
-                    return false;
-                }
-            }
-            return true;
         }
     }
 }

--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -1,5 +1,9 @@
 #
+<<<<<<< HEAD
 # Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+=======
+# Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+>>>>>>> 907f9ee7083 (8237192: Generate stripped/public pdbs on Windows for jdk images)
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -437,6 +441,7 @@ define SetupNativeCompilation
 
   # Need to make sure TARGET is first on list
   $1 := $$($1_TARGET)
+<<<<<<< HEAD
   ifeq ($$($1_STATIC_LIBRARY),)
     ifneq ($$($1_DEBUG_SYMBOLS),)
       ifeq ($(ENABLE_DEBUG_SYMBOLS), true)
@@ -451,6 +456,116 @@ define SetupNativeCompilation
 		$(CP) $$< $$@
             $$($1_OUTPUT_DIR)/$$($1_NOSUFFIX).diz : $$($1_OBJECT_DIR)/$$($1_NOSUFFIX).diz
 		$(CP) $$< $$@
+=======
+
+  ifneq ($$($1_COPY_DEBUG_SYMBOLS), false)
+    $1_COPY_DEBUG_SYMBOLS := $(COPY_DEBUG_SYMBOLS)
+  endif
+
+  ifneq ($$($1_ZIP_EXTERNAL_DEBUG_SYMBOLS), false)
+    $1_ZIP_EXTERNAL_DEBUG_SYMBOLS := $(ZIP_EXTERNAL_DEBUG_SYMBOLS)
+  endif
+
+  ifeq ($$($1_COPY_DEBUG_SYMBOLS), true)
+    ifneq ($$($1_DEBUG_SYMBOLS), false)
+      # Only copy debug symbols for dynamic libraries and programs.
+      ifneq ($$($1_TYPE), STATIC_LIBRARY)
+        # Generate debuginfo files.
+        ifeq ($(OPENJDK_TARGET_OS), windows)
+          $1_EXTRA_LDFLAGS += -debug "-pdb:$$($1_OUTPUT_DIR)/$$($1_NOSUFFIX).pdb" \
+              "-map:$$($1_OUTPUT_DIR)/$$($1_NOSUFFIX).map"
+          ifeq ($(SHIP_DEBUG_SYMBOLS), public)
+            $1_EXTRA_LDFLAGS += "-pdbstripped:$$($1_OUTPUT_DIR)/$$($1_NOSUFFIX).stripped.pdb"
+          endif
+          $1_DEBUGINFO_FILES := $$($1_OUTPUT_DIR)/$$($1_NOSUFFIX).pdb \
+              $$($1_OUTPUT_DIR)/$$($1_NOSUFFIX).map
+
+        else ifneq ($(findstring $(OPENJDK_TARGET_OS), linux solaris), )
+          $1_DEBUGINFO_FILES := $$($1_OUTPUT_DIR)/$$($1_NOSUFFIX).debuginfo
+          # Setup the command line creating debuginfo files, to be run after linking.
+          # It cannot be run separately since it updates the original target file
+          $1_CREATE_DEBUGINFO_CMDS := \
+              $$($1_OBJCOPY) --only-keep-debug $$($1_TARGET) $$($1_DEBUGINFO_FILES) $$(NEWLINE) \
+              $(CD) $$($1_OUTPUT_DIR) && \
+                  $$($1_OBJCOPY) --add-gnu-debuglink=$$($1_DEBUGINFO_FILES) $$($1_TARGET)
+
+        else ifeq ($(OPENJDK_TARGET_OS), macosx)
+          $1_DEBUGINFO_FILES := \
+              $$($1_OUTPUT_DIR)/$$($1_BASENAME).dSYM/Contents/Info.plist \
+              $$($1_OUTPUT_DIR)/$$($1_BASENAME).dSYM/Contents/Resources/DWARF/$$($1_BASENAME)
+          $1_CREATE_DEBUGINFO_CMDS := \
+              $(DSYMUTIL) --out $$($1_OUTPUT_DIR)/$$($1_BASENAME).dSYM $$($1_TARGET)
+        endif # OPENJDK_TARGET_OS
+
+        # Since the link rule creates more than one file that we want to track,
+        # we have to use some tricks to get make to cooperate. To properly
+        # trigger downstream dependants of $$($1_DEBUGINFO_FILES), we must have
+        # a recipe in the rule below. To avoid rerunning the recipe every time
+        # have it touch the target. If a debuginfo file is deleted by something
+        # external, explicitly delete the TARGET to trigger a rebuild of both.
+        ifneq ($$(wildcard $$($1_DEBUGINFO_FILES)), $$($1_DEBUGINFO_FILES))
+          $$(call LogDebug, Deleting $$($1_BASENAME) because debuginfo files are missing)
+          $$(shell $(RM) $$($1_TARGET))
+        endif
+        $$($1_DEBUGINFO_FILES): $$($1_TARGET)
+		$$(if $$(CORRECT_FUNCTION_IN_RECIPE_EVALUATION), \
+		  $$(if $$(wildcard $$@), , $$(error $$@ was not created for $$<)) \
+		)
+		$(TOUCH) $$@
+
+        $1 += $$($1_DEBUGINFO_FILES)
+
+        ifeq ($$($1_ZIP_EXTERNAL_DEBUG_SYMBOLS), true)
+          $1_DEBUGINFO_ZIP := $$($1_OUTPUT_DIR)/$$($1_NOSUFFIX).diz
+          $1 += $$($1_DEBUGINFO_ZIP)
+
+          # The dependency on TARGET is needed for debuginfo files
+          # to be rebuilt properly.
+          $$($1_DEBUGINFO_ZIP): $$($1_DEBUGINFO_FILES) $$($1_TARGET)
+		$(CD) $$($1_OUTPUT_DIR) && \
+		    $(ZIPEXE) -q -r $$@ $$(subst $$($1_OUTPUT_DIR)/,, $$($1_DEBUGINFO_FILES))
+
+        endif
+       endif # !STATIC_LIBRARY
+    endif # $1_DEBUG_SYMBOLS != false
+  endif # COPY_DEBUG_SYMBOLS
+
+  # Unless specifically set, stripping should only happen if symbols are also
+  # being copied.
+  $$(call SetIfEmpty, $1_STRIP_SYMBOLS, $$($1_COPY_DEBUG_SYMBOLS))
+
+  ifneq ($$($1_STRIP_SYMBOLS), false)
+    ifneq ($$($1_STRIP), )
+      # Default to using the global STRIPFLAGS. Allow for overriding with an empty value
+      $1_STRIPFLAGS ?= $(STRIPFLAGS)
+      $1_STRIP_CMD := $$($1_STRIP) $$($1_STRIPFLAGS) $$($1_TARGET)
+    endif
+  endif
+
+  ifeq ($$($1_TYPE), STATIC_LIBRARY)
+    $1_VARDEPS := $$($1_AR) $$($1_ARFLAGS) $$($1_LIBS) \
+        $$($1_EXTRA_LIBS)
+    $1_VARDEPS_FILE := $$(call DependOnVariable, $1_VARDEPS, \
+        $$($1_OBJECT_DIR)/$$($1_NOSUFFIX).vardeps)
+
+    # Generating a static library, ie object file archive.
+    ifeq ($(STATIC_BUILD), true)
+      ifeq ($$($1_USE_MAPFILE_FOR_SYMBOLS), true)
+        STATIC_MAPFILE_DEP := $$($1_MAPFILE)
+      endif
+    endif
+
+    $1_TARGET_DEPS := $$($1_ALL_OBJS) $$($1_RES) $$($1_VARDEPS_FILE) $$(STATIC_MAPFILE_DEP)
+
+    $$($1_TARGET): $$($1_TARGET_DEPS)
+	$$(call LogInfo, Building static library $$($1_BASENAME))
+	$$(call ExecuteWithLog, $$($1_OBJECT_DIR)/$$($1_SAFE_NAME)_link, \
+	    $$($1_AR) $$($1_ARFLAGS) $(AR_OUT_OPTION)$$($1_TARGET) $$($1_ALL_OBJS) \
+	        $$($1_RES))
+        ifeq ($(STATIC_BUILD), true)
+          ifeq ($$($1_USE_MAPFILE_FOR_SYMBOLS), true)
+	    $(CP) $$($1_MAPFILE) $$(@D)/$$(basename $$(@F)).symbols
+>>>>>>> 907f9ee7083 (8237192: Generate stripped/public pdbs on Windows for jdk images)
           else
             # The dependency on TARGET is needed on windows for debuginfo files
             # to be rebuilt properly.


### PR DESCRIPTION
Hi all,
This is backport [JDK-8237192](https://bugs.openjdk.org/browse/JDK-8237192) from jdk11u-dev to jdk8u-dev, to fix 'tools/launcher/VersionCheck.java' test fails with fastdebug build which report 'jstack.debuginfo: cannot execute binary file'.

File 'jdk/test/tools/launcher/TestHelper.java', 'jdk/test/tools/launcher/VersionCheck.java' and make/common/NativeCompilation.gmk has different context make this backport uncleanly, mainly in copyrighht year different.

Change has been verified locally, text-fix only, no risk.