### PR TITLE
8380689: distrust/Chunghwa.java test fails with a compilation error

### DIFF
--- a/jdk/test/sun/security/ssl/X509TrustManagerImpl/distrust/Chunghwa.java
+++ b/jdk/test/sun/security/ssl/X509TrustManagerImpl/distrust/Chunghwa.java
@@ -34,7 +34,7 @@ import java.util.Date;
  * @bug 8369282
  * @summary Check that TLS Server certificates chaining back to distrusted
  *          Chunghwa root are invalid
- * @library /test/lib
+ * @library /lib/security
  * @modules java.base/sun.security.validator
  * @run main/othervm Chunghwa after policyOn invalid
  * @run main/othervm Chunghwa after policyOff valid


### PR DESCRIPTION
Simple fix for the distrust/Chunghwa.java compilation issue
JDK8 has another library path than JDK11+

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8380689](https://bugs.openjdk.org/browse/JDK-8380689) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8380689](https://bugs.openjdk.org/browse/JDK-8380689): distrust/Chunghwa.java test fails with a compilation error (**Bug** - P4 - Approved)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/778/head:pull/778` \
`$ git checkout pull/778`

Update a local copy of the PR: \
`$ git checkout pull/778` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/778/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 778`

View PR using the GUI difftool: \
`$ git pr show -t 778`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/778.diff">https://git.openjdk.org/jdk8u-dev/pull/778.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/778#issuecomment-4112870111)
</details>
