### PR TITLE
8343622: AesDkCrypto.stringToKey should not return null

### DIFF
--- a/jdk/src/share/classes/javax/security/auth/kerberos/KeyImpl.java
+++ b/jdk/src/share/classes/javax/security/auth/kerberos/KeyImpl.java
@@ -92,7 +92,7 @@ class KeyImpl implements SecretKey, Destroyable, Serializable {
             this.keyBytes = key.getBytes();
             this.keyType = key.getEType();
         } catch (KrbException e) {
-            throw new IllegalArgumentException(e.getMessage());
+            throw new IllegalArgumentException("key creation error", e);
         }
     }
 

--- a/jdk/src/share/classes/sun/security/krb5/internal/crypto/dk/AesDkCrypto.java
+++ b/jdk/src/share/classes/sun/security/krb5/internal/crypto/dk/AesDkCrypto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,8 @@ import sun.security.krb5.KrbCryptoException;
 import sun.security.krb5.Confounder;
 import sun.security.krb5.internal.crypto.KeyUsage;
 import java.util.Arrays;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * This class provides the implementation of AES Encryption for Kerberos
@@ -104,10 +106,8 @@ public class AesDkCrypto extends DkCrypto {
 
         byte[] saltUtf8 = null;
         try {
-            saltUtf8 = salt.getBytes("UTF-8");
+            saltUtf8 = salt.getBytes(UTF_8);
             return stringToKey(password, saltUtf8, s2kparams);
-        } catch (Exception e) {
-            return null;
         } finally {
             if (saltUtf8 != null) {
                 Arrays.fill(saltUtf8, (byte)0);

--- a/jdk/src/share/classes/sun/security/krb5/internal/crypto/dk/ArcFourCrypto.java
+++ b/jdk/src/share/classes/sun/security/krb5/internal/crypto/dk/ArcFourCrypto.java
@@ -90,8 +90,6 @@ public class ArcFourCrypto extends DkCrypto {
             MessageDigest md = sun.security.provider.MD4.getInstance();
             md.update(passwd);
             digest = md.digest();
-        } catch (Exception e) {
-            return null;
         } finally {
             if (passwd != null) {
                 Arrays.fill(passwd, (byte)0);

--- a/jdk/src/share/classes/sun/security/provider/MD4.java
+++ b/jdk/src/share/classes/sun/security/provider/MD4.java
@@ -77,13 +77,8 @@ public final class MD4 extends DigestBase {
         });
     }
 
-    public static MessageDigest getInstance() {
-        try {
-            return MessageDigest.getInstance("MD4", md4Provider);
-        } catch (NoSuchAlgorithmException e) {
-            // should never occur
-            throw new ProviderException(e);
-        }
+    public static MessageDigest getInstance() throws NoSuchAlgorithmException {
+        return MessageDigest.getInstance("MD4", md4Provider);
     }
 
     // Standard constructor, creates a new MD4 instance.

--- a/jdk/test/sun/security/krb5/NullStringToKey.java
+++ b/jdk/test/sun/security/krb5/NullStringToKey.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 8343622
+ * @summary KerberosKey created with null key bytes
+ * @library /test/lib
+ * @run main/othervm NullStringToKey
+ */
+
+import jdk.test.lib.Utils;
+
+import javax.security.auth.kerberos.KerberosKey;
+import javax.security.auth.kerberos.KerberosPrincipal;
+import java.security.Security;
+import java.util.List;
+
+public class NullStringToKey {
+    public static void main(String[] args) throws Exception {
+
+        Security.removeProvider("SUN");
+        Security.removeProvider("SunJCE");
+
+        KerberosPrincipal name = new KerberosPrincipal("me@ME.COM");
+        char[] pass = "password".toCharArray();
+        for (String alg : new String[] {
+                "aes128-cts-hmac-sha1-96", "aes256-cts-hmac-sha1-96"}) {
+            System.out.println(alg);
+            Utils.runAndCheckException(() -> new KerberosKey(name, pass, alg),
+                    IllegalArgumentException.class);
+        }
+    }
+}


### PR DESCRIPTION
I'd like to backport it for parity with oracle-8u491 and fix the NPE issue.

Almost clean backport from [JDK11 PR](https://github.com/openjdk/jdk11u-dev/pull/3168) with the following changes:
- JDK8 does not have [JDK-8014628](https://bugs.openjdk.org/browse/JDK-8014628) "Support AES Encryption with HMAC-SHA2 for Kerberos 5 defined in RFC 8009". AesSha2DkCrypto.java is skipped
- NullStringToKey.java test is updated to verify SHA1 algorithms only

sun/security/krb5 JTREG tests are passed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8343622](https://bugs.openjdk.org/browse/JDK-8343622) needs maintainer approval

### Issue
 * [JDK-8343622](https://bugs.openjdk.org/browse/JDK-8343622): AesDkCrypto.stringToKey should not return null (**Bug** - P4 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/769/head:pull/769` \
`$ git checkout pull/769`

Update a local copy of the PR: \
`$ git checkout pull/769` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/769/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 769`

View PR using the GUI difftool: \
`$ git pr show -t 769`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/769.diff">https://git.openjdk.org/jdk8u-dev/pull/769.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/769#issuecomment-4026135524)
</details>
