### PR TITLE
Backport 9b8b6695108762063f96a275d9567bed72b88126

### DIFF
--- a/jdk/test/jdk/lambda/separate/Compiler.java
+++ b/jdk/test/jdk/lambda/separate/Compiler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,7 +54,7 @@ public class Compiler {
     private static final AtomicInteger counter = new AtomicInteger();
     private static final String targetDir =
         System.getProperty("lambda.separate.targetDirectory",
-            System.getProperty("java.io.tmpdir") + File.separator + "gen-separate");
+            "." + File.separator + "gen-separate");
     private static final File root = new File(targetDir);
     private static ConcurrentHashMap<String,File> cache =
             new ConcurrentHashMap<>();
@@ -189,7 +189,7 @@ public class Compiler {
                 StandardLocation.CLASS_OUTPUT, Arrays.asList(destDir));
         } catch (IOException e) {
             throw new RuntimeException(
-                "IOException encountered during compilation");
+                "IOException encountered during compilation: " + e.getMessage(), e);
         }
         Boolean result = ct.call();
         if (result == Boolean.FALSE) {


### PR DESCRIPTION
This backport was previously submitted in https://github.com/openjdk/jdk8u-dev/pull/610 and was [approved](https://bugs.openjdk.org/browse/JDK-8044051) at the time. However, since the original patch has been abandoned and the original author @yaqsun  is currently on vacation, I would like to open a new PR to move this backport forward.

As described in https://github.com/openjdk/jdk8u-dev/pull/610, the patch applies cleanly. It only affects test cases. Low risk. Related tests have passed.
