### PR TITLE
Backport c240356dba403e2864b1c21f9133cbc19bb6cbcb

### DIFF
--- a/jdk/test/java/net/BindException/Test.java
+++ b/jdk/test/java/net/BindException/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
  /*
  * @test
  * @bug 4417734
+ * @key intermittent
  * @summary Test that we get a BindException in all expected combinations
  */
 import java.net.*;


### PR DESCRIPTION
Hi all,

I want to backport JDK-8153147 to mark java/net/BindException/Test.java as intermittently failing. The `@key intermittent` will enable this test disable or auto rerun when fails for some setups.