### PR TITLE
8352942: jdk/jfr/startupargs/TestMemoryOptions.java fails with 32-bit build

### DIFF
--- a/jdk/test/jdk/jfr/startupargs/TestMemoryOptions.java
+++ b/jdk/test/jdk/jfr/startupargs/TestMemoryOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -493,6 +493,7 @@ public class TestMemoryOptions {
             ProcessBuilder pb;
             if (flightRecorderOptions != null) {
                 pb = ProcessTools.createJavaProcessBuilder(true,
+                                                           "-Xmx256m",
                                                            flightRecorderOptions,
                                                            "-XX:StartFlightRecording",
                                                            SUT.class.getName(),
@@ -500,6 +501,7 @@ public class TestMemoryOptions {
             } else {
                 // default, no FlightRecorderOptions passed
                 pb = ProcessTools.createJavaProcessBuilder(true,
+                                                           "-Xmx256m",
                                                            "-XX:StartFlightRecording",
                                                            SUT.class.getName(),
                                                            tc.getTestName());


### PR DESCRIPTION
Hi All,
I would like to add this bug fix for the bug in jdk/jfr/startupargs/TestMemoryOptions.java. This test contains 24 test cases and fails the "ThreadBufferSizeExceedMemorySize" case.
The cause of this bug is the memory allocation issue, which occurs only on 32-bit Server VM, not on Client VM or 64-bit JDK. The failure happens because Server VM's default heap size reduces available memory space, causing JFR to fail memory allocation.
To resolve this issue, -Xmx256M is explicitly set, matching the Client VM default heap size, ensuring sufficient memory space remains available for JFR.
I believe that this test verifies that the combination of memory options for JFR is valid or invalid and that the MaxHeapSize setting does not affect the verification.
Change has been verified locally, test-fix only, no risk.

Would someone please review this fix?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8352942](https://bugs.openjdk.org/browse/JDK-8352942) needs maintainer approval

### Issue
 * [JDK-8352942](https://bugs.openjdk.org/browse/JDK-8352942): jdk/jfr/startupargs/TestMemoryOptions.java fails with 32-bit build (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/641/head:pull/641` \
`$ git checkout pull/641`

Update a local copy of the PR: \
`$ git checkout pull/641` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/641/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 641`

View PR using the GUI difftool: \
`$ git pr show -t 641`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/641.diff">https://git.openjdk.org/jdk8u-dev/pull/641.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/641#issuecomment-2753649580)
</details>
