### PR TITLE
8358568: C2 compilation hits "must have a monitor" assert with -XX:-GenerateSynchronizationCode

### DIFF
--- a/hotspot/src/share/vm/opto/locknode.cpp
+++ b/hotspot/src/share/vm/opto/locknode.cpp
@@ -198,7 +198,8 @@ void Parse::do_monitor_enter() {
 //------------------------------do_monitor_exit--------------------------------
 void Parse::do_monitor_exit() {
   kill_dead_locals();
-
+  if( !GenerateSynchronizationCode )
+    return;
   pop();                        // Pop oop to unlock
   // Because monitors are guaranteed paired (else we bail out), we know
   // the matching Lock for this Unlock.  Hence we know there is no need


### PR DESCRIPTION
This PR fixes JDK-8358568, a JVM crash triggered when running with -XX:-GenerateSynchronizationCode

Problem：
When synchronization code generation is disabled by -XX:-GenerateSynchronizationCode, the compiler’s do_monitor_exit() method still tries to access monitor objects without checking if any monitors exist.This causes an assertion failure and JVM crash.

Root Cause：
Parse::do_monitor_exit() calls shared_unlock() using monitor info unconditionally,but with GenerateSynchronizationCode disabled, no monitor info is available, leading to invalid access.

Fix
Add a check in do_monitor_exit() to skip monitor unlocking if GenerateSynchronizationCode is false, avoiding invalid monitor access and preventing the crash.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8358568](https://bugs.openjdk.org/browse/JDK-8358568) needs maintainer approval

### Issue
 * [JDK-8358568](https://bugs.openjdk.org/browse/JDK-8358568): C2 compilation hits "must have a monitor" assert with -XX:-GenerateSynchronizationCode (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/664/head:pull/664` \
`$ git checkout pull/664`

Update a local copy of the PR: \
`$ git checkout pull/664` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/664/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 664`

View PR using the GUI difftool: \
`$ git pr show -t 664`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/664.diff">https://git.openjdk.org/jdk8u-dev/pull/664.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/664#issuecomment-3026414423)
</details>
