### PR TITLE
8369996: Testcase java/net/Socket/B8312065.java fails on Mac, AIX and Solaris

### DIFF
--- a/jdk/test/java/net/Socket/B8312065.java
+++ b/jdk/test/java/net/Socket/B8312065.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8312065
  * @summary Socket.connect does not timeout as expected when profiling (i.e. keep receiving signal)
- * @requires (os.family != "windows")
+ * @requires (os.family == "linux")
  * @build B8312065
  * @run shell B8312065.sh
  */


### PR DESCRIPTION
Hi,

Could I have a review of this patch ?

This patch limits the test for [JDK-8312065](https://bugs.openjdk.org/browse/JDK-8312065) to run only on Linux. 

The test for [JDK-8312065](https://bugs.openjdk.org/browse/JDK-8312065) needs to build a native library to send signals to Java threads. I don't have Mac, AIX and Solaris devices. Limit the platform is the simplest way for now.

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8369996](https://bugs.openjdk.org/browse/JDK-8369996) needs maintainer approval

### Issue
 * [JDK-8369996](https://bugs.openjdk.org/browse/JDK-8369996): Testcase java/net/Socket/B8312065.java fails on Mac, AIX and Solaris (**Bug** - P4 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/768/head:pull/768` \
`$ git checkout pull/768`

Update a local copy of the PR: \
`$ git checkout pull/768` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/768/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 768`

View PR using the GUI difftool: \
`$ git pr show -t 768`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/768.diff">https://git.openjdk.org/jdk8u-dev/pull/768.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/768#issuecomment-4009233268)
</details>
