### PR TITLE
8351439: [8u] test/java/util/TimeZone/tools/share/Makefile use wrong path to tzdb

### DIFF
--- a/jdk/test/java/util/TimeZone/tools/share/Makefile
+++ b/jdk/test/java/util/TimeZone/tools/share/Makefile
@@ -30,7 +30,7 @@
 #     make install
 #
 
-TZDATA = ../../../../../../../src/java.base/share/data/tzdata
+TZDATA = ../../../../../../make/data/tzdata/
 TZDATA_VER = `grep '^tzdata' $(TZDATA)/VERSION`
 TZNAME = africa antarctica asia australasia europe northamerica \
 	solar87 solar88 solar89 southamerica \


### PR DESCRIPTION
The TZDATA has been updated to work with jdk8u-dev