### PR TITLE
8358538: Update GHA Windows runner to 2025

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -676,7 +676,7 @@ jobs:
 
   windows_x64_build:
     name: Windows x64
-    runs-on: "windows-2019"
+    runs-on: "windows-2025"
     needs: prerequisites
     if: needs.prerequisites.outputs.should_run != 'false' && needs.prerequisites.outputs.platform_windows_x64 != 'false'
 
@@ -854,7 +854,7 @@ jobs:
 
   windows_x86_build:
     name: Windows x86
-    runs-on: "windows-2019"
+    runs-on: "windows-2025"
     needs: prerequisites
     if: needs.prerequisites.outputs.should_run != 'false' && needs.prerequisites.outputs.platform_windows_x86 != 'false'
 
@@ -1028,7 +1028,7 @@ jobs:
 
   windows_x64_test:
     name: Windows x64
-    runs-on: "windows-2019"
+    runs-on: "windows-2025"
     needs:
       - prerequisites
       - windows_x64_build
@@ -1189,7 +1189,7 @@ jobs:
 
   windows_x86_test:
     name: Windows x86
-    runs-on: "windows-2019"
+    runs-on: "windows-2025"
     needs:
       - prerequisites
       - windows_x86_build


### PR DESCRIPTION
Backport of [JDK-8358538](https://bugs.openjdk.org/browse/JDK-8358538) from JDK11 that uses the new `windows-2025` GHA runner, that is replacing the old `windows-2019` GHA runner since 2025-06-30. The backport is not clean, since the GHA configuration is completely different from JDK11.

JDK8 still builds with Visual Studio 2017, so there's no need to backport [JDK-8360042](https://bugs.openjdk.org/browse/JDK-8360042), nor to change any other setting.

Build should be clean, but for the `jdk_security_infra` test failures, that are well known to fail in JDK8 (as they should in JDK11), and are unrelated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8358538](https://bugs.openjdk.org/browse/JDK-8358538) needs maintainer approval

### Issue
 * [JDK-8358538](https://bugs.openjdk.org/browse/JDK-8358538): Update GHA Windows runner to 2025 (**Bug** - P4 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/665/head:pull/665` \
`$ git checkout pull/665`

Update a local copy of the PR: \
`$ git checkout pull/665` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/665/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 665`

View PR using the GUI difftool: \
`$ git pr show -t 665`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/665.diff">https://git.openjdk.org/jdk8u-dev/pull/665.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/665#issuecomment-3032174525)
</details>
