### PR TITLE
8036915: setLocationRelativeTo stopped working in Ubuntu 13.10 (Unity)

### DIFF
--- a/jdk/src/solaris/classes/sun/awt/X11/XDecoratedPeer.java
+++ b/jdk/src/solaris/classes/sun/awt/X11/XDecoratedPeer.java
@@ -29,6 +29,9 @@ import java.awt.*;
 import java.awt.event.ComponentEvent;
 import java.awt.event.InvocationEvent;
 import java.awt.event.WindowEvent;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import sun.awt.IconInfo;
 import sun.util.logging.PlatformLogger;
@@ -52,6 +55,8 @@ abstract class XDecoratedPeer extends XWindowPeer {
     XContentWindow content;
     Insets currentInsets;
     XFocusProxyWindow focusProxy;
+    static final Map<Class<?>,Insets> lastKnownInsets =
+                                   Collections.synchronizedMap(new HashMap<>());
 
     XDecoratedPeer(Window target) {
         super(target);
@@ -74,6 +79,9 @@ abstract class XDecoratedPeer extends XWindowPeer {
         winAttr.initialFocus = true;
 
         currentInsets = new Insets(0,0,0,0);
+        if (XWM.getWMID() == XWM.UNITY_COMPIZ_WM) {
+            currentInsets = lastKnownInsets.get(getClass());
+        }
         applyGuessedInsets();
 
         Rectangle bounds = (Rectangle)params.get(BOUNDS);
@@ -297,7 +305,25 @@ abstract class XDecoratedPeer extends XWindowPeer {
         if (ev.get_atom() == XWM.XA_KDE_NET_WM_FRAME_STRUT.getAtom()
             || ev.get_atom() == XWM.XA_NET_FRAME_EXTENTS.getAtom())
         {
-            getWMSetInsets(XAtom.get(ev.get_atom()));
+            if (XWM.getWMID() != XWM.UNITY_COMPIZ_WM) {
+                getWMSetInsets(XAtom.get(ev.get_atom()));
+            } else {
+                if(!isReparented()) {
+                    return;
+                }
+                wm_set_insets = null;
+                Insets in = getWMSetInsets(XAtom.get(ev.get_atom()));
+                if (isNull(in)) {
+                    return;
+                }
+                if (!isEmbedded() && !isTargetUndecorated()) {
+                    lastKnownInsets.put(getClass(), in);
+                }
+                if (!in.equals(dimensions.getInsets())) {
+                    handleCorrectInsets(in);
+                }
+                insets_corrected = true;
+            }
         }
     }
 
@@ -370,7 +396,7 @@ abstract class XDecoratedPeer extends XWindowPeer {
                     }
                 }
 
-                if (correctWM != null) {
+                if (correctWM != null && XWM.getWMID() != XWM.UNITY_COMPIZ_WM) {
                     handleCorrectInsets(correctWM);
                 }
             }
@@ -664,6 +690,9 @@ abstract class XDecoratedPeer extends XWindowPeer {
 
     boolean no_reparent_artifacts = false;
     public void handleConfigureNotifyEvent(XEvent xev) {
+        if (XWM.getWMID() == XWM.UNITY_COMPIZ_WM && !insets_corrected) {
+            return;
+        }
         assert (SunToolkit.isAWTLockHeldByCurrentThread());
         XConfigureEvent xe = xev.get_xconfigure();
         if (insLog.isLoggable(PlatformLogger.Level.FINE)) {

--- a/jdk/src/solaris/classes/sun/awt/X11/XWM.java
+++ b/jdk/src/solaris/classes/sun/awt/X11/XWM.java
@@ -1340,6 +1340,9 @@ final class XWM
               case LG3D_WM:
                   res = zeroInsets;
                   break;
+              case UNITY_COMPIZ_WM:
+                  res = new Insets(28, 1, 1, 1);
+                  break;
               case MOTIF_WM:
               case OPENLOOK_WM:
               default:

--- a/jdk/src/solaris/classes/sun/awt/X11/XWindowPeer.java
+++ b/jdk/src/solaris/classes/sun/awt/X11/XWindowPeer.java
@@ -775,6 +775,7 @@ class XWindowPeer extends XPanelPeer implements WindowPeer,
                 case XWM.METACITY_WM:
                 case XWM.MUTTER_WM:
                 case XWM.SAWFISH_WM:
+                case XWM.UNITY_COMPIZ_WM:
                 {
                     Point xlocation = queryXLocation();
                     if (log.isLoggable(PlatformLogger.Level.FINE)) {

--- a/jdk/test/java/awt/Window/GetScreenLocation/GetScreenLocationTest.java
+++ b/jdk/test/java/awt/Window/GetScreenLocation/GetScreenLocationTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test @summary setLocationRelativeTo stopped working in Ubuntu 13.10 (Unity)
+ * @bug 8036915
+ * @run main GetScreenLocationTest
+ */
+import java.awt.*;
+
+public class GetScreenLocationTest {
+
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+        Window frame = null;
+        for(int i = 0; i < 50; i++) {
+            if(frame != null) frame.dispose();
+            frame = new Dialog((Frame)null);
+            frame.setBounds(0, 0, 200, 200);
+            frame.setVisible(true);
+            robot.waitForIdle();
+            robot.delay(200);
+            frame.setLocation(321, 321);
+            robot.waitForIdle();
+            robot.delay(200);
+            Dimension size = frame.getSize();
+            if(size.width != 200 || size.height != 200) {
+                frame.dispose();
+                throw new RuntimeException("getSize() is wrong " + size);
+            }
+            Rectangle r = frame.getBounds();
+            frame.dispose();
+            if(r.x != 321 || r.y != 321) {
+                throw new RuntimeException("getLocation() returns " +
+                        "wrong coordinates " + r.getLocation());
+            }
+            if(r.width != 200 || r.height != 200) {
+                throw new RuntimeException("getSize() is wrong " + r.getSize());
+            }
+        }
+        System.out.println("ok");
+    }
+
+}


### PR DESCRIPTION
Backporting JDK-8036915: setLocationRelativeTo stopped working in Ubuntu 13.10 (Unity). As described on the original ticket, this change ensures that insets are correctly set when using Unity interface and otherwise have no effect. Ran GHA checks. Patch is clean (beyond file renaming).

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[ \] [JDK-8036915](https://bugs.openjdk.org/browse/JDK-8036915) needs maintainer approval
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8036915](https://bugs.openjdk.org/browse/JDK-8036915): setLocationRelativeTo stopped working in Ubuntu 13.10 (Unity) (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/839/head:pull/839` \
`$ git checkout pull/839`

Update a local copy of the PR: \
`$ git checkout pull/839` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/839/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 839`

View PR using the GUI difftool: \
`$ git pr show -t 839`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/839.diff">https://git.openjdk.org/jdk8u-dev/pull/839.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/839#issuecomment-4927616381)
</details>
