### PR TITLE
8056283: @ignore tools/javac/defaultMethods/Assertions.java until JDK-8047675 is fixed

### DIFF
--- a/langtools/test/tools/javac/defaultMethods/Assertions.java
+++ b/langtools/test/tools/javac/defaultMethods/Assertions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2014, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import java.util.Set;
 /*
  * @test
  * @bug 8025141
+ * @ignore 8047675 test fails if run with assertions enabled in jtreg
  * @summary Interfaces must not contain non-public fields, ensure $assertionsDisabled
  *          is not generated into an interface
  * @compile Assertions.java


### PR DESCRIPTION
Hi all,

I want to backport [JDK-8047675](https://bugs.openjdk.org/browse/JDK-8047675) to jdk8u-dev, but I found that this PR is the prefixed PR to backport [JDK-8047675](https://bugs.openjdk.org/browse/JDK-8047675) to jdk8u-dev.

This PR only add `@ignore` derictive to disable the test. Test-fix only, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8056283](https://bugs.openjdk.org/browse/JDK-8056283) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8056283](https://bugs.openjdk.org/browse/JDK-8056283): @<!---->ignore tools/javac/defaultMethods/Assertions.java until JDK-8047675 is fixed (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/669/head:pull/669` \
`$ git checkout pull/669`

Update a local copy of the PR: \
`$ git checkout pull/669` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/669/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 669`

View PR using the GUI difftool: \
`$ git pr show -t 669`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/669.diff">https://git.openjdk.org/jdk8u-dev/pull/669.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/669#issuecomment-3072918986)
</details>
