### PR TITLE
8340552: Harden TzdbZoneRulesCompiler against missing zone names

### DIFF
--- a/jdk/make/src/classes/build/tools/tzdb/TzdbZoneRulesCompiler.java
+++ b/jdk/make/src/classes/build/tools/tzdb/TzdbZoneRulesCompiler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -248,7 +248,7 @@ public final class TzdbZoneRulesCompiler {
             // link version-region-rules
             out.writeShort(builtZones.size());
             for (Map.Entry<String, ZoneRules> entry : builtZones.entrySet()) {
-                 int regionIndex = Arrays.binarySearch(regionArray, entry.getKey());
+                 int regionIndex = findRegionIndex(regionArray, entry.getKey());
                  int rulesIndex = rulesList.indexOf(entry.getValue());
                  out.writeShort(regionIndex);
                  out.writeShort(rulesIndex);
@@ -256,8 +256,8 @@ public final class TzdbZoneRulesCompiler {
             // alias-region
             out.writeShort(links.size());
             for (Map.Entry<String, String> entry : links.entrySet()) {
-                 int aliasIndex = Arrays.binarySearch(regionArray, entry.getKey());
-                 int regionIndex = Arrays.binarySearch(regionArray, entry.getValue());
+                 int aliasIndex = findRegionIndex(regionArray, entry.getKey());
+                 int regionIndex = findRegionIndex(regionArray, entry.getValue());
                  out.writeShort(aliasIndex);
                  out.writeShort(regionIndex);
             }
@@ -283,6 +283,14 @@ public final class TzdbZoneRulesCompiler {
 
     /** The built zones. */
     private final SortedMap<String, ZoneRules> builtZones = new TreeMap<>();
+
+    private static int findRegionIndex(String[] regionArray, String region) {
+        int index = Arrays.binarySearch(regionArray, region);
+        if (index < 0) {
+            throw new IllegalArgumentException("Unknown region: " + region);
+        }
+        return index;
+    }
 
     /** Whether to output verbose messages. */
     private boolean verbose;


### PR DESCRIPTION
The changes are the same as submitted by https://github.com/openjdk/jdk8u/pull/66 but now moved to https://github.com/openjdk/jdk8u-dev

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340552](https://bugs.openjdk.org/browse/JDK-8340552) needs maintainer approval

### Issue
 * [JDK-8340552](https://bugs.openjdk.org/browse/JDK-8340552): Harden TzdbZoneRulesCompiler against missing zone names (**Bug** - P5 - Approved)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/623/head:pull/623` \
`$ git checkout pull/623`

Update a local copy of the PR: \
`$ git checkout pull/623` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/623/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 623`

View PR using the GUI difftool: \
`$ git pr show -t 623`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/623.diff">https://git.openjdk.org/jdk8u-dev/pull/623.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/623#issuecomment-2671891008)
</details>
