### PR TITLE
8385876: [8u] hotspot/src/share/vm/code/compiledIC.cpp:406:30: error: 'this' pointer is null

### DIFF
--- a/hotspot/make/linux/makefiles/gcc.make
+++ b/hotspot/make/linux/makefiles/gcc.make
@@ -238,6 +238,11 @@ ifeq ($(USE_FORMAT_OVERFLOW), 1)
   CFLAGS_WARN/os_linux.o = $(CFLAGS_WARN/DEFAULT) -Wno-error=format-overflow
 endif
 
+ifeq ($(JVM_VARIANT_ZERO), true)
+  CFLAGS_WARN/compiledIC.o = $(CFLAGS_WARN/DEFAULT) -Wno-error=nonnull
+  CFLAGS_WARN/sharedRuntime.o = $(CFLAGS_WARN/DEFAULT) -Wno-error=nonnull
+endif
+
 # The flags to use for an Optimized g++ build
 OPT_CFLAGS/SIZE=-Os
 OPT_CFLAGS/SPEED=-O3


### PR DESCRIPTION
Zero on gcc 14.2.0 shows these warnings, which are treated as errors by default:
```
/ws/jdk8u-dev/hotspot/src/share/vm/code/compiledIC.cpp: In member function 'void CompiledIC::set_to_monomorphic(CompiledICInfo&)':
/ws/jdk8u-dev/hotspot/src/share/vm/code/compiledIC.cpp:406:30: warning: 'this' pointer is null [-Wnonnull]
  406 |       csc->set_to_interpreted(method, info.entry());
      |       ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
In file included from /ws/jdk8u-dev/hotspot/src/share/vm/code/compiledIC.cpp:28:
/ws/jdk8u-dev/hotspot/src/share/vm/code/compiledIC.hpp:317:8: note: in a call to non-static member function 'void CompiledStaticCall::set_to_interpreted(methodHandle, address)'
  317 |   void set_to_interpreted(methodHandle callee, address entry);
      |        ^~~~~~~~~~~~~~~~~~
```
Variable `csc` in [CompiledIC.cpp](https://github.com/openjdk/jdk8u-dev/blob/0d1968f112e0f6cbe1d7a04f47080fb239f0168f/hotspot/src/share/vm/code/compiledIC.cpp#L406) originates from `instruction_address` [method](https://github.com/openjdk/jdk8u-dev/blob/436eadfb3392aa4c3b07afd04c7da72e73ab46d5/hotspot/src/cpu/zero/vm/nativeInst_zero.hpp#L74) (which technically returns `NULL` on Zero JVM).

```
/ws/jdk8u-dev/hotspot/src/share/vm/runtime/sharedRuntime.cpp: In static member function 'static methodHandle SharedRuntime::resolve_sub_helper(JavaThread*, bool, bool, Thread*)':
/ws/jdk8u-dev/hotspot/src/share/vm/runtime/sharedRuntime.cpp:1322:26: warning: 'this' pointer is null [-Wnonnull]
 1322 |         if (ssc->is_clean()) ssc->set(static_call_info);
      |             ~~~~~~~~~~~~~^~
In file included from /ws/jdk8u-dev/hotspot/src/share/vm/runtime/sharedRuntime.cpp:28:
/ws/jdk8u-dev/hotspot/src/share/vm/code/compiledIC.hpp:335:8: note: in a call to non-static member function 'bool CompiledStaticCall::is_clean() const'
  335 |   bool is_clean() const;
      |        ^~~~~~~~
/ws/jdk8u-dev/hotspot/src/share/vm/runtime/sharedRuntime.cpp:1322:38: warning: 'this' pointer is null [-Wnonnull]
 1322 |         if (ssc->is_clean()) ssc->set(static_call_info);
      |                              ~~~~~~~~^~~~~~~~~~~~~~~~~~
/ws/jdk8u-dev/hotspot/src/share/vm/code/compiledIC.hpp:345:8: note: in a call to non-static member function 'void CompiledStaticCall::set(const StaticCallInfo&)'
  345 |   void set(const StaticCallInfo& info);
      |        ^~~
```
Same kind of problem. Variable `ssc` in [sharedRuntime.cpp](https://github.com/openjdk/jdk8u-dev/blob/436eadfb3392aa4c3b07afd04c7da72e73ab46d5/hotspot/src/share/vm/runtime/sharedRuntime.cpp#L1322) originates from `nativeCall_before` [method](https://github.com/openjdk/jdk8u-dev/blob/0d1968f112e0f6cbe1d7a04f47080fb239f0168f/hotspot/src/cpu/zero/vm/nativeInst_zero.hpp#L112) (technically `NULL` on Zero JVM).

**Details:**
This only affects JDK8 in Zero variant. Based on presence of `ShouldNotCallThis();` in functions returning `NULL` pointer, I assume problematic code is, in fact, "dead code" and should not cause problems at runtime. 

Building broken, dead code, is not optimal, but given that this is old jdk, I just made warning for affected files non-fatal.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[ \] [JDK-8385876](https://bugs.openjdk.org/browse/JDK-8385876) needs maintainer approval
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8385876](https://bugs.openjdk.org/browse/JDK-8385876): [8u] hotspot/src/share/vm/code/compiledIC.cpp:406:30: error: 'this' pointer is null (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/836/head:pull/836` \
`$ git checkout pull/836`

Update a local copy of the PR: \
`$ git checkout pull/836` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/836/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 836`

View PR using the GUI difftool: \
`$ git pr show -t 836`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/836.diff">https://git.openjdk.org/jdk8u-dev/pull/836.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/836#issuecomment-4834826253)
</details>
