### PR TITLE
8336012: Fix usages of jtreg-reserved properties

### DIFF
--- a/jdk/test/java/lang/invoke/PrivateInvokeTest.java
+++ b/jdk/test/java/lang/invoke/PrivateInvokeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/jdk/test/java/lang/invoke/PrivateInvokeTest.java
+++ b/jdk/test/java/lang/invoke/PrivateInvokeTest.java
@@ -68,8 +68,6 @@ public class PrivateInvokeTest {
         String vstr = System.getProperty(THIS_CLASS.getSimpleName()+".verbose");
         if (vstr == null)
             vstr = System.getProperty(THIS_CLASS.getName()+".verbose");
-        if (vstr == null)
-            vstr = System.getProperty("test.verbose");
         if (vstr != null)  verbose = Integer.parseInt(vstr);
     }
     private static int referenceKind(Method m) {


### PR DESCRIPTION
Backport of JDK-8336012 - Fix usages of jtreg-reserved properties

It's fixing the java/lang/invoke/PrivateInvokeTest.java#PrivateInvokeTest failure.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] [JDK-8336012](https://bugs.openjdk.org/browse/JDK-8336012) needs maintainer approval

### Issue
 * [JDK-8336012](https://bugs.openjdk.org/browse/JDK-8336012): Fix usages of jtreg-reserved properties (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/846/head:pull/846` \
`$ git checkout pull/846`

Update a local copy of the PR: \
`$ git checkout pull/846` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/846/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 846`

View PR using the GUI difftool: \
`$ git pr show -t 846`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/846.diff">https://git.openjdk.org/jdk8u-dev/pull/846.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/846#issuecomment-5439031794)
</details>
