### PR TITLE
8240226: DeflateIn_InflateOut.java test incorrectly assumes size of compressed file

### DIFF
--- a/jdk/test/java/util/zip/DeflateIn_InflateOut.java
+++ b/jdk/test/java/util/zip/DeflateIn_InflateOut.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,8 +42,6 @@ public class DeflateIn_InflateOut {
     private static InflaterOutputStream ios;
 
     private static void reset() {
-        new Random(new Date().getTime()).nextBytes(data);
-
         bais = new ByteArrayInputStream(data);
         dis = new DeflaterInputStream(bais);
 
@@ -218,6 +216,8 @@ public class DeflateIn_InflateOut {
 
 
     public static void realMain(String[] args) throws Throwable {
+        new Random(new Date().getTime()).nextBytes(data);
+
         ArrayReadWrite();
 
         ArrayReadByteWrite();


### PR DESCRIPTION
`java/util/zip/DeflateIn_InflateOut.java` failed with a system zlib.
The backport is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8240226](https://bugs.openjdk.org/browse/JDK-8240226) needs maintainer approval

### Issue
 * [JDK-8240226](https://bugs.openjdk.org/browse/JDK-8240226): DeflateIn_InflateOut.java test incorrectly assumes size of compressed file (**Bug** - P4 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/698/head:pull/698` \
`$ git checkout pull/698`

Update a local copy of the PR: \
`$ git checkout pull/698` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/698/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 698`

View PR using the GUI difftool: \
`$ git pr show -t 698`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/698.diff">https://git.openjdk.org/jdk8u-dev/pull/698.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/698#issuecomment-3305752504)
</details>
