### PR TITLE
8159694: HiDPI, Unity, java/awt/dnd/DropTargetEnterExitTest/MissedDragExitTest.java

### DIFF
--- a/jdk/test/java/awt/dnd/DropTargetEnterExitTest/MissedDragExitTest.java
+++ b/jdk/test/java/awt/dnd/DropTargetEnterExitTest/MissedDragExitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,6 +59,7 @@ public class MissedDragExitTest {
 
     private static void initAndShowUI() {
         f = new Frame("Test frame");
+        f.setUndecorated(true);
         f.setBounds(FRAME_LOCATION,FRAME_LOCATION,FRAME_SIZE,FRAME_SIZE);
 
         final DraggablePanel dragSource = new DraggablePanel();
@@ -101,7 +102,7 @@ public class MissedDragExitTest {
             Util.drag(r,
                     new Point(FRAME_LOCATION + FRAME_SIZE / 3, FRAME_LOCATION + FRAME_SIZE / 3),
                     new Point(FRAME_LOCATION + FRAME_SIZE / 3 * 2, FRAME_LOCATION + FRAME_SIZE / 3 * 2),
-                    InputEvent.BUTTON1_MASK);
+                    InputEvent.BUTTON1_DOWN_MASK);
             Util.waitForIdle(r);
 
             if (!dragExitCalled) {

--- a/jdk/test/java/awt/regtesthelpers/Util.java
+++ b/jdk/test/java/awt/regtesthelpers/Util.java
@@ -323,8 +323,13 @@ public final class Util {
      *     {@code InputEvent.BUTTON3_MASK}
      */
     public static void drag(Robot robot, Point startPoint, Point endPoint, int button) {
-        if (!(button == InputEvent.BUTTON1_MASK || button == InputEvent.BUTTON2_MASK
-                || button == InputEvent.BUTTON3_MASK))
+        if (!(button == InputEvent.BUTTON1_MASK
+                || button == InputEvent.BUTTON2_MASK
+                || button == InputEvent.BUTTON3_MASK
+                || button == InputEvent.BUTTON1_DOWN_MASK
+                || button == InputEvent.BUTTON2_DOWN_MASK
+                || button == InputEvent.BUTTON3_DOWN_MASK
+        ))
         {
             throw new IllegalArgumentException("invalid mouse button");
         }


### PR DESCRIPTION
Hi,

This is a backoport of JDK-8159694: HiDPI, Unity, java/awt/dnd/DropTargetEnterExitTest/MissedDragExitTest.java

Original patch applies cleanly to 8u except for fix for Problemlist and path changes.
This PR is a dependency for #653 . So this PR shoud be integrated before #653 is integrated.

Testing: MissedDragExitTest.java passes on Windows11

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8159694](https://bugs.openjdk.org/browse/JDK-8159694) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8159694](https://bugs.openjdk.org/browse/JDK-8159694): HiDPI, Unity, java/awt/dnd/DropTargetEnterExitTest/MissedDragExitTest.java (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/652/head:pull/652` \
`$ git checkout pull/652`

Update a local copy of the PR: \
`$ git checkout pull/652` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/652/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 652`

View PR using the GUI difftool: \
`$ git pr show -t 652`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/652.diff">https://git.openjdk.org/jdk8u-dev/pull/652.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/652#issuecomment-2878714847)
</details>
