### PR TITLE
8340387: Update OS detection code to recognize Windows Server 2025

### DIFF
--- a/hotspot/src/os/windows/vm/os_windows.cpp
+++ b/hotspot/src/os/windows/vm/os_windows.cpp
@@ -1833,7 +1833,10 @@ void os::win32::print_windows_version(outputStream* st) {
       // - 2016 GA 10/2016 build: 14393
       // - 2019 GA 11/2018 build: 17763
       // - 2022 GA 08/2021 build: 20348
-      if (build_number > 20347) {
+      // - 2025 Preview build   : 26040
+      if (build_number > 26039) {
+        st->print("Server 2025");
+      } else if (build_number > 20347) {
         st->print("Server 2022");
       } else if (build_number > 17762) {
         st->print("Server 2019");

--- a/jdk/src/windows/native/java/lang/java_props_md.c
+++ b/jdk/src/windows/native/java/lang/java_props_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -480,6 +480,8 @@ GetJavaProperties(JNIEnv* env)
          *       where (buildNumber > 17762)
          * Windows Server 2022          10              0  (!VER_NT_WORKSTATION)
          *       where (buildNumber > 20347)
+         * Windows Server 2025          10              0  (!VER_NT_WORKSTATION)
+         *       where (buildNumber > 26039)
          *
          * This mapping will presumably be augmented as new Windows
          * versions are released.
@@ -563,7 +565,10 @@ GetJavaProperties(JNIEnv* env)
                     case  0:
                         /* Windows server 2019 GA 10/2018 build number is 17763 */
                         /* Windows server 2022 build number is 20348 */
-                        if (buildNumber > 20347) {
+                        /* Windows server 2025 Preview build is 26040 */
+                        if (buildNumber > 26039) {
+                            sprops.os_name = "Windows Server 2025";
+                        } else if (buildNumber > 20347) {
                             sprops.os_name = "Windows Server 2022";
                         } else if (buildNumber > 17676) {
                             sprops.os_name = "Windows Server 2019";


### PR DESCRIPTION
Backport for parity with Oracle.

Almost clean backport after adjusting paths. The only conflict is in copyright years (in java_props_md.c), applied manually.

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340387](https://bugs.openjdk.org/browse/JDK-8340387) needs maintainer approval

### Issue
 * [JDK-8340387](https://bugs.openjdk.org/browse/JDK-8340387): Update OS detection code to recognize Windows Server 2025 (**Bug** - P3 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/655/head:pull/655` \
`$ git checkout pull/655`

Update a local copy of the PR: \
`$ git checkout pull/655` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/655/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 655`

View PR using the GUI difftool: \
`$ git pr show -t 655`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/655.diff">https://git.openjdk.org/jdk8u-dev/pull/655.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/655#issuecomment-2896961424)
</details>
