### PR TITLE
8380078: Update GIFlib to 6.1.2

### DIFF
--- a/THIRD_PARTY_README
+++ b/THIRD_PARTY_README
@@ -2381,7 +2381,7 @@ licenses.
 
 -------------------------------------------------------------------------------
 
-%% This notice is provided with respect to GIFLIB 6.1.1 & libungif 4.1.3,
+%% This notice is provided with respect to GIFLIB 6.1.2 & libungif 4.1.3,
 which may be included with JRE 8, JDK 8, and OpenJDK 8.
 
 --- begin of LICENSE ---

--- a/jdk/src/share/native/sun/awt/giflib/gif_lib.h
+++ b/jdk/src/share/native/sun/awt/giflib/gif_lib.h
@@ -39,7 +39,7 @@ extern "C" {
 
 #define GIFLIB_MAJOR 6
 #define GIFLIB_MINOR 1
-#define GIFLIB_RELEASE 1
+#define GIFLIB_RELEASE 2
 
 #define GIF_ERROR 0
 #define GIF_OK 1

--- a/jdk/src/share/native/sun/awt/giflib/gifalloc.c
+++ b/jdk/src/share/native/sun/awt/giflib/gifalloc.c
@@ -373,6 +373,14 @@ SavedImage *GifMakeSavedImage(GifFileType *GifFile,
                          * aliasing problems.
                          */
 
+                        /* Null out aliased pointers before any allocations
+                         * so that FreeLastSavedImage won't free CopyFrom's
+                         * data if an allocation fails partway through. */
+                        sp->ImageDesc.ColorMap = NULL;
+                        sp->RasterBits = NULL;
+                        sp->ExtensionBlocks = NULL;
+                        sp->ExtensionBlockCount = 0;
+
                         /* first, the local color map */
                         if (CopyFrom->ImageDesc.ColorMap != NULL) {
                                 sp->ImageDesc.ColorMap = GifMakeMapObject(


### PR DESCRIPTION
**Part of getting giflib updated to 6.1.2 -- deferred from https://github.com/openjdk/jdk8u/pull/89**

This updates the in-tree giflib to 6.1.2. The actual code changes are a clean backport. The license file changes needed adapting from the giflib.md file in 11u and later to the THIRD_PARTY_README file in 8u (now only one copy following [JDK-8338144](https://bugs.openjdk.org/browse/JDK-8338144))

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8380078](https://bugs.openjdk.org/browse/JDK-8380078) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8380078](https://bugs.openjdk.org/browse/JDK-8380078): Update GIFlib to 6.1.2 (**Bug** - P3 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) Review applies to [e66a52c0](https://git.openjdk.org/jdk8u-dev/pull/786/files/e66a52c018037d287084b6939db4e25784181ef8)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/786/head:pull/786` \
`$ git checkout pull/786`

Update a local copy of the PR: \
`$ git checkout pull/786` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/786/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 786`

View PR using the GUI difftool: \
`$ git pr show -t 786`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/786.diff">https://git.openjdk.org/jdk8u-dev/pull/786.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/786#issuecomment-4251328908)
</details>
