### PR TITLE
8351098: Bump update version of OpenJDK: 8u462

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -1,7 +1,7 @@
 [general]
 project=jdk8u
 jbs=JDK
-version=openjdk8u452
+version=openjdk8u462
 
 [checks]
 error=author,committer,reviewers,merge,issues,executable,symlink,message,hg-tag,whitespace

--- a/common/autoconf/version-numbers
+++ b/common/autoconf/version-numbers
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
 JDK_MAJOR_VERSION=1
 JDK_MINOR_VERSION=8
 JDK_MICRO_VERSION=0
-JDK_UPDATE_VERSION=452
+JDK_UPDATE_VERSION=462
 LAUNCHER_NAME=openjdk
 PRODUCT_NAME=OpenJDK
 PRODUCT_SUFFIX="Runtime Environment"


### PR DESCRIPTION
Rampdown for 8u452 [has begun](https://mail.openjdk.org/pipermail/jdk8u-dev/2025-March/019828.html). 8u-dev needs to transition to 8u462.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8351098](https://bugs.openjdk.org/browse/JDK-8351098) needs maintainer approval

### Issue
 * [JDK-8351098](https://bugs.openjdk.org/browse/JDK-8351098): Bump update version of OpenJDK: 8u462 (**Enhancement** - P4 - Approved)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/633/head:pull/633` \
`$ git checkout pull/633`

Update a local copy of the PR: \
`$ git checkout pull/633` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/633/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 633`

View PR using the GUI difftool: \
`$ git pr show -t 633`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/633.diff">https://git.openjdk.org/jdk8u-dev/pull/633.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/633#issuecomment-2697344099)
</details>
