### PR TITLE
8246330: Add TLS Tests for Legacy ECDSA curves

### DIFF
--- a/jdk/test/javax/net/ssl/templates/SSLSocketTemplate.java
+++ b/jdk/test/javax/net/ssl/templates/SSLSocketTemplate.java
@@ -357,12 +357,14 @@ public class SSLSocketTemplate {
     // Trusted certificates.
     protected final static Cert[] TRUSTED_CERTS = {
             Cert.CA_ECDSA_SECP256R1,
+            Cert.CA_ECDSA_SECT283R1,
             Cert.CA_RSA_2048,
             Cert.CA_DSA_2048 };
 
     // End entity certificate.
     protected final static Cert[] END_ENTITY_CERTS = {
             Cert.EE_ECDSA_SECP256R1,
+            Cert.EE_ECDSA_SECT283R1,
             Cert.EE_RSA_2048,
             Cert.EE_EC_RSA_SECP256R1,
             Cert.EE_DSA_2048 };
@@ -696,6 +698,32 @@ public class SSLSocketTemplate {
                 "p1YdWENftmDoNTJ3O6TNlXb90jKWgAirCXNBUompPtHKkO592eDyGcT1h8qjrKlm\n" +
                 "Kw=="),
 
+         CA_ECDSA_SECT283R1(
+                "EC",
+                // SHA1withECDSA, curve sect283r1
+                // Validity
+                //     Not Before: May 26 06:06:52 2020 GMT
+                //     Not After : May 21 06:06:52 2040 GMT
+                // Subject Key Identifier:
+                //     CF:A3:99:ED:4C:6E:04:41:09:21:31:33:B6:80:D5:A7:BF:2B:98:04
+                "-----BEGIN CERTIFICATE-----\n" +
+                "MIIB8TCCAY+gAwIBAgIJANQFsBngZ3iMMAsGByqGSM49BAEFADBdMQswCQYDVQQG\n" +
+                "EwJVUzELMAkGA1UECBMCQ0ExCzAJBgNVBAcTAlNBMQ8wDQYDVQQKEwZPcmFjbGUx\n" +
+                "DzANBgNVBAsTBkpQR1NRRTESMBAGA1UEAxMJc2VjdDI4M3IxMB4XDTIwMDUyNjE4\n" +
+                "MDY1MloXDTQwMDUyMTE4MDY1MlowXTELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNB\n" +
+                "MQswCQYDVQQHEwJTQTEPMA0GA1UEChMGT3JhY2xlMQ8wDQYDVQQLEwZKUEdTUUUx\n" +
+                "EjAQBgNVBAMTCXNlY3QyODNyMTBeMBAGByqGSM49AgEGBSuBBAARA0oABALatmDt\n" +
+                "QIhjpK4vJjv4GgC8CUH/VAWLUSQRU7yGGQ3NF8rVBARv0aehiII0nzjDVX5KrP/A\n" +
+                "w/DmW7q8PfEAIktuaA/tcKv/OKMyMDAwHQYDVR0OBBYEFM+jme1MbgRBCSExM7aA\n" +
+                "1ae/K5gEMA8GA1UdEwEB/wQFMAMBAf8wCwYHKoZIzj0EAQUAA08AMEwCJAGHsAP8\n" +
+                "HlcVqszra+fxq35juTxHJIfxTKIr7f54Ywtz7AJowgIkAxydv8g+dkuniOUAj0Xt\n" +
+                "FnGVp6HzKX5KM1zLpfqmix8ZPP/A\n" +
+                "-----END CERTIFICATE-----",
+                "MIGQAgEAMBAGByqGSM49AgEGBSuBBAARBHkwdwIBAQQkAdcyn/FxiNvuTsSgDehq\n" +
+                "SGFiTxAKNMMJfmsO6GHekzszFqjPoUwDSgAEAtq2YO1AiGOkri8mO/gaALwJQf9U\n" +
+                "BYtRJBFTvIYZDc0XytUEBG/Rp6GIgjSfOMNVfkqs/8DD8OZburw98QAiS25oD+1w\n" +
+                "q/84"),
+
         CA_RSA_2048(
                 "RSA",
                 // SHA256withRSA, 2048 bits
@@ -800,6 +828,33 @@ public class SSLSocketTemplate {
                 "eNLB4sm70tLtycUJG+/8vLTjmbvKpc/2Dku5UOlMVBl9uwntRNPmoHz6YXraEQJU" +
                 "tXHs6lmu6+uBmtJ5I9ZMJHEao4E4icdDcJ1F6+/FQFxYVRfefjt5X6ob3bRBrZIQ" +
                 "xj4OzQQjAiEAsceWOM8do4etxp2zgnoNXV8PUUyqWhz1+0srcKV7FR4="),
+
+        EE_ECDSA_SECT283R1(
+                "EC",
+                // SHA1withECDSA, curve sect283r1
+                // Validity
+                //     Not Before: May 26 06:08:15 2020 GMT
+                //     Not After : May 21 06:08:15 2040 GMT
+                // Authority Key Identifier:
+                //     CF:A3:99:ED:4C:6E:04:41:09:21:31:33:B6:80:D5:A7:BF:2B:98:04
+                "-----BEGIN CERTIFICATE-----\n" +
+                "MIICFTCCAbOgAwIBAgIJAM0Dd9zxR9CeMAsGByqGSM49BAEFADBdMQswCQYDVQQG\n" +
+                "EwJVUzELMAkGA1UECBMCQ0ExCzAJBgNVBAcTAlNBMQ8wDQYDVQQKEwZPcmFjbGUx\n" +
+                "DzANBgNVBAsTBkpQR1NRRTESMBAGA1UEAxMJc2VjdDI4M3IxMB4XDTIwMDUyNjE4\n" +
+                "MDgxNVoXDTQwMDUyMTE4MDgxNVowYDELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNB\n" +
+                "MQswCQYDVQQHEwJTQTEPMA0GA1UEChMGT3JhY2xlMQ8wDQYDVQQLEwZKUEdTUUUx\n" +
+                "FTATBgNVBAMMDHNlY3QyODNyMV9lZTBeMBAGByqGSM49AgEGBSuBBAARA0oABAMP\n" +
+                "oaMP2lIiCrNaFSePtZA8nBnqJXSGCz8kosKeYTqz/SPE1AN6BvM4xl0kPQZvJWMz\n" +
+                "fyTcm2Ar0PdbIh8f22vJfO+0JpfhnqNTMFEwHQYDVR0OBBYEFOzDGNWQhslU5ei4\n" +
+                "SYda/ro9DickMA8GA1UdEwQIMAYBAf8CAQAwHwYDVR0jBBgwFoAUz6OZ7UxuBEEJ\n" +
+                "ITEztoDVp78rmAQwCwYHKoZIzj0EAQUAA08AMEwCJALYBWSYdbhRiW4mNulQh6/v\n" +
+                "dfHG3y/oMjzJEmT/A0WYl96ohgIkAbDC0Ke632RXtCZ4xa2FrmzP41Vb80mSH1iY\n" +
+                "FCJ3LVoTEUgN\n" +
+                "-----END CERTIFICATE-----",
+                "MIGQAgEAMBAGByqGSM49AgEGBSuBBAARBHkwdwIBAQQkAXq9LPYU+XSrImPzgO1e\n" +
+                "hsgjfTBXlWGveFUtn0OHPtbp7hzpoUwDSgAEAw+how/aUiIKs1oVJ4+1kDycGeol\n" +
+                "dIYLPySiwp5hOrP9I8TUA3oG8zjGXSQ9Bm8lYzN/JNybYCvQ91siHx/ba8l877Qm\n" +
+                "l+Ge"),
 
         EE_ECDSA_SECP256R1(
                 "EC",

--- a/jdk/test/sun/security/ssl/CipherSuite/DisabledCurve.java
+++ b/jdk/test/sun/security/ssl/CipherSuite/DisabledCurve.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8246330
+ * @library /javax/net/ssl/templates
+ * @run main/othervm -Djdk.tls.namedGroups="sect283r1"
+        DisabledCurve DISABLE_NONE PASS
+ * @run main/othervm -Djdk.tls.namedGroups="sect283r1"
+        DisabledCurve sect283r1 FAIL
+*/
+import java.security.Security;
+import java.util.Arrays;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLServerSocket;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLException;
+
+public class DisabledCurve extends SSLSocketTemplate {
+
+    private static volatile int index;
+    private static final String[][][] protocols = {
+            { { "TLSv1.3", "TLSv1.2", "TLSv1.1", "TLSv1" }, { "TLSv1.2" } },
+            { { "TLSv1.2" }, { "TLSv1.3", "TLSv1.2", "TLSv1.1", "TLSv1" } },
+            { { "TLSv1.2" }, { "TLSv1.2" } }, { { "TLSv1.1" }, { "TLSv1.1" } },
+            { { "TLSv1" }, { "TLSv1" } } };
+
+    protected SSLContext createClientSSLContext() throws Exception {
+        return createSSLContext(
+                new SSLSocketTemplate.Cert[] {
+                        SSLSocketTemplate.Cert.CA_ECDSA_SECT283R1 },
+                new SSLSocketTemplate.Cert[] {
+                        SSLSocketTemplate.Cert.EE_ECDSA_SECT283R1 },
+                getClientContextParameters());
+    }
+
+    protected SSLContext createServerSSLContext() throws Exception {
+        return createSSLContext(
+                new SSLSocketTemplate.Cert[] {
+                        SSLSocketTemplate.Cert.CA_ECDSA_SECT283R1 },
+                new SSLSocketTemplate.Cert[] {
+                        SSLSocketTemplate.Cert.EE_ECDSA_SECT283R1 },
+                getServerContextParameters());
+    }
+
+    @Override
+    protected void configureClientSocket(SSLSocket socket) {
+        String[] ps = protocols[index][0];
+
+        System.out.print("Setting client protocol(s): ");
+        Arrays.stream(ps).forEachOrdered(System.out::print);
+        System.out.println();
+
+        socket.setEnabledProtocols(ps);
+    }
+
+    @Override
+    protected void configureServerSocket(SSLServerSocket serverSocket) {
+        String[] ps = protocols[index][1];
+
+        System.out.print("Setting server protocol(s): ");
+        Arrays.stream(ps).forEachOrdered(System.out::print);
+        System.out.println();
+
+        serverSocket.setEnabledProtocols(ps);
+    }
+
+    public static void main(String[] args) throws Exception {
+        String expected = args[1];
+        String disabledName = ("DISABLE_NONE".equals(args[0]) ? "" : args[0]);
+        if (disabledName.equals("")) {
+            Security.setProperty("jdk.disabled.namedCurves", "");
+        }
+        System.setProperty("jdk.sunec.disableNative", "false");
+
+        for (index = 0; index < protocols.length; index++) {
+            try {
+                (new DisabledCurve()).run();
+                if (expected.equals("FAIL")) {
+                    throw new RuntimeException(
+                            "The test case should not reach here");
+                }
+            } catch (SSLException | IllegalStateException ssle) {
+                if ((expected.equals("FAIL"))
+                        && Security.getProperty("jdk.disabled.namedCurves")
+                                .contains(disabledName)) {
+                    System.out.println(
+                            "Expected exception was thrown: TEST PASSED");
+                } else {
+                    throw new RuntimeException(ssle);
+                }
+
+            }
+
+        }
+    }
+}

--- a/jdk/test/sun/security/ssl/CipherSuite/DisabledCurve.java
+++ b/jdk/test/sun/security/ssl/CipherSuite/DisabledCurve.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8246330
  * @library /javax/net/ssl/templates
+ *          /lib/security
  * @run main/othervm -Djdk.tls.namedGroups="sect283r1"
         DisabledCurve DISABLE_NONE PASS
  * @run main/othervm -Djdk.tls.namedGroups="sect283r1"
@@ -93,6 +94,9 @@ public class DisabledCurve extends SSLSocketTemplate {
             Security.setProperty("jdk.disabled.namedCurves", "");
         }
         System.setProperty("jdk.sunec.disableNative", "false");
+
+        // Re-enable TLSv1 and TLSv1.1 since test depends on it.
+        SecurityUtils.removeFromDisabledTlsAlgs("TLSv1", "TLSv1.1");
 
         for (index = 0; index < protocols.length; index++) {
             try {


### PR DESCRIPTION
Another SSL test backport in preparation for JDK-8284047. The patch isn't clean because of a) different paths in JDK 8u and b) because of `8202343: Disable TLS 1.0 and 1.1` done ahead of this backport, and, thus, this patch needs to re-enable those TLS versions. See second commit.

**Testing**
- [x] The new `DisabledCurve.java` test passes. Existing SSL tests continue to pass.

Thoughts?

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8246330](https://bugs.openjdk.org/browse/JDK-8246330) needs maintainer approval

### Issue
 * [JDK-8246330](https://bugs.openjdk.org/browse/JDK-8246330): Add TLS Tests for Legacy ECDSA curves (**Enhancement** - P3 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/804/head:pull/804` \
`$ git checkout pull/804`

Update a local copy of the PR: \
`$ git checkout pull/804` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/804/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 804`

View PR using the GUI difftool: \
`$ git pr show -t 804`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/804.diff">https://git.openjdk.org/jdk8u-dev/pull/804.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/804#issuecomment-4498432730)
</details>
