### PR TITLE
GHA: update to ubuntu 22.04 and bullseye sysroot

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   prerequisites:
     name: Prerequisites
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     outputs:
       should_run: ${{ steps.check_submit.outputs.should_run }}
       bundle_id: ${{ steps.check_bundle_id.outputs.bundle_id }}
@@ -115,7 +115,7 @@ jobs:
 
   linux_x64_build:
     name: Linux x64
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     needs: prerequisites
     if: needs.prerequisites.outputs.should_run != 'false' && needs.prerequisites.outputs.platform_linux_x64 != 'false'
 
@@ -191,7 +191,7 @@ jobs:
 
   linux_x64_test:
     name: Linux x64
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     needs:
       - prerequisites
       - linux_x64_build
@@ -308,7 +308,7 @@ jobs:
 
   linux_additional_build:
     name: Linux additional
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     needs:
       - prerequisites
     if: needs.prerequisites.outputs.should_run != 'false' && needs.prerequisites.outputs.platform_linux_additional != 'false'
@@ -464,7 +464,7 @@ jobs:
 
   linux_x86_build:
     name: Linux x86
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     needs: prerequisites
     if: needs.prerequisites.outputs.should_run != 'false' && needs.prerequisites.outputs.platform_linux_x86 != 'false'
 
@@ -550,7 +550,7 @@ jobs:
 
   linux_x86_test:
     name: Linux x86
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     needs:
       - prerequisites
       - linux_x86_build
@@ -1584,7 +1584,7 @@ jobs:
 
   artifacts:
     name: Post-process artifacts
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     if: always()
     continue-on-error: true
     needs:


### PR DESCRIPTION
Updates GHA workflow to Ubuntu 22.04.

**Notes:**
- code changes were done manually here (GHA workflows were rewritten in newer JDKs)
- Ubuntu 20.04 runner image for GHA is already deprecated and will be [unsupported soon](https://github.com/actions/runner-images/issues/11101)
- sysroot update to bullseye was already [done separately](https://github.com/openjdk/jdk8u-dev/pull/491)  (update to ubuntu 22.04 was not done at the time, it was blocked by [JDK-8281096](https://bugs.openjdk.org/browse/JDK-8281096) )

**Testing:**
tier1 in GHA: OK

Failures:
- jdk/security_infra failures - unrelated
- linux x86 hotspot/tier1
  - `gc/concurrentMarkSweep/CheckAllocateAndSystemGC.java` timeout, seems unrelated
- macOS
  - 2 known failures, addressed by: https://github.com/openjdk/jdk8u-dev/pull/553

