### PR TITLE
8365560: [8u] ppc64le MaxRAM default is too low at 4GiB

### DIFF
--- a/hotspot/src/cpu/ppc/vm/c2_globals_ppc.hpp
+++ b/hotspot/src/cpu/ppc/vm/c2_globals_ppc.hpp
@@ -83,7 +83,7 @@ define_pd_global(intx, ReservedCodeCacheSize,        256*M);
 define_pd_global(intx, CodeCacheExpansionSize,       64*K);
 
 // Ergonomics related flags
-define_pd_global(uint64_t,MaxRAM,                    4ULL*G);
+define_pd_global(uint64_t,MaxRAM,                    128ULL*G);
 define_pd_global(uintx, CodeCacheMinBlockLength,     4);
 define_pd_global(uintx, CodeCacheMinimumUseSpace,    400*K);
 


### PR DESCRIPTION
Bump the default value of MaxRAM from 4GiB to 128GiB on PPC64, aligning with the other 64bit ports.

This change was made as part of a bundle of clean-ups in JDK11 (JDK-8194814), but here I do not attempt to backport the other changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8365560](https://bugs.openjdk.org/browse/JDK-8365560) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365560](https://bugs.openjdk.org/browse/JDK-8365560): [8u] ppc64le MaxRAM default is too low at 4GiB (**Bug** - P4 - Approved)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/675/head:pull/675` \
`$ git checkout pull/675`

Update a local copy of the PR: \
`$ git checkout pull/675` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/675/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 675`

View PR using the GUI difftool: \
`$ git pr show -t 675`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/675.diff">https://git.openjdk.org/jdk8u-dev/pull/675.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/675#issuecomment-3188907495)
</details>
