### PR TITLE
Backport 46251bc6e248a19e8d78173ff8d0502c68ee1acb

### DIFF
--- a/jdk/src/share/classes/javax/swing/plaf/basic/BasicOptionPaneUI.java
+++ b/jdk/src/share/classes/javax/swing/plaf/basic/BasicOptionPaneUI.java
@@ -83,6 +83,7 @@ public class BasicOptionPaneUI extends OptionPaneUI {
     public static final int MinimumHeight = 90;
 
     private static String newline;
+    private static int recursionCount;
 
     /**
      * <code>JOptionPane</code> that the receiver is providing the
@@ -396,7 +397,7 @@ public class BasicOptionPaneUI extends OptionPaneUI {
                 if (nl == 0) {
                     JPanel breakPanel = new JPanel() {
                         public Dimension getPreferredSize() {
-                            Font       f = getFont();
+                            Font f = getFont();
 
                             if (f != null) {
                                 return new Dimension(1, f.getSize() + 2);
@@ -411,8 +412,14 @@ public class BasicOptionPaneUI extends OptionPaneUI {
                     addMessageComponents(container, cons, s.substring(0, nl),
                                       maxll, false);
                 }
+                // Prevent recursion of more than
+                // 200 successive newlines in a message
+                if (recursionCount++ > 200) {
+                    recursionCount = 0;
+                    return;
+                }
                 addMessageComponents(container, cons, s.substring(nl + nll), maxll,
-                                  false);
+                                     false);
 
             } else if (len > maxll) {
                 Container c = Box.createVerticalBox();

--- a/jdk/test/javax/swing/JOptionPane/TestOptionPaneStackOverflow.java
+++ b/jdk/test/javax/swing/JOptionPane/TestOptionPaneStackOverflow.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+   @bug 8224267
+   @key headful
+   @summary Verifies if StackOverflowError is not thrown for multiple newlines
+   @run main TestOptionPaneStackOverflow
+ */
+
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JOptionPane;
+import javax.swing.SwingUtilities;
+
+public class TestOptionPaneStackOverflow
+{
+    static JFrame frame;
+
+    public static void main(String[] argv) throws Exception
+    {
+        try {
+            String message = java.nio.CharBuffer.allocate(5000).toString().
+                                  replace('\0','\n');
+            SwingUtilities.invokeAndWait(() -> {
+                frame = new JFrame();
+                JOptionPane optionPane = new JOptionPane();
+                optionPane.createDialog(frame, null);
+                optionPane.setMessage(message);
+            });
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
Hi all,

This is a parity backport with Oracle's 8u461, OpenJDK 8u462 is affected. The commit [46251bc6](https://github.com/openjdk/jdk/commit/46251bc6e248a19e8d78173ff8d0502c68ee1acb) didn't apply cleanly as [JDK-8049870](https://bugs.openjdk.org/browse/JDK-8049870) hasn't been backported to jdk8u-dev. The paths have been changed to the 8u path scheme. The test passes with the fix and fails otherwise.

Thanks!