### PR TITLE
8345133: Test sun/security/tools/jarsigner/TsacertOptionTest.java failed: Warning found in stdout

### DIFF
--- a/jdk/test/sun/security/tools/jarsigner/TsacertOptionTest.java
+++ b/jdk/test/sun/security/tools/jarsigner/TsacertOptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -110,6 +110,7 @@ public class TsacertOptionTest {
                 "-alias", CA_KEY_ALIAS,
                 "-keystore", KEYSTORE,
                 "-storepass", PASSWORD,
+                "-startdate", "-1M",
                 "-keypass", PASSWORD,
                 "-validity", Integer.toString(VALIDITY),
                 "-infile", "certreq",


### PR DESCRIPTION
Backport for parity with Oracle 11.0.28. Clean except for copyright date and file location, low risk: test only, modified test passes, eliminates warning.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8345133](https://bugs.openjdk.org/browse/JDK-8345133) needs maintainer approval

### Issue
 * [JDK-8345133](https://bugs.openjdk.org/browse/JDK-8345133): Test sun/security/tools/jarsigner/TsacertOptionTest.java failed: Warning found in stdout (**Bug** - P4 - Approved)


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/645/head:pull/645` \
`$ git checkout pull/645`

Update a local copy of the PR: \
`$ git checkout pull/645` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/645/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 645`

View PR using the GUI difftool: \
`$ git pr show -t 645`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/645.diff">https://git.openjdk.org/jdk8u-dev/pull/645.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/645#issuecomment-2787212814)
</details>
