### PR TITLE
8360166: CodeSource.implies(): Wildcard host fails to imply specific host

### DIFF
--- a/jdk/src/share/classes/java/net/SocketPermission.java
+++ b/jdk/src/share/classes/java/net/SocketPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -928,7 +928,7 @@ public final class SocketPermission extends Permission
 
             // check and see if we have any wildcards...
             if (this.wildcard || that.wildcard) {
-                // if they are both wildcards, return true iff
+                // if they are both wildcards, return true if
                 // that's cname ends with this cname (i.e., *.sun.com
                 // implies *.eng.sun.com)
                 if (this.wildcard && that.wildcard)
@@ -938,12 +938,12 @@ public final class SocketPermission extends Permission
                 if (that.wildcard)
                     return false;
 
-                // this is a wildcard, lets see if that's cname ends with
-                // it...
-                if (that.cname == null) {
-                    that.getCanonName();
+                // if "that" was initialized with an IP address
+                // return false
+                if (that.init_with_ip) {
+                    return false;
                 }
-                return (that.cname.endsWith(this.cname));
+                return (that.hostname.endsWith(this.cname));
             }
 
             // comapare IP addresses

--- a/jdk/test/java/security/CodeSource/Implies.java
+++ b/jdk/test/java/security/CodeSource/Implies.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 4866847 7152564 7155693
+ * @bug 4866847 7152564 7155693 8360166
  * @summary various CodeSource.implies tests
  */
 

--- a/jdk/test/java/security/CodeSource/Implies.java
+++ b/jdk/test/java/security/CodeSource/Implies.java
@@ -47,6 +47,16 @@ public class Implies {
         // port check should match default port of thatURL
         testImplies(thisURL, thatURL, true);
 
+        thisURL = new URL("http", "*.example.com", "/file");
+        thatURL = new URL("HTTP", "www.example.com", "/file");
+        // wildcard check should match specific hostname of thatURL
+        testImplies(thisURL, thatURL, true);
+
+        thisURL = new URL("http", "*.example.com", "/file");
+        thatURL = new URL("HTTP", "127.0.0.1", "/file");
+        // wildcard check should not match url with ip
+        testImplies(thisURL, thatURL, false);
+
         System.out.println("test passed");
     }
 


### PR DESCRIPTION
Please review this PR which use hostname not cname to check imply. And alse add test case.

If there are any problems please let me know and I will correct them promptly.