### PR TITLE
8351359: OperatingSystemMXBean: values from getCpuLoad and getProcessCpuLoad are stale after 24.8 days (Windows)

### DIFF
--- a/jdk/src/windows/native/sun/management/OperatingSystemImpl.c
+++ b/jdk/src/windows/native/sun/management/OperatingSystemImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/jdk/src/windows/native/sun/management/OperatingSystemImpl.c
+++ b/jdk/src/windows/native/sun/management/OperatingSystemImpl.c
@@ -215,7 +215,7 @@ static PdhLookupPerfNameByIndexFunc PdhLookupPerfNameByIndex_i;
  */
 typedef struct {
     HQUERY      query;
-    uint64_t    lastUpdate; // Last time query was updated (ticks)
+    uint64_t    lastUpdate; // Last time query was updated (millis)
 } UpdateQueryS, *UpdateQueryP;
 
 // Min time between query updates (ticks)
@@ -993,7 +993,7 @@ bindPdhFunctionPointers(HMODULE h) {
  */
 static int
 getPerformanceData(UpdateQueryP query, HCOUNTER c, PDH_FMT_COUNTERVALUE* value, DWORD format) {
-    clock_t now = clock();
+    uint64_t now = GetTickCount64();
 
     /*
      * Need to limit how often we update the query

--- a/jdk/src/windows/native/sun/management/OperatingSystemImpl.c
+++ b/jdk/src/windows/native/sun/management/OperatingSystemImpl.c
@@ -218,7 +218,7 @@ typedef struct {
     uint64_t    lastUpdate; // Last time query was updated (millis)
 } UpdateQueryS, *UpdateQueryP;
 
-// Min time between query updates (ticks)
+// Min time between query updates (millis)
 static const int MIN_UPDATE_INTERVAL = 500;
 
 /*


### PR DESCRIPTION
Hi,

It's a clean backport of JDK-8351359.
I didn't include `#include <sysinfoapi.h>` as it is in [the original commit](https://github.com/openjdk/jdk/commit/900b3ff7ee933520efe2438fb7c841a4e6a93d17) because of compilation problem.
Instead of that, there is already included `windows.h` that contains the `GetTickCount64()` function. It's redundant to include `sysinfoapi.h`.
The changes are related to Windows only.

Testing:
- manual testing code that calls `getProcessCpuLoad()` on windows server 2025, intel cpu
- testing x86 and x64 builds
- Pre-submit tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8351359](https://bugs.openjdk.org/browse/JDK-8351359) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351359](https://bugs.openjdk.org/browse/JDK-8351359): OperatingSystemMXBean: values from getCpuLoad and getProcessCpuLoad are stale after 24.8 days (Windows) (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/701/head:pull/701` \
`$ git checkout pull/701`

Update a local copy of the PR: \
`$ git checkout pull/701` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/701/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 701`

View PR using the GUI difftool: \
`$ git pr show -t 701`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/701.diff">https://git.openjdk.org/jdk8u-dev/pull/701.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/701#issuecomment-3453286359)
</details>
