### PR TITLE
8273135: java/awt/color/ICC_ColorSpace/MTTransformReplacedProfile.java crashes in liblcms.dylib with NULLSeek+0x7

### DIFF
--- a/jdk/src/share/native/sun/java2d/cmm/lcms/cmsio0.c
+++ b/jdk/src/share/native/sun/java2d/cmm/lcms/cmsio0.c
@@ -1660,7 +1660,7 @@ cmsBool IsTypeSupported(cmsTagDescriptor* TagDescriptor, cmsTagTypeSignature Typ
 void* CMSEXPORT cmsReadTag(cmsHPROFILE hProfile, cmsTagSignature sig)
 {
     _cmsICCPROFILE* Icc = (_cmsICCPROFILE*) hProfile;
-    cmsIOHANDLER* io = Icc ->IOhandler;
+    cmsIOHANDLER* io;
     cmsTagTypeHandler* TypeHandler;
     cmsTagTypeHandler LocalTypeHandler;
     cmsTagDescriptor*  TagDescriptor;
@@ -1704,6 +1704,8 @@ void* CMSEXPORT cmsReadTag(cmsHPROFILE hProfile, cmsTagSignature sig)
     TagSize   = Icc -> TagSizes[n];
 
     if (TagSize < 8) goto Error;
+
+    io = Icc ->IOhandler;
 
     if (io == NULL) { // This is a built-in profile that has been manipulated, abort early
 


### PR DESCRIPTION
This fix is present in upstream LCMS 2.13. So it should have been included as part of the backported [JDK-8 backported 8321489: Update LCMS to 2.16](https://github.com/openjdk/jdk8u-dev/commit/d887a86128421655f833e68f3efe5c2db670842f). However, that backport originated from [JDK-11](https://github.com/openjdk/jdk11u-dev/commit/2921ad6bb89c91ef7992a1eefa93e9a670512f54) where this 2.13 bugfix was missing for an unknown reason. It was only [backported to JDK-11 later](https://github.com/openjdk/jdk11u-dev/commit/a83d9303d5d1f7f3415436e145ea414b2680f783).




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8273135](https://bugs.openjdk.org/browse/JDK-8273135) needs maintainer approval

### Issue
 * [JDK-8273135](https://bugs.openjdk.org/browse/JDK-8273135): java/awt/color/ICC_ColorSpace/MTTransformReplacedProfile.java crashes in liblcms.dylib with NULLSeek+0x7 (**Bug** - P4 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/807/head:pull/807` \
`$ git checkout pull/807`

Update a local copy of the PR: \
`$ git checkout pull/807` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/807/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 807`

View PR using the GUI difftool: \
`$ git pr show -t 807`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/807.diff">https://git.openjdk.org/jdk8u-dev/pull/807.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/807#issuecomment-4516774385)
</details>
