### PR TITLE
8315380: AsyncGetCallTrace crash in frame::safe_for_sender

### DIFF
--- a/hotspot/src/cpu/aarch64/vm/frame_aarch64.cpp
+++ b/hotspot/src/cpu/aarch64/vm/frame_aarch64.cpp
@@ -84,7 +84,8 @@ bool frame::safe_for_sender(JavaThread *thread) {
   // So unextended sp must be within the stack but we need not to check
   // that unextended sp >= sp
 
-  bool unextended_sp_safe = (unextended_sp < thread->stack_base());
+  bool unextended_sp_safe = (unextended_sp < thread->stack_base()) &&
+                            (unextended_sp >= thread->stack_base() - thread->stack_size());
 
   if (!unextended_sp_safe) {
     return false;


### PR DESCRIPTION
Backport from  https://github.com/openjdk/jdk11u-dev/commit/d46f769e70f6c0e8effcb78310cacc391a14fd6f  .Fix AsyncGetCallTrace crash in frame::safe_for_sender.  The `stack_end` method is not defined in the `Thread` class of JDK8.

The `stack_end` method is equivalent to the following implementation:
```
thread->stack_base() - thread->stack_size()
```

The proposed change then is:
```
bool unextended_sp_safe = (unextended_sp < thread->stack_base() && \
                             sp >= thread->stack_base() - thread->stack_size());
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] [JDK-8315380](https://bugs.openjdk.org/browse/JDK-8315380) needs maintainer approval

### Issue
 * [JDK-8315380](https://bugs.openjdk.org/browse/JDK-8315380): AsyncGetCallTrace crash in frame::safe_for_sender (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/845/head:pull/845` \
`$ git checkout pull/845`

Update a local copy of the PR: \
`$ git checkout pull/845` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/845/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 845`

View PR using the GUI difftool: \
`$ git pr show -t 845`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/845.diff">https://git.openjdk.org/jdk8u-dev/pull/845.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/845#issuecomment-5437099818)
</details>
