### PR TITLE
8336451: [11u] GHA macos-13 and macos-15 builders are unable to resolve local hostname

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -1533,6 +1533,12 @@ jobs:
       - name: Select Xcode version
         run: sudo xcode-select --switch /Applications/Xcode_14.3.1.app/Contents/Developer
 
+      # Fixes JDK-8336451
+      - name: 'Update /etc/hosts on macos'
+        run: |
+          echo -e "127.0.0.1     $(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
+          echo -e "" | sudo tee -a /etc/hosts
+
       - name: Run tests
         run: >
           chmod +x "${HOME}/jtreg/bin/jtreg" &&


### PR DESCRIPTION
Another GHA work-around. Sometimes GHA tests on MacOSX fails with something like:

```
VM initialization failed for: /Users/runner/jdk-macos-x64/jdk-1.8.0-internal+0_osx-x64_bin/j2sdk-image/jre/bin/java -classpath /Users/runner/work/jdk8u-dev/jdk8u-dev/test-results/testoutput/jdk_tier1/JTwork/classes/com/sun/jdi -Xdebug -Xrunjdwp:transport=dt_socket,address=sjc20-cw752-2deed029-f22c-4b58-be22-6c2b8db93551-8E6FDEE10350.local:49673,suspend=y AccessSpecifierTarg
```

For test:
```
com/sun/jdi/RedefineCrossEvent.java
```

See for example here:
https://github.com/jerboaa/jdk8u-dev/actions/runs/21296331427/job/61304441710#step:12:1032

The reason is similar to the failures we saw in JDK 11u. Therefore, I propose to backport the GHA work-around to JDK 8u as well. This should stabilize testing.

Test run with this is here:
https://github.com/jerboaa/jdk8u-dev/actions/runs/21300159612

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8336451](https://bugs.openjdk.org/browse/JDK-8336451) needs maintainer approval

### Issue
 * [JDK-8336451](https://bugs.openjdk.org/browse/JDK-8336451): [11u] GHA macos-13 and macos-15 builders are unable to resolve local hostname (**Enhancement** - P4 - Approved)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/749/head:pull/749` \
`$ git checkout pull/749`

Update a local copy of the PR: \
`$ git checkout pull/749` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/749/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 749`

View PR using the GUI difftool: \
`$ git pr show -t 749`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/749.diff">https://git.openjdk.org/jdk8u-dev/pull/749.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/749#issuecomment-3792304259)
</details>
