### PR TITLE
8269029: compiler/codegen/TestCharVect2.java fails for client VMs

### DIFF
--- a/hotspot/test/compiler/codegen/TestCharVect2.java
+++ b/hotspot/test/compiler/codegen/TestCharVect2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,14 @@
  * @summary incorrect results of char vectors right shift operaiton
  *
  * @run main/othervm/timeout=400 -Xbatch -Xmx128m compiler.codegen.TestCharVect2
+ */
+
+/**
+ * @test
+ * @bug 8001183
+ * @summary incorrect results of char vectors right shift operation
+ * @requires vm.compiler2.enabled | vm.graal.enabled
+ *
  * @run main/othervm/timeout=400 -Xbatch -Xmx128m -XX:MaxVectorSize=8 compiler.codegen.TestCharVect2
  * @run main/othervm/timeout=400 -Xbatch -Xmx128m -XX:MaxVectorSize=16 compiler.codegen.TestCharVect2
  * @run main/othervm/timeout=400 -Xbatch -Xmx128m -XX:MaxVectorSize=32 compiler.codegen.TestCharVect2

--- a/hotspot/test/compiler/codegen/TestCharVect2.java
+++ b/hotspot/test/compiler/codegen/TestCharVect2.java
@@ -33,7 +33,7 @@
  * @test
  * @bug 8001183
  * @summary incorrect results of char vectors right shift operation
- * @requires vm.compiler2.enabled | vm.graal.enabled
+ * @requires vm.flavor == "server"
  *
  * @run main/othervm/timeout=400 -Xbatch -Xmx128m -XX:MaxVectorSize=8 compiler.codegen.TestCharVect2
  * @run main/othervm/timeout=400 -Xbatch -Xmx128m -XX:MaxVectorSize=16 compiler.codegen.TestCharVect2


### PR DESCRIPTION
This is backport of  "[8269029](https://bugs.openjdk.org/browse/JDK-8269029) compiler/codegen/TestCharVect2.java fails for client VMs" to jdk8u as Windows 32bit build fails on this test because of the absense of the VM options. 

Simple conflict resolution, original change has an additional arg in the context lines. However, I had to change the implementation, as there are no properties `vm.compiler2.enabled | vm.graal.enabled` in JDK8, so I've replaced them with `vm.flavor == "server"` as the problem occurs on client VMs.

Test failures in `jdk/security_infra` are not related to the change.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] [JDK-8269029](https://bugs.openjdk.org/browse/JDK-8269029) needs maintainer approval

### Issue
 * [JDK-8269029](https://bugs.openjdk.org/browse/JDK-8269029): compiler/codegen/TestCharVect2.java fails for client VMs (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/837/head:pull/837` \
`$ git checkout pull/837`

Update a local copy of the PR: \
`$ git checkout pull/837` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/837/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 837`

View PR using the GUI difftool: \
`$ git pr show -t 837`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/837.diff">https://git.openjdk.org/jdk8u-dev/pull/837.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/837#issuecomment-4840310387)
</details>
