### PR TITLE
Backport 6e48caf2507d4a45e1861ee699a32a5e459d70c2

### DIFF
--- a/jdk/test/java/util/concurrent/ConcurrentHashMap/ConcurrentAssociateTest.java
+++ b/jdk/test/java/util/concurrent/ConcurrentHashMap/ConcurrentAssociateTest.java
@@ -120,7 +120,8 @@ public class ConcurrentAssociateTest {
             }
         };
 
-        int ps = Runtime.getRuntime().availableProcessors();
+        // Bound concurrency to avoid degenerate performance
+        int ps = Math.min(Runtime.getRuntime().availableProcessors(), 32);
         Stream<CompletableFuture> runners = IntStream.range(0, ps)
                 .mapToObj(i -> sr.get())
                 .map(CompletableFuture::runAsync);


### PR DESCRIPTION
Hi all,
  This is clean backport to fix the test run time outed which the tested machine has huge cpu core number. Change has been verified locally, test-fix only, no risk.