### PR TITLE
8339803: Acknowledge case insensitive unambiguous keywords in tzdata files

### DIFF
--- a/jdk/test/sun/util/calendar/zi/RuleRec.java
+++ b/jdk/test/sun/util/calendar/zi/RuleRec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -170,12 +170,13 @@ class RuleRec {
                 rec.toYear = Integer.parseInt(token);
             } catch (NumberFormatException e) {
                 // it's not integer
-                if ("min".equals(token) || "minimum".equals(token)) {
+                int len = token.length();
+                if (token.regionMatches(true, 0, "minimum", 0, len)) {
                     rec.fromYear = Zoneinfo.getMinYear();
-                } else if ("max".equals(token) || "maximum".equals(token)) {
+                } else if (token.regionMatches(true, 0, "maximum", 0, len)) {
                     rec.toYear = Integer.MAX_VALUE;
                     rec.isLastRule = true;
-                } else if ("only".equals(token)) {
+                } else if (token.regionMatches(true, 0, "only", 0, len)) {
                     rec.toYear = rec.fromYear;
                 } else {
                     Main.panic("invalid year value: "+token);

--- a/jdk/test/sun/util/calendar/zi/Zoneinfo.java
+++ b/jdk/test/sun/util/calendar/zi/Zoneinfo.java
@@ -242,8 +242,9 @@ class Zoneinfo {
                     continue;
                 }
                 String token = tokens.nextToken();
+                int len = token.length();
 
-                if (continued || "Zone".equals(token)) {
+                if (continued || token.regionMatches(true, 0, "Zone", 0, len)){
                     if (zone == null) {
                         if (!tokens.hasMoreTokens()) {
                             panic("syntax error: zone no more token");
@@ -270,7 +271,7 @@ class Zoneinfo {
                         }
                         zone = null;
                     }
-                } else if ("Rule".equals(token)) {
+                } else if (token.regionMatches(true, 0, "Rule", 0, len)) {
                     if (!tokens.hasMoreTokens()) {
                         panic("syntax error: rule no more token");
                     }
@@ -283,7 +284,7 @@ class Zoneinfo {
                     RuleRec rrec = RuleRec.parse(tokens);
                     rrec.setLine(line);
                     rule.add(rrec);
-                } else if ("Link".equals(token)) {
+                } else if (token.regionMatches(true, 0, "Link", 0, len)) {
                     // Link <newname> <oldname>
                     try {
                         String name1 = tokens.nextToken();


### PR DESCRIPTION
Improves parsing of keywords in tzdata rules

- The patch from 11u doesn't apply cleanly due to [JDK-8042369](https://bugs.openjdk.org/browse/JDK-8042369) missing in 8u. I backported new version of `parseYear` method (https://hg.openjdk.org/jdk9/jdk9/jdk/rev/6c26f18d9bc0#l8.347) with minor adaption to 8u codebase and then replaced uses of `equals()` with `regionMatches()`
- Minor conflict in copyright year in RuleRec.java, applied manually

Testing: all relevant tests passed (java/text/Format java/util/TimeZone sun/util/calendar sun/util/resources)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8339803](https://bugs.openjdk.org/browse/JDK-8339803) needs maintainer approval

### Issue
 * [JDK-8339803](https://bugs.openjdk.org/browse/JDK-8339803): Acknowledge case insensitive unambiguous keywords in tzdata files (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/632/head:pull/632` \
`$ git checkout pull/632`

Update a local copy of the PR: \
`$ git checkout pull/632` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/632/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 632`

View PR using the GUI difftool: \
`$ git pr show -t 632`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/632.diff">https://git.openjdk.org/jdk8u-dev/pull/632.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/632#issuecomment-2695139608)
</details>
