### PR TITLE
6815126: intermittent SimulResumerTest.java failure

### DIFF
--- a/jdk/test/com/sun/jdi/SimulResumerTest.java
+++ b/jdk/test/com/sun/jdi/SimulResumerTest.java
@@ -177,12 +177,18 @@ public class SimulResumerTest extends TestScaffold {
                 List<StackFrame> frames = thr.frames();
                 // no failure return value here; could cause an NPE
 
-                int nframes = frames.size();
-                if (nframes > 0) {
-                    // hmm, how could it ever be 0?
-                    kind = "frames(0, size - 1)";
+                kind = "frames(0, size - 1)";
                 System.out.println("kind = " + kind);
-                    thr.frames(0, frames.size() - 1);
+                int nframes = frames.size();
+                while (nframes > 0) {
+                    try {
+                        thr.frames(0, nframes - 1);
+                        break;
+                    } catch (IndexOutOfBoundsException iobe) {
+                        // 6815126. let's try to get less frames
+                        iobe.printStackTrace();
+                        nframes--;
+                    }
                 }
 
                 kind = "frameCount()";


### PR DESCRIPTION
Hi all,

This is clean backport to fix the test bug, which cause test intermittent fails.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-6815126](https://bugs.openjdk.org/browse/JDK-6815126) needs maintainer approval

### Issue
 * [JDK-6815126](https://bugs.openjdk.org/browse/JDK-6815126): intermittent SimulResumerTest.java failure (**Bug** - P4 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/806/head:pull/806` \
`$ git checkout pull/806`

Update a local copy of the PR: \
`$ git checkout pull/806` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/806/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 806`

View PR using the GUI difftool: \
`$ git pr show -t 806`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/806.diff">https://git.openjdk.org/jdk8u-dev/pull/806.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/806#issuecomment-4523778824)
</details>
