### PR TITLE
8384902: Update GIFlib to 6.1.3

### DIFF
--- a/THIRD_PARTY_README
+++ b/THIRD_PARTY_README
@@ -2381,7 +2381,7 @@ licenses.
 
 -------------------------------------------------------------------------------
 
-%% This notice is provided with respect to GIFLIB 6.1.2 & libungif 4.1.3,
+%% This notice is provided with respect to GIFLIB 6.1.3 & libungif 4.1.3,
 which may be included with JRE 8, JDK 8, and OpenJDK 8.
 
 --- begin of LICENSE ---

--- a/jdk/src/share/native/sun/awt/giflib/dgif_lib.c
+++ b/jdk/src/share/native/sun/awt/giflib/dgif_lib.c
@@ -1187,7 +1187,15 @@ void DGifDecreaseImageCounter(GifFileType *GifFile) {
                 GifFreeMapObject(GifFile->SavedImages[GifFile->ImageCount].ImageDesc.ColorMap);
         }
 
-        // Realloc array according to the new image counter.
+        // Avoid a dodgy edge casse in reallocarray() */
+        if (GifFile->ImageCount <= 0) {
+                free(GifFile->SavedImages);
+                GifFile->SavedImages = NULL;
+                GifFile->ImageCount = 0;
+                return;
+        }
+
+        /* Realloc array according to the new image counter. */
         correct_saved_images = (SavedImage *)reallocarray(
             GifFile->SavedImages, GifFile->ImageCount, sizeof(SavedImage));
         if (correct_saved_images != NULL) {

--- a/jdk/src/share/native/sun/awt/giflib/gif_lib.h
+++ b/jdk/src/share/native/sun/awt/giflib/gif_lib.h
@@ -39,7 +39,7 @@ extern "C" {
 
 #define GIFLIB_MAJOR 6
 #define GIFLIB_MINOR 1
-#define GIFLIB_RELEASE 2
+#define GIFLIB_RELEASE 3
 
 #define GIF_ERROR 0
 #define GIF_OK 1

--- a/jdk/src/share/native/sun/awt/giflib/gifalloc.c
+++ b/jdk/src/share/native/sun/awt/giflib/gifalloc.c
@@ -167,9 +167,9 @@ ColorMapObject *GifUnionColorMap(const ColorMapObject *ColorIn1,
          * of table 1.  This is very useful if your display is limited to
          * 16 colors.
          */
-        while (ColorIn1->Colors[CrntSlot - 1].Red == 0 &&
+        while (CrntSlot > 0 && (ColorIn1->Colors[CrntSlot - 1].Red == 0 &&
                ColorIn1->Colors[CrntSlot - 1].Green == 0 &&
-               ColorIn1->Colors[CrntSlot - 1].Blue == 0) {
+                            ColorIn1->Colors[CrntSlot - 1].Blue == 0)) {
                 CrntSlot--;
         }
 


### PR DESCRIPTION
Backport of [JDK-8384902](https://bugs.openjdk.org/browse/JDK-8384902) from JDK-11. 

There's a slight difference from JDK-11 in the way `SavedImage *correct_saved_images;` is declared in `dgif_lib.c/DGifDecreaseImageCounter`, introduced when backporting [JDK-8379256](https://bugs.openjdk.org/browse/JDK-8379256) to JDK8.

Tested on RH8/gcc 8.5.0 with `jdk/test/java/awt/SplashScreen` tests, passing:

```
TEST RESULT: Passed. Execution successful
--------------------------------------------------
Test results: passed: 1
```

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] [JDK-8384902](https://bugs.openjdk.org/browse/JDK-8384902) needs maintainer approval
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8384902](https://bugs.openjdk.org/browse/JDK-8384902): Update GIFlib to 6.1.3 (**Bug** - P3 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/827/head:pull/827` \
`$ git checkout pull/827`

Update a local copy of the PR: \
`$ git checkout pull/827` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/827/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 827`

View PR using the GUI difftool: \
`$ git pr show -t 827`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/827.diff">https://git.openjdk.org/jdk8u-dev/pull/827.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/827#issuecomment-4657604520)
</details>
