### PR TITLE
8374888: Implement internal test cache to help UserIterCount test performance

### DIFF
--- a/jdk/test/sun/security/krb5/auto/UserIterCount.java
+++ b/jdk/test/sun/security/krb5/auto/UserIterCount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,11 +29,19 @@
  * @compile -XDignore.symbol.file UserIterCount.java
  * @run main/othervm -Dsun.net.spi.nameservice.provider.1=ns,mock UserIterCount
  */
+
+import java.util.HashMap;
+
+import sun.security.krb5.EncryptionKey;
+import sun.security.krb5.KrbException;
 import sun.security.krb5.PrincipalName;
 
 public class UserIterCount {
 
     static class MyKDC extends OneKDC {
+        static final HashMap<String, EncryptionKey> CACHE
+                = new HashMap<>();
+
         public MyKDC() throws Exception {
             super(null);
         }
@@ -49,6 +57,18 @@ public class UserIterCount {
             } else {
                 return super.getParams(p, etype);
             }
+        }
+
+        @Override
+        EncryptionKey keyForUser(PrincipalName p, int etype, boolean server)
+                throws KrbException {
+            String key = p.toString() + etype + server;
+            EncryptionKey v = CACHE.get(key);
+            if (v == null) {
+                v = super.keyForUser(p, etype, server);
+                CACHE.put(key, v);
+            }
+            return v;
         }
     }
 


### PR DESCRIPTION
Fixes failing test on slow platforms

Almost clean backport. `var` replaced with the real type

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8374888](https://bugs.openjdk.org/browse/JDK-8374888) needs maintainer approval

### Issue
 * [JDK-8374888](https://bugs.openjdk.org/browse/JDK-8374888): Implement internal test cache to help UserIterCount test performance (**Bug** - P4 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/793/head:pull/793` \
`$ git checkout pull/793`

Update a local copy of the PR: \
`$ git checkout pull/793` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/793/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 793`

View PR using the GUI difftool: \
`$ git pr show -t 793`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/793.diff">https://git.openjdk.org/jdk8u-dev/pull/793.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/793#issuecomment-4357152738)
</details>
