### PR TITLE
8388811: [8u] VS2010 build broken by JDK-8374058

### DIFF
--- a/jdk/src/share/native/sun/awt/image/jpeg/imageioJPEG.c
+++ b/jdk/src/share/native/sun/awt/image/jpeg/imageioJPEG.c
@@ -924,6 +924,7 @@ imageio_fill_input_buffer(j_decompress_ptr cinfo)
     JNIEnv *env = (JNIEnv *)JNU_GetEnv(jvm, JNI_VERSION_1_2);
     int ret;
     jobject input = NULL;
+    jboolean isCopy;
 
     /* This is where input suspends */
     if (sb->suspendable) {
@@ -953,7 +954,7 @@ imageio_fill_input_buffer(j_decompress_ptr cinfo)
      * release it and get new copy, if we don't have native copy we rely
      * on JVM to maintain the pinned handle of java array.
      */
-    jboolean isCopy = sb->isCopy;
+    isCopy = sb->isCopy;
     if (isCopy) {
         unpinStreamBuffer(env, &data->streamBuf, src->next_input_byte, JNI_ABORT);
     }


### PR DESCRIPTION
JDK-8374058, part of the 8u502 security changes, broke the build on Visual Studio 2010 by introducing a variable declaration in the middle of the function.

Moving it to the top of the function fixes the issue.  I've confirmed this locally with `gcc` using `-Werror=declaration-after-statement`.

~~~
diff --git a/jdk/make/lib/Awt2dLibraries.gmk b/jdk/make/lib/Awt2dLibraries.gmk
index dc140de77f..177a734594 100644
--- a/jdk/make/lib/Awt2dLibraries.gmk
+++ b/jdk/make/lib/Awt2dLibraries.gmk
@@ -741,7 +741,8 @@ $(eval $(call SetupNativeCompilation,BUILD_LIBJPEG, \
     OPTIMIZATION := HIGHEST, \
     CFLAGS := $(CFLAGS_JDKLIB) \
         $(BUILD_LIBJPEG_CLOSED_INCLUDES) \
-        -I$(JDK_TOPDIR)/src/share/native/sun/awt/image/jpeg, \
+        -I$(JDK_TOPDIR)/src/share/native/sun/awt/image/jpeg \
+    	-Werror=declaration-after-statement, \
     MAPFILE := $(BUILD_LIBJPEG_MAPFILE), \
     LDFLAGS := $(LDFLAGS_JDKLIB) \
         $(call SET_SHARED_LIBRARY_ORIGIN), \
~~~

As a follow-on, I intend to look at whether we can introduce `-Werror=declaration-after-statement` to `gcc` builds so we can catch instances in shared code without requiring a Visual Studio 2010 build.  This is at least the third instance of such breakage.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8388811](https://bugs.openjdk.org/browse/JDK-8388811) needs maintainer approval

### Issue
 * [JDK-8388811](https://bugs.openjdk.org/browse/JDK-8388811): [8u] VS2010 build broken by JDK-8374058 (**Bug** - P4 - Approved)


### Reviewers
 * [Thomas Fitzsimmons](https://openjdk.org/census#fitzsim) (@fitzsim - no project role)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/843/head:pull/843` \
`$ git checkout pull/843`

Update a local copy of the PR: \
`$ git checkout pull/843` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/843/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 843`

View PR using the GUI difftool: \
`$ git pr show -t 843`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/843.diff">https://git.openjdk.org/jdk8u-dev/pull/843.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/843#issuecomment-5060620010)
</details>
