### PR TITLE
8162545: Mac build failure

### DIFF
--- a/jdk/src/share/native/sun/awt/image/jpeg/imageioJPEG.c
+++ b/jdk/src/share/native/sun/awt/image/jpeg/imageioJPEG.c
@@ -2690,7 +2690,7 @@ Java_com_sun_imageio_plugins_jpeg_JPEGImageWriter_writeTables
     RELEASE_ARRAYS(env, data, NULL);
 }
 
-static void freeArray(void** arr, jint size) {
+static void freeArray(UINT8** arr, jint size) {
     int i;
     if (arr != NULL) {
         for (i = 0; i < size; i++) {


### PR DESCRIPTION
Backport fixing compilation error on newer gcc (14.2.0), found when [testing other PR](https://github.com/openjdk/jdk8u-dev/pull/573#issuecomment-4420035244):
```
/starfive/jdk8u-dev/jdk/src/share/native/sun/awt/image/jpeg/imageioJPEG.c: In function 'Java_com_sun_imageio_plugins_jpeg_JPEGImageWriter_writeImage':
/starfive/jdk8u-dev/jdk/src/share/native/sun/awt/image/jpeg/imageioJPEG.c:2857:19: error: passing argument 1 of 'freeArray' from incompatible pointer type [-Wincompatible-pointer-types]
 2857 |         freeArray(scale, numBands);
      |                   ^~~~~
      |                   |
      |                   UINT8 ** {aka unsigned char **}
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8162545](https://bugs.openjdk.org/browse/JDK-8162545) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8162545](https://bugs.openjdk.org/browse/JDK-8162545): Mac build failure (**Bug** - P1 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/795/head:pull/795` \
`$ git checkout pull/795`

Update a local copy of the PR: \
`$ git checkout pull/795` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/795/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 795`

View PR using the GUI difftool: \
`$ git pr show -t 795`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/795.diff">https://git.openjdk.org/jdk8u-dev/pull/795.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/795#issuecomment-4420432743)
</details>
