### PR TITLE
8355249: Remove the use of WMIC from the entire source code

### DIFF
--- a/common/autoconf/build-performance.m4
+++ b/common/autoconf/build-performance.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -84,7 +84,8 @@ AC_DEFUN([BPERF_CHECK_MEMORY_SIZE],
     FOUND_MEM=yes
   elif test "x$OPENJDK_BUILD_OS" = xwindows; then
     # Windows, but without cygwin
-    MEMORY_SIZE=`wmic computersystem get totalphysicalmemory -value | grep = | cut -d "=" -f 2-`
+    MEMORY_SIZE=`powershell -Command \
+        "(Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory" | $SED 's/\\r//g' `
     MEMORY_SIZE=`expr $MEMORY_SIZE / 1024 / 1024`
     FOUND_MEM=yes
   fi

--- a/common/autoconf/generated-configure.sh
+++ b/common/autoconf/generated-configure.sh
@@ -3666,7 +3666,7 @@ ac_configure="$SHELL $ac_aux_dir/configure"  # Please don't use this var.
 
 
 #
-# Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -4410,7 +4410,7 @@ VS_TOOLSET_SUPPORTED_2022=true
 #CUSTOM_AUTOCONF_INCLUDE
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1767977874
+DATE_WHEN_GENERATED=1771403045
 
 ###############################################################################
 #
@@ -51929,7 +51929,8 @@ $as_echo_n "checking for memory size... " >&6; }
     FOUND_MEM=yes
   elif test "x$OPENJDK_BUILD_OS" = xwindows; then
     # Windows, but without cygwin
-    MEMORY_SIZE=`wmic computersystem get totalphysicalmemory -value | grep = | cut -d "=" -f 2-`
+    MEMORY_SIZE=`powershell -Command \
+        "(Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory" | $SED 's/\\r//g' `
     MEMORY_SIZE=`expr $MEMORY_SIZE / 1024 / 1024`
     FOUND_MEM=yes
   fi


### PR DESCRIPTION
Hi All,

I would like to backport JDK-8355249 done to jdk8. 
This backport is not clean and differs in some respects from the fix for JDK 11.

The following files are not present in JDK 8, so no changes are required:

- make/RunTestsPrebuilt.gmk
- test/failure_handler/src/share/conf/windows.properties
- test/jdk/tools/jpackage/helpers/jdk/jpackage/test/WindowsHelper.java
- test/jdk/tools/jpackage/windows/Win8301247Test.java

The following two files need to be modified.

- common/autoconf/build-performance.m4
- common/autoconf/generated-configure.sh

The changes to `build-performance.m4` are equivalent to those in JDK 11.
`generated-configure.sh` exist only in JDK 8. After modifying `build-performance.m4`, I ran `autogen.sh` to properly regenerate  `generate_configure.sh`.

Thank you.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] [JDK-8355249](https://bugs.openjdk.org/browse/JDK-8355249) needs maintainer approval

### Issue
 * [JDK-8355249](https://bugs.openjdk.org/browse/JDK-8355249): Remove the use of WMIC from the entire source code (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/774/head:pull/774` \
`$ git checkout pull/774`

Update a local copy of the PR: \
`$ git checkout pull/774` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/774/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 774`

View PR using the GUI difftool: \
`$ git pr show -t 774`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/774.diff">https://git.openjdk.org/jdk8u-dev/pull/774.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/774#issuecomment-4081512180)
</details>
