### PR TITLE
8347740: java/io/File/createTempFile/SpecialTempFile.java failing

### DIFF
--- a/jdk/test/java/io/File/createTempFile/SpecialTempFile.java
+++ b/jdk/test/java/io/File/createTempFile/SpecialTempFile.java
@@ -32,9 +32,12 @@ import java.io.File;
 import java.io.IOException;
 
 public class SpecialTempFile {
-
+    //
+    // If exceptionExpected == null, then any IOException thrown by
+    // File.createTempFile is ignored.
+    //
     private static void test(String name, String[] prefix, String[] suffix,
-                             boolean exceptionExpected) throws IOException
+                             Boolean exceptionExpected) throws IOException
     {
         if (prefix == null || suffix == null
             || prefix.length != suffix.length)
@@ -61,19 +64,21 @@ public class SpecialTempFile {
                     else
                         f = File.createTempFile(prefix[i], suffix[i], new File(dir));
                 } catch (IOException e) {
-                    if (exceptionExpected) {
-                        if (e.getMessage().startsWith(exceptionMsg))
-                            exceptionThrown = true;
-                        else
-                            System.out.println("Wrong error message:" +
-                                               e.getMessage());
-                    } else {
-                        throw e;
+                    if (exceptionExpected != null) {
+                        if (exceptionExpected) {
+                            if (e.getMessage().startsWith(exceptionMsg))
+                                exceptionThrown = true;
+                            else
+                                System.out.println("Wrong error message:" +
+                                                   e.getMessage());
+                        } else {
+                            throw e;
+                        }
+
+                        if (exceptionExpected && (!exceptionThrown || f != null))
+                            throw new RuntimeException("IOException expected");
                     }
                 }
-
-                if (exceptionExpected && (!exceptionThrown || f != null))
-                    throw new RuntimeException("IOException is expected");
             }
         }
     }
@@ -106,6 +111,11 @@ public class SpecialTempFile {
         // Test JDK-8013827
         String[] resvPre = { "LPT1.package.zip", "com7.4.package.zip" };
         String[] resvSuf = { ".temp", ".temp" };
-        test("ReservedName", resvPre, resvSuf, true);
+        System.out.println("OS name:    " + StaticProperty.osName() + "\n" +
+                           "OS version: " + OSVersion.current());
+
+        // Here the test is for whether File.createTempFile hangs, so whether
+        // an exception is thrown is ignored: expectedException == null
+        test("ReservedName", resvPre, resvSuf, null);
     }
 }

--- a/jdk/test/java/io/File/createTempFile/SpecialTempFile.java
+++ b/jdk/test/java/io/File/createTempFile/SpecialTempFile.java
@@ -30,6 +30,9 @@
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 public class SpecialTempFile {
     //
@@ -48,21 +51,21 @@ public class SpecialTempFile {
         final String exceptionMsg = "Unable to create temporary file";
         String[] dirs = { null, "." };
 
+        Path testPath = Paths.get(System.getProperty("test.dir", "."));
         for (int i = 0; i < prefix.length; i++) {
             boolean exceptionThrown = false;
             File f = null;
 
             for (String dir: dirs) {
+                Path tempDir = Files.createTempDirectory(testPath, dir);
                 System.out.println("In test " + name +
                                    ", creating temp file with prefix, " +
                                    prefix[i] + ", suffix, " + suffix[i] +
-                                   ", in dir, " + dir);
+                                   ", in dir, " + tempDir);
 
                 try {
-                    if (dir == null || dir.isEmpty())
-                        f = File.createTempFile(prefix[i], suffix[i]);
-                    else
-                        f = File.createTempFile(prefix[i], suffix[i], new File(dir));
+                    f = File.createTempFile(prefix[i], suffix[i],
+                    tempDir.toFile());
                 } catch (IOException e) {
                     if (exceptionExpected != null) {
                         if (exceptionExpected) {
@@ -86,10 +89,6 @@ public class SpecialTempFile {
     public static void main(String[] args) throws Exception {
         // Common test
         final String name = "SpecialTempFile";
-        File f = new File(System.getProperty("java.io.tmpdir"), name);
-        if (!f.exists()) {
-            f.createNewFile();
-        }
         String[] nulPre = { name + "\u0000" };
         String[] nulSuf = { ".test" };
         test("NulName", nulPre, nulSuf, true);
@@ -111,8 +110,8 @@ public class SpecialTempFile {
         // Test JDK-8013827
         String[] resvPre = { "LPT1.package.zip", "com7.4.package.zip" };
         String[] resvSuf = { ".temp", ".temp" };
-        System.out.println("OS name:    " + StaticProperty.osName() + "\n" +
-                           "OS version: " + OSVersion.current());
+        System.out.println("OS name:    " + System.getProperty("os.name") + "\n" +
+                           "OS version: " + System.getProperty("os.version"));
 
         // Here the test is for whether File.createTempFile hangs, so whether
         // an exception is thrown is ignored: expectedException == null


### PR DESCRIPTION
I would like to backport [ 8347740](https://bugs.openjdk.org/browse/JDK-8347740) to jdk8u, which has been backported to  jdk21 and jdk17.  We see it in our CI. It's a test fix, no risk.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] [JDK-8347740](https://bugs.openjdk.org/browse/JDK-8347740) needs maintainer approval
- \[ \] [JDK-8353714](https://bugs.openjdk.org/browse/JDK-8353714) needs maintainer approval
- \[ \] [JDK-8183344](https://bugs.openjdk.org/browse/JDK-8183344) needs maintainer approval

### Issues
 * [JDK-8347740](https://bugs.openjdk.org/browse/JDK-8347740): java/io/File/createTempFile/SpecialTempFile.java failing (**Bug** - P3)
 * [JDK-8183344](https://bugs.openjdk.org/browse/JDK-8183344): Better cleanup for jdk/test/java/io/File/createTempFile/SpecialTempFile.java (**Bug** - P4)
 * [JDK-8353714](https://bugs.openjdk.org/browse/JDK-8353714): [17u] Backport of 8347740 incomplete (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/794/head:pull/794` \
`$ git checkout pull/794`

Update a local copy of the PR: \
`$ git checkout pull/794` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/794/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 794`

View PR using the GUI difftool: \
`$ git pr show -t 794`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/794.diff">https://git.openjdk.org/jdk8u-dev/pull/794.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/794#issuecomment-4409079910)
</details>
