### PR TITLE
8366112: [8u] GHA: Fix broken installation of Windows SDK

### DIFF
--- a/.github/workflows/freetype.vcxproj
+++ b/.github/workflows/freetype.vcxproj
@@ -78,7 +78,7 @@
 -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{78B079BD-9FC7-4B9E-B4A6-96DA0F00248B}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -798,7 +798,7 @@ jobs:
           'install --productId Microsoft.VisualStudio.Product.Community --channelId VisualStudio.15.Release
           --add Microsoft.VisualStudio.Workload.NativeDesktop
           --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64
-          --add Microsoft.VisualStudio.Component.Windows10SDK.17763
+          --add Microsoft.VisualStudio.Component.Windows10SDK.19041
           --quiet --wait'
 
       - name: Fix OpenJDK permissions


### PR DESCRIPTION
Installation of Windows SDK 10 by VS 2017 [no longer works](https://github.com/kvergizova/jdk8u-dev/actions/runs/17135435204/job/48610166513). This causes configure failure for windows x64 builds (during freetype configuration):

```
configure: User specified --with-freetype-src but building freetype failed. (see freetype.log for build results)
```

Actual failure is (from freetype.log):
```
C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\VC\VCTargets\Microsoft.Cpp.WindowsSDK.targets(46,5): error MSB8036: The Windows SDK version 10.0.17763.0 was not found. Install the required version of Windows SDK or change the SDK version in the project property pages or by right-clicking the solution and selecting "Retarget solution". [D:\a\jdk8u-dev\jdk8u-dev\freetype\builds\windows\vc2010\freetype.vcxproj]
```

While VS 2017 shows no installation errors, it seems like requested SDK version (17763) is no longer available and need to be updated. (VS 2017 installer apparently downloads components from the internet)

Fix:
When checked manually in Windows VM, `19041` was only Windows SDK 10 version available in VS2017 installer, so I switched to that version.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8366112](https://bugs.openjdk.org/browse/JDK-8366112) needs maintainer approval

### Issue
 * [JDK-8366112](https://bugs.openjdk.org/browse/JDK-8366112): [8u] GHA: Fix broken installation of Windows SDK (**Bug** - P4 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/681/head:pull/681` \
`$ git checkout pull/681`

Update a local copy of the PR: \
`$ git checkout pull/681` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/681/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 681`

View PR using the GUI difftool: \
`$ git pr show -t 681`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/681.diff">https://git.openjdk.org/jdk8u-dev/pull/681.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/681#issuecomment-3221083071)
</details>
