### PR TITLE
Backport 4c9eaddaef83c6ba30e27ae3e0d16caeeec206cb

### DIFF
--- a/hotspot/test/compiler/unsafe/TestMisalignedUnsafeAccess.java
+++ b/hotspot/test/compiler/unsafe/TestMisalignedUnsafeAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2020, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/jdk/test/javax/net/ssl/ServerName/EndingDotHostname.java
+++ b/jdk/test/javax/net/ssl/ServerName/EndingDotHostname.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -247,4 +247,3 @@ public class EndingDotHostname {
         sslIS.read();
     }
 }
-

--- a/jdk/test/javax/net/ssl/templates/SSLExampleCert.java
+++ b/jdk/test/javax/net/ssl/templates/SSLExampleCert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/jdk/test/javax/security/auth/callback/PasswordCallback/CheckCleanerBound.java
+++ b/jdk/test/javax/security/auth/callback/PasswordCallback/CheckCleanerBound.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,4 +58,3 @@ public final class CheckCleanerBound {
         }
     }
 }
-

--- a/jdk/test/javax/security/auth/callback/PasswordCallback/PasswordCleanup.java
+++ b/jdk/test/javax/security/auth/callback/PasswordCallback/PasswordCleanup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2022, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,4 +49,3 @@ public final class PasswordCleanup {
         }
     }
 }
-

--- a/jdk/test/jdk/internal/platform/docker/GetFreeSwapSpaceSize.java
+++ b/jdk/test/jdk/internal/platform/docker/GetFreeSwapSpaceSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2020, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/jdk/test/jdk/internal/platform/docker/TestGetFreeSwapSpaceSize.java
+++ b/jdk/test/jdk/internal/platform/docker/TestGetFreeSwapSpaceSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (C) 2020, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Please review this backport of `JDK-8364597: Replace THL A29 Limited with Tencent`.
This backport is not clean, because most files don't exist in jdk8u,
and the copyright years in the following files are different between the repos.
- jdk/test/jdk/internal/platform/docker/GetFreeSwapSpaceSize.java
- jdk/test/jdk/internal/platform/docker/TestGetFreeSwapSpaceSize.java