### PR TITLE
8353657: [8u] Test tools/launcher/VersionCheck.java fails with debug build

### DIFF
--- a/jdk/test/tools/launcher/TestHelper.java
+++ b/jdk/test/tools/launcher/TestHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -107,6 +107,7 @@ public class TestHelper {
     static final String CLASS_FILE_EXT = ".class";
     static final String JAR_FILE_EXT   = ".jar";
     static final String EXE_FILE_EXT   = ".exe";
+    static final String DEBUGINFO_FILE_EXT   = ".debuginfo";
     static final String JLDEBUG_KEY     = "_JAVA_LAUNCHER_DEBUG";
     static final String EXPECTED_MARKER = "TRACER_MARKER:About to EXEC";
     static final String TEST_PREFIX     = "###TestError###: ";

--- a/jdk/test/tools/launcher/VersionCheck.java
+++ b/jdk/test/tools/launcher/VersionCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -245,6 +245,9 @@ public class VersionCheck extends TestHelper {
             }
             String name = pathname.getName().toLowerCase();
             if (isWindows && !name.endsWith(EXE_FILE_EXT)) {
+                return false;
+            }
+            if(name.endsWith(DEBUGINFO_FILE_EXT)) {
                 return false;
             }
             for (String x : exclude) {


### PR DESCRIPTION
Hi all,

Test tools/launcher/VersionCheck.java fails with fastdebug build which report 'jstack.debuginfo: cannot execute binary file'. This failure fixed by [JDK-8237192](https://bugs.openjdk.org/browse/JDK-8237192) in jdk15, only a subset of [JDK-8237192](https://bugs.openjdk.org/browse/JDK-8237192) to fix this test failure. So it's not suitable to backport [JDK-8237192](https://bugs.openjdk.org/browse/JDK-8237192) to jdk8u-dev, then I create this PR to fix this testbug.

This PR skip all the `*.debuginfo` files to check the '-version' or '-J-version'. Change has been verified localy, test-fix only, no risk.