### PR TITLE
8303215: Make thread stacks not use huge pages

### DIFF
--- a/hotspot/src/os_cpu/linux_aarch64/vm/globals_linux_aarch64.hpp
+++ b/hotspot/src/os_cpu/linux_aarch64/vm/globals_linux_aarch64.hpp
@@ -29,10 +29,18 @@
 // (see globals.hpp)
 
 define_pd_global(bool, DontYieldALot,            false);
-define_pd_global(intx, ThreadStackSize,          2048); // 0 => use system default
-define_pd_global(intx, VMThreadStackSize,        2048);
 
-define_pd_global(intx, CompilerThreadStackSize,  0);
+// Set default stack sizes < 2MB so as to prevent stacks from getting
+// large-page aligned and backed by THPs on systems where 2MB is the
+// default huge page size. For non-JavaThreads, glibc may add an additional
+// guard page to the total stack size, so to keep the default sizes same
+// for all the following flags, we set them to 2 pages less than 2MB. On
+// systems where 2MB is the default large page size, 4KB is most commonly
+// the regular page size.
+define_pd_global(intx, ThreadStackSize,          2040); // 0 => use system default
+define_pd_global(intx, VMThreadStackSize,        2040);
+
+define_pd_global(intx, CompilerThreadStackSize,  2040);
 
 define_pd_global(uintx,JVMInvokeMethodSlack,     8192);
 

--- a/hotspot/src/os_cpu/linux_aarch64/vm/globals_linux_aarch64.hpp
+++ b/hotspot/src/os_cpu/linux_aarch64/vm/globals_linux_aarch64.hpp
@@ -40,7 +40,7 @@ define_pd_global(bool, DontYieldALot,            false);
 define_pd_global(intx, ThreadStackSize,          2040); // 0 => use system default
 define_pd_global(intx, VMThreadStackSize,        2040);
 
-define_pd_global(intx, CompilerThreadStackSize,  2040);
+define_pd_global(intx, CompilerThreadStackSize,  0);
 
 define_pd_global(uintx,JVMInvokeMethodSlack,     8192);
 


### PR DESCRIPTION
Hi All,

I would like to backport the fix for bug JDK-8303215 to JDK 8. This bug addresses an issue with Transparent Huge Pages (THP) and thread stack allocation.
This fix is unclean, but almost clean backport from jdk11.

1. Backport:
The fix is almost clean from jdk11, but there is a slight difference.

- os_linux.cpp
Since JDK 8 does not include JDK-8183552, we need to add one more include statement. JDK-8183552 will likely not be backported to 8u.

- globals_linux_aarch64.hpp
In JDK 11, `CompilerThreadStackSize` is set to 2048, whereas JDK 8 originally sets it to `0`. This change to 2048 was introduced in JDK-8140520. Since JDK-8140520 is likely not directly related to this fix, I have excluded it from this fix and changed `CompilerThreadStackSize` to 2040.

2. Bug Reproduction:
The bug was successfully reproduced in Linux x86_64 with THP enabled (/sys/kernel/mm/transparent_hugepage/enabled = always).
Reproduction was confirmed using the following dummy thread program:
```
public class ThreadStackHugePageTest {
        public static void main(String[] args) {
                final int NUM_THREADS = 1000;
                final long SLEEP_SECONDS = 3600;
                final long SLEEP_MILISECONDS = SLEEP_SECONDS * 1000;

                List<Thread> threads = new ArrayList<>();

                for (int i = 0; i < NUM_THREADS; i++) {
                        Runnable task = () -> {
                                try {
                                        Thread.sleep(SLEEP_MILISECONDS);
                                } catch (InterruptedException e) {
                                        Thread.currentThread().interrupt();
                                }
                        };

                        Thread thread = new Thread(task);
                        threads.add(thread);

                        thread.start();
                }

                System.out.println("all threads are started");

                for (Thread thread : threads) {
                        try {
                                thread.join();
                        } catch (InterruptedException e) {
                                Thread.currentThread().interrupt();
                        }
                }
        }
}
```
The fix significantly reduces the number of anonymous regions with fully occupied RSS.

3. Regression Testing:
I ran the test/hotspot tests on Linux x64 as a regression test. No failures were found.

Thank you.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))
- \[x\] [JDK-8303215](https://bugs.openjdk.org/browse/JDK-8303215) needs maintainer approval

### Issue
 * [JDK-8303215](https://bugs.openjdk.org/browse/JDK-8303215): Make thread stacks not use huge pages (**Enhancement** - P3 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**) Review applies to [87b748cb](https://git.openjdk.org/jdk8u-dev/pull/746/files/87b748cb2c6983ec6740595884e18ca0bcc11401)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/746/head:pull/746` \
`$ git checkout pull/746`

Update a local copy of the PR: \
`$ git checkout pull/746` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/746/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 746`

View PR using the GUI difftool: \
`$ git pr show -t 746`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/746.diff">https://git.openjdk.org/jdk8u-dev/pull/746.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/746#issuecomment-3759779088)
</details>
