### PR TITLE
8378823: AIX build fails after zlib updated by JDK-8378631

### DIFF
--- a/jdk/make/lib/CoreLibraries.gmk
+++ b/jdk/make/lib/CoreLibraries.gmk
@@ -268,6 +268,10 @@ else
   ZLIB_CPPFLAGS := -I$(JDK_TOPDIR)/src/share/native/java/util/zip/zlib
   ifeq ($(OPENJDK_TARGET_OS), macosx)
     ZLIB_CPPFLAGS += -DHAVE_UNISTD_H=1 -DHAVE_STDARG_H=1
+  else ifeq ($(OPENJDK_TARGET_OS), linux)
+    ZLIB_CPPFLAGS += -DHAVE_UNISTD_H=1 -DHAVE_STDARG_H=1
+  else ifeq ($(OPENJDK_TARGET_OS), aix)
+    ZLIB_CPPFLAGS += -DHAVE_UNISTD_H=1 -DHAVE_STDARG_H=1
   endif
 endif
 


### PR DESCRIPTION
Backport of [JDK-8378823](https://bugs.openjdk.org/browse/JDK-8378823) from JDK11 (P1).

Relevant tests continue to pass on `rhel8/gcc 8.5.0`. Couldn't test on `aix`, though. Maybe it's worth testing in Solaris as well.

Relevant tests continue to pass:

- jdk/test/java/util/zip/

```
TEST RESULT: Passed. Execution successful
--------------------------------------------------
Test results: passed: 55; error: 1
```
With the error being expected: java/util/zip/3GBZipFiles.sh Error. Test ignored: runs for hours and eats up 7 Gigabytes of disk space.

- jdk/test/java/tools/pack200

```
TEST RESULT: Passed. Execution successful
--------------------------------------------------
Test results: passed: 18
```

- jdk/test/demo/zipfs/

```
TEST RESULT: Passed. Execution successful
--------------------------------------------------
Test results: passed: 6
```

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8378823](https://bugs.openjdk.org/browse/JDK-8378823) needs maintainer approval

### Issue
 * [JDK-8378823](https://bugs.openjdk.org/browse/JDK-8378823): AIX build fails after zlib updated by JDK-8378631 (**Bug** - P1 - Approved)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/823/head:pull/823` \
`$ git checkout pull/823`

Update a local copy of the PR: \
`$ git checkout pull/823` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/823/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 823`

View PR using the GUI difftool: \
`$ git pr show -t 823`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/823.diff">https://git.openjdk.org/jdk8u-dev/pull/823.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/823#issuecomment-4611205689)
</details>
