### PR TITLE
8314730: GHA: Drop libfreetype6-dev transitional package in favor of libfreetype-dev

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -381,7 +381,7 @@ jobs:
           sudo dpkg --add-architecture i386
           sudo apt-get update
           sudo apt-get install --only-upgrade apt
-          sudo apt-get install openjdk-8-jdk gcc-9-multilib g++-9-multilib libfreetype6-dev:i386 libxrandr-dev:i386 libxtst-dev:i386 libtiff-dev:i386 libcupsimage2-dev:i386 libcups2-dev:i386 libasound2-dev:i386
+          sudo apt-get install openjdk-8-jdk gcc-9-multilib g++-9-multilib libfreetype-dev:i386 libxrandr-dev:i386 libxtst-dev:i386 libtiff-dev:i386 libcupsimage2-dev:i386 libcups2-dev:i386 libasound2-dev:i386
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 100 --slave /usr/bin/g++ g++ /usr/bin/g++-9
         if: matrix.multilib != ''
 
@@ -406,7 +406,7 @@ jobs:
           sudo qemu-debootstrap
           --arch=${{ matrix.debian-arch }}
           --verbose
-          --include=fakeroot,symlinks,build-essential,libx11-dev,libxext-dev,libxrender-dev,libxrandr-dev,libxtst-dev,libxt-dev,libcups2-dev,libfontconfig1-dev,libasound2-dev,libfreetype6-dev,libpng-dev,libffi-dev
+          --include=fakeroot,symlinks,build-essential,libx11-dev,libxext-dev,libxrender-dev,libxrandr-dev,libxtst-dev,libxt-dev,libcups2-dev,libfontconfig1-dev,libasound2-dev,libfreetype-dev,libpng-dev,libffi-dev
           --resolve-deps
           bookworm
           ~/sysroot-${{ matrix.debian-arch }}
@@ -520,7 +520,7 @@ jobs:
           sudo dpkg --add-architecture i386
           sudo apt-get update
           sudo apt-get install --only-upgrade apt
-          sudo apt-get install openjdk-8-jdk gcc-9-multilib g++-9-multilib libfreetype6-dev:i386 libxrandr-dev:i386 libxtst-dev:i386 libtiff-dev:i386 libcupsimage2-dev:i386 libcups2-dev:i386 libasound2-dev:i386
+          sudo apt-get install openjdk-8-jdk gcc-9-multilib g++-9-multilib libfreetype-dev:i386 libxrandr-dev:i386 libxtst-dev:i386 libtiff-dev:i386 libcupsimage2-dev:i386 libcups2-dev:i386 libasound2-dev:i386
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 100 --slave /usr/bin/g++ g++ /usr/bin/g++-9
 
       - name: Configure


### PR DESCRIPTION
Backport switches `libfreetype6-dev` to `libfreetype-dev` in GHA. This is done as dependency for [JDK-8368248 backport](https://github.com/openjdk/jdk8u-dev/pull/797), since trixie does not have `libfreetype6-dev`.

Github workflows in 8 are very different from newer jdks, so made from scratch in spirit of original change. Only affects GHA.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8314730](https://bugs.openjdk.org/browse/JDK-8314730) needs maintainer approval

### Issue
 * [JDK-8314730](https://bugs.openjdk.org/browse/JDK-8314730): GHA: Drop libfreetype6-dev transitional package in favor of libfreetype-dev (**Enhancement** - P4 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/796/head:pull/796` \
`$ git checkout pull/796`

Update a local copy of the PR: \
`$ git checkout pull/796` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/796/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 796`

View PR using the GUI difftool: \
`$ git pr show -t 796`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/796.diff">https://git.openjdk.org/jdk8u-dev/pull/796.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/796#issuecomment-4433611137)
</details>
