### PR TITLE
8351624: [8u] Xerces-J version wrong in THIRD_PARTY_README after JDK-7150324

### DIFF
--- a/THIRD_PARTY_README
+++ b/THIRD_PARTY_README
@@ -3083,7 +3083,7 @@ included with JRE 8, JDK 8, and OpenJDK 8.
   Apache Jakarta BCEL 5.1 
   Apache Santuario XML Security for Java 2.1.3
   Apache Xalan-Java 2.7.2
-  Apache Xerces Java 2.10.0 
+  Apache Xerces Java 2.7.1
   Apache XML Resolver 1.1 
 
 


### PR DESCRIPTION
Hi all,

This PR fixes the wrong version of Xerces-J.
The version of Xerces-J became 2.7.1 in JDK-7150324, but it is 2.10.0 in THIRD_PARTY_README.
Just fix THIRD_PARTY_README, no risk.

Thanks