### PR TITLE
Backport e61f97d3ac3ae1cc3f807abcc10d3f405ab69852

### DIFF
--- a/jdk/test/security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java
+++ b/jdk/test/security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java
@@ -612,20 +612,20 @@ public class CAInterop {
                     "https://revoked.sfig2.catest.starfieldtech.com");
 
             case "globalsigneccrootcar4":
-                    return new CATestURLs("https://good.gsr4.demo.pki.goog",
-                    "https://revoked.gsr4.demo.pki.goog");
+                    return new CATestURLs("https://good.gsr4.demosite.pki.goog",
+                    "https://revoked.gsr4.demosite.pki.goog");
             case "gtsrootcar1":
-                    return new CATestURLs("https://good.gtsr1.demo.pki.goog",
-                    "https://revoked.gtsr1.demo.pki.goog");
+                    return new CATestURLs("https://good.gtsr1.demosite.pki.goog",
+                    "https://revoked.gtsr1.demosite.pki.goog");
             case "gtsrootcar2":
-                    return new CATestURLs("https://good.gtsr2.demo.pki.goog",
-                    "https://revoked.gtsr2.demo.pki.goog");
+                    return new CATestURLs("https://good.gtsr2.demosite.pki.goog",
+                    "https://revoked.gtsr2.demosite.pki.goog");
             case "gtsrootecccar3":
-                    return new CATestURLs("https://good.gtsr3.demo.pki.goog",
-                    "https://revoked.gtsr3.demo.pki.goog");
+                    return new CATestURLs("https://good.gtsr3.demosite.pki.goog",
+                    "https://revoked.gtsr3.demosite.pki.goog");
             case "gtsrootecccar4":
-                    return new CATestURLs("https://good.gtsr4.demo.pki.goog",
-                    "https://revoked.gtsr4.demo.pki.goog");
+                    return new CATestURLs("https://good.gtsr4.demosite.pki.goog",
+                    "https://revoked.gtsr4.demosite.pki.goog");
 
             case "microsoftecc2017":
                     return new CATestURLs("https://acteccroot2017.pki.microsoft.com",


### PR DESCRIPTION
This fixes failing Google cacert tests. It should leave us with just two failing (`digicerttlsrsarootg5`, `quovadisrootca2g3`), which we can fix or exclude separately. The backport applies cleanly from 11u after the paths are shuffled.

Testing shows that the tests now pass:
~~~
Passed: security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#globalsigne46
Passed: security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#globalsigneccrootcar4
Passed: security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#globalsignr46
Passed: security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#globalsignrootcar6
Passed: security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#godaddyrootg2ca
Passed: security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#gtsrootcar1
Passed: security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#gtsrootcar2
Passed: security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#gtsrootecccar3
Passed: security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#gtsrootecccar4
~~~