### PR TITLE
8221710: [TESTBUG] more configurable parameters for docker testing

### DIFF
--- a/test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java
+++ b/test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java
@@ -42,6 +42,7 @@ import jdk.test.lib.Container;
 import jdk.test.lib.Utils;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
+import jtreg.SkippedException;
 
 
 public class DockerTestUtils {
@@ -90,9 +91,7 @@ public class DockerTestUtils {
         if (isDockerEngineAvailable()) {
             return true;
         } else {
-            System.out.println("Docker engine is not available on this system");
-            System.out.println("This test is SKIPPED");
-            return false;
+            throw new SkippedException("Docker engine is not available on this system");
         }
     }
 


### PR DESCRIPTION
  Only SkippedException is backported; the other changes have already been backported, and test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java has been iteratively updated.

Through testing, this backport passes the test cases below when the Docker status is 'start'.

`jdk/internal/platform/docker/TestDockerBasic.java
jdk/internal/platform/docker/TestDockerCpuMetrics.java
jdk/internal/platform/docker/TestDockerMemoryMetrics.java
jdk/internal/platform/docker/TestGetFreeSwapSpaceSize.java
jdk/internal/platform/docker/TestSystemMetrics.java
jdk/internal/platform/docker/TestUseContainerSupport.java`

---------
- [ ] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] [JDK-8221710](https://bugs.openjdk.org/browse/JDK-8221710) needs maintainer approval
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Issue
 * [JDK-8221710](https://bugs.openjdk.org/browse/JDK-8221710): [TESTBUG] more configurable parameters for docker testing (**Enhancement** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/805/head:pull/805` \
`$ git checkout pull/805`

Update a local copy of the PR: \
`$ git checkout pull/805` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/805/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 805`

View PR using the GUI difftool: \
`$ git pr show -t 805`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/805.diff">https://git.openjdk.org/jdk8u-dev/pull/805.diff</a>

</details>
