### PR TITLE
8388142: [8u] Path to PreferredKey.java exclusion is wrong

### DIFF
--- a/jdk/test/ProblemList.txt
+++ b/jdk/test/ProblemList.txt
@@ -309,9 +309,6 @@ sun/security/pkcs11/rsa/TestKeyPairGenerator.java               linux-all,solari
 # 8151834
 sun/security/mscapi/SmallPrimeExponentP.java                    windows-i586
 
-#8176354
-sun/security/ssl/com/sun/net/ssl/internal/ssl/X509KeyManager/PreferredKey.java     generic-all
-
 # 8206909
 com/sun/crypto/provider/CICO/PBEFunc/CICOPBEFuncTest.java       solaris-sparcv9
 


### PR DESCRIPTION
Test was excluded due to issue that was later fixed.

Also, the unexclusion refers to the old file location, which no longer exists, so the exclusion isn't excluding anything.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8388142](https://bugs.openjdk.org/browse/JDK-8388142) needs maintainer approval

### Issue
 * [JDK-8388142](https://bugs.openjdk.org/browse/JDK-8388142): [8u] Path to PreferredKey.java exclusion is wrong (**Bug** - P4 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/841/head:pull/841` \
`$ git checkout pull/841`

Update a local copy of the PR: \
`$ git checkout pull/841` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/841/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 841`

View PR using the GUI difftool: \
`$ git pr show -t 841`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/841.diff">https://git.openjdk.org/jdk8u-dev/pull/841.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/841#issuecomment-4959133896)
</details>
