### PR TITLE
8278472: Invalid value set to CANDIDATEFORM structure

### DIFF
--- a/jdk/src/windows/native/sun/windows/awt_Component.cpp
+++ b/jdk/src/windows/native/sun/windows/awt_Component.cpp
@@ -3862,11 +3862,11 @@ void AwtComponent::SetCandidateWindow(int iCandType, int x, int y)
     HIMC hIMC = ImmGetContext(hwnd);
     if (hIMC) {
         CANDIDATEFORM cf;
-        cf.dwStyle = CFS_POINT;
+        cf.dwStyle = CFS_CANDIDATEPOS;
         ImmGetCandidateWindow(hIMC, 0, &cf);
         if (x != cf.ptCurrentPos.x || y != cf.ptCurrentPos.y) {
             cf.dwIndex = iCandType;
-            cf.dwStyle = CFS_POINT;
+            cf.dwStyle = CFS_CANDIDATEPOS;
             cf.ptCurrentPos.x = x;
             cf.ptCurrentPos.y = y;
             cf.rcArea.left = cf.rcArea.top = cf.rcArea.right = cf.rcArea.bottom = 0;


### PR DESCRIPTION
Hi all,

This is a backport of JDK-8278472: Invalid value set to CANDIDATEFORM structure

Except for the fix for Copyright year and the path change, original patch applies cleanly to 8u.
This resolves an issue where the candidate window does not appear when using an IME other than Microsoft IME.

Testing: jdk_desktop tests on Windows Server 2022 (some tests failed, but they failed before this fix was made)

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8278472](https://bugs.openjdk.org/browse/JDK-8278472) needs maintainer approval

### Issue
 * [JDK-8278472](https://bugs.openjdk.org/browse/JDK-8278472): Invalid value set to CANDIDATEFORM structure (**Bug** - P3 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/648/head:pull/648` \
`$ git checkout pull/648`

Update a local copy of the PR: \
`$ git checkout pull/648` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/648/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 648`

View PR using the GUI difftool: \
`$ git pr show -t 648`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/648.diff">https://git.openjdk.org/jdk8u-dev/pull/648.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/648#issuecomment-2829248753)
</details>
