### PR TITLE
8252250: isnanf is obsolete

### DIFF
--- a/hotspot/src/share/vm/utilities/globalDefinitions_gcc.hpp
+++ b/hotspot/src/share/vm/utilities/globalDefinitions_gcc.hpp
@@ -235,7 +235,7 @@ inline int g_isnan(double f) { return isnand(f); }
 #elif defined(__APPLE__)
 inline int g_isnan(double f) { return isnan(f); }
 #elif defined(LINUX) || defined(_ALLBSD_SOURCE)
-inline int g_isnan(float  f) { return isnanf(f); }
+inline int g_isnan(float  f) { return isnan(f); }
 inline int g_isnan(double f) { return isnan(f); }
 #else
 #error "missing platform-specific definition here"

--- a/jdk/src/solaris/native/common/jdk_util_md.h
+++ b/jdk/src/solaris/native/common/jdk_util_md.h
@@ -37,7 +37,7 @@
 #define ISNAND(d) isnan(d)
 #elif defined(__linux__) || defined(_ALLBSD_SOURCE)
 #include <math.h>
-#define ISNANF(f) isnanf(f)
+#define ISNANF(f) isnan(f)
 #define ISNAND(d) isnan(d)
 #elif defined(_AIX)
 #include <math.h>


### PR DESCRIPTION
Clean backport of  [JDK-8252250](https://bugs.openjdk.org/browse/JDK-8252250)  insnanf is obsolute. Low risk.

GHA tested




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8252250](https://bugs.openjdk.org/browse/JDK-8252250) needs maintainer approval

### Issue
 * [JDK-8252250](https://bugs.openjdk.org/browse/JDK-8252250): isnanf is obsolete (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/831/head:pull/831` \
`$ git checkout pull/831`

Update a local copy of the PR: \
`$ git checkout pull/831` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/831/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 831`

View PR using the GUI difftool: \
`$ git pr show -t 831`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/831.diff">https://git.openjdk.org/jdk8u-dev/pull/831.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/831#issuecomment-4672641452)
</details>
