### PR TITLE
Backport 19ead83208381512fa2c89673b8d992b6106cc1c

### DIFF
--- a/hotspot/test/ProblemList.txt
+++ b/hotspot/test/ProblemList.txt
@@ -68,3 +68,8 @@ compiler/rtm/locking/TestUseRTMAfterLockInflation.java 8183263 generic-x64,gener
 compiler/rtm/locking/TestUseRTMForInflatedLocks.java 8183263 generic-x64,generic-i586
 compiler/rtm/locking/TestUseRTMForStackLocks.java 8183263 generic-x64,generic-i586
 compiler/rtm/method_options/TestUseRTMLockElidingOption.java 8183263 generic-x64,generic-i586
+
+
+# :hotspot_gc
+
+gc/survivorAlignment/TestPromotionFromSurvivorToTenuredAfterMinorGC.java 8177765 generic-all


### PR DESCRIPTION
Hi all,

I found that gc/survivorAlignment/TestPromotionFromSurvivorToTenuredAfterMinorGC.java intermittent fails which has been fixed by jdk13 in [JDK-8218049](https://bugs.openjdk.org/browse/JDK-8218049). I think this fixed PR do not suitable to backport from jdk13 to jdk8u. So I want to backport [JDK-8186149](https://bugs.openjdk.org/browse/JDK-8186149) to quarantine this fragile test.

Backport not clean because there are many different context between jdk8u and jdk13 for hotspot/test/ProblemList.txt

Only touch the Problemlist, no risk.