### PR TITLE
8350816: [8u] Update TzdbZoneRulesCompiler to ignore HST/EST/MST links

### DIFF
--- a/jdk/make/src/classes/build/tools/tzdb/TzdbZoneRulesCompiler.java
+++ b/jdk/make/src/classes/build/tools/tzdb/TzdbZoneRulesCompiler.java
@@ -640,6 +640,9 @@ public final class TzdbZoneRulesCompiler {
         builtZones.remove("EST");
         builtZones.remove("HST");
         builtZones.remove("MST");
+        links.remove("EST");
+        links.remove("HST");
+        links.remove("MST");
     }
 
     /**


### PR DESCRIPTION
This is 8u-specific issue. It's a prerequisite for backport of 2024b ([JDK-8339637](https://bugs.openjdk.org/browse/JDK-8339637)) as backporting 2024b to 8u as is leads to the following failure

java.lang.IllegalArgumentException: Unknown region: HST
	at build.tools.tzdb.TzdbZoneRulesCompiler.findRegionIndex(TzdbZoneRulesCompiler.java:290)
	at build.tools.tzdb.TzdbZoneRulesCompiler.outputFile(TzdbZoneRulesCompiler.java:259)
	at build.tools.tzdb.TzdbZoneRulesCompiler.compile(TzdbZoneRulesCompiler.java:193)
	at build.tools.tzdb.TzdbZoneRulesCompiler.main(TzdbZoneRulesCompiler.java:91)

[JDK-8042369](https://bugs.openjdk.org/browse/JDK-8042369) updated the compiler to ignore HST/EST/MST links in 9+  (https://hg.openjdk.org/jdk9/jdk9/jdk/rev/6c26f18d9bc0#l8.139) so the failure didn't appear with backports of 2024b to 11+

The patch changes the compiler in 8u to ignore HST/EST/MST links and work in the same way as it works for 11+

Testing: all relevant tests passed (java/text/Format java/util/TimeZone sun/util/calendar sun/util/resources)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8350816](https://bugs.openjdk.org/browse/JDK-8350816) needs maintainer approval

### Issue
 * [JDK-8350816](https://bugs.openjdk.org/browse/JDK-8350816): [8u] Update TzdbZoneRulesCompiler to ignore HST/EST/MST links (**Bug** - P4 - Approved)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/630/head:pull/630` \
`$ git checkout pull/630`

Update a local copy of the PR: \
`$ git checkout pull/630` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/630/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 630`

View PR using the GUI difftool: \
`$ git pr show -t 630`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/630.diff">https://git.openjdk.org/jdk8u-dev/pull/630.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/630#issuecomment-2686339701)
</details>
