### PR TITLE
8312182: THPs cause huge RSS due to thread start timing issue

### DIFF
--- a/hotspot/src/os/linux/vm/globals_linux.hpp
+++ b/hotspot/src/os/linux/vm/globals_linux.hpp
@@ -55,7 +55,17 @@
   product(bool, PreferContainerQuotaForCPUCount, true,                  \
           "Calculate the container CPU availability based on the value" \
           " of quotas (if set), when true. Otherwise, use the CPU"      \
-          " shares value, provided it is less than quota.")
+          " shares value, provided it is less than quota.")             \
+                                                                        \
+  diagnostic(bool, THPStackMitigation, true,                            \
+          "If THPs are unconditionally enabled on the system (mode "    \
+          "\"always\"), the JVM will prevent THP from forming in "      \
+          "thread stacks. When disabled, the absence of this mitigation"\
+          "allows THPs to form in thread stacks.")                      \
+                                                                        \
+  develop(bool, DelayThreadStartALot, false,                            \
+          "Artificially delay thread starts randomly for testing.")     \
+                                                                        \
 
 //
 // Defines Linux-specific default values. The flags are available on all

--- a/hotspot/src/os/linux/vm/os_linux.cpp
+++ b/hotspot/src/os/linux/vm/os_linux.cpp
@@ -3694,7 +3694,7 @@ static bool is_thp_always_mode() {
 static bool is_glibc_2_27_or_later(void) {
   int major = -1, minor = -1;
   const char *version_str = gnu_get_libc_version();
-  assert(version_str != nullptr, "gnu_get_libc_version returns null?");
+  assert(version_str != NULL, "gnu_get_libc_version returns null?");
 
   if (sscanf(version_str, "%d.%d", &major, &minor) != 2) {
     // if unsure, just assume we are running on a newer glibc; that is
@@ -3713,7 +3713,7 @@ static bool is_glibc_2_27_or_later(void) {
 // (replacement for log_info(os))
 static void log_info_os(const char* txt) {
   if(Verbose && PrintMiscellaneous) {
-    tty->print_cr("%s");
+    tty->print_cr("%s", txt);
   }
 }
 

--- a/hotspot/src/os/linux/vm/os_linux.cpp
+++ b/hotspot/src/os/linux/vm/os_linux.cpp
@@ -845,6 +845,10 @@ static void *java_start(Thread *thread) {
     }
   }
 
+  if (DelayThreadStartALot) {
+    os::naked_short_sleep(100);
+  }
+
   // call one more level start routine
   thread->run();
 
@@ -903,13 +907,24 @@ bool os::create_thread(Thread* thread, ThreadType thr_type, size_t stack_size) {
 
     stack_size = MAX2(stack_size, os::Linux::min_stack_allowed);
 
-    // Add an additional page to the stack size to reduce its chances of getting large page aligned
-    // so that the stack does not get backed by a transparent huge page.
-    size_t default_large_page_size = os::large_page_size();
-    if (default_large_page_size != 0 &&
-        stack_size >= default_large_page_size &&
-        is_aligned(stack_size, default_large_page_size)) {
-      stack_size += os::vm_page_size();
+    if (THPStackMitigation) {
+      // In addition to the glibc guard page that prevents inter-thread-stack hugepage
+      // coalescing (see comment in os::Linux::default_guard_size()), we also make
+      // sure the stack size itself is not huge-page-size aligned; that makes it much
+      // more likely for thread stack boundaries to be unaligned as well and hence
+      // protects thread stacks from being targeted by khugepaged.
+
+      // Note JDK 11/8: In order to minimize changes to these old releases, here we
+      // continue to assume that <static large page size> == <thp page size> (instead
+      // of querying THP page geometry from the OS). Outside of obscure corner cases
+      // (e.g. 1GB static huge pages set up as only variant on x64) this is not a problem,
+      // and these corner cases are served better with modern JVM variants.
+      size_t default_large_page_size = os::large_page_size();
+      if (default_large_page_size != 0 &&
+          stack_size >= default_large_page_size &&
+          is_aligned(stack_size, default_large_page_size)) {
+        stack_size += os::vm_page_size();
+      }
     }
 
     pthread_attr_setstacksize(&attr, stack_size);
@@ -918,7 +933,27 @@ bool os::create_thread(Thread* thread, ThreadType thr_type, size_t stack_size) {
   }
 
   // glibc guard page
-  pthread_attr_setguardsize(&attr, os::Linux::default_guard_size(thr_type));
+  size_t guard_size = os::Linux::default_guard_size(thr_type);
+  if (THPStackMitigation) {
+    // If THPs are unconditionally enabled, the following scenario can lead to huge RSS
+    // - parent thread spawns, in quick succession, multiple child threads
+    // - child threads are slow to start
+    // - thread stacks of future child threads are adjacent and get merged into one large VMA
+    //   by the kernel, and subsequently transformed into huge pages by khugepaged
+    // - child threads come up, place JVM guard pages, thus splinter the large VMA, splinter
+    //   the huge pages into many (still paged-in) small pages.
+    // The result of that sequence are thread stacks that are fully paged-in even though the
+    // threads did not even start yet.
+    // We prevent that by letting the glibc allocate a guard page, which causes a VMA with different
+    // permission bits to separate two ajacent thread stacks and therefore prevent merging stacks
+    // into one VMA.
+    //
+    // Yes, this means we have two guard sections - the glibc and the JVM one - per thread. But the
+    // cost for that one extra protected page is dwarfed from a large win in performance and memory
+    // that avoiding interference by khugepaged buys us.
+    guard_size = MAX2((size_t)os::vm_page_size(), guard_size);
+  }
+  pthread_attr_setguardsize(&attr, guard_size);
 
   ThreadState state;
 
@@ -3637,9 +3672,44 @@ bool os::Linux::setup_large_page_type(size_t page_size) {
   return UseSHM;
 }
 
+// JDK 11 and 8: is_thp_always_mode was added to support JDK-8312182 without
+// having to backport a long chain of newer THP-releated patches.
+static bool is_thp_always_mode() {
+  const char* filename = "/sys/kernel/mm/transparent_hugepage/enabled";
+  bool result = false;
+  FILE* f = ::fopen(filename, "r");
+  if (f != NULL) {
+    char buf[64];
+    char* s = fgets(buf, sizeof(buf), f);
+    assert(s == buf, "Should have worked");
+    if (::strstr(buf, "[always]") != NULL) {
+      result = true;
+    }
+    fclose(f);
+  }
+  return result;
+}
+
 void os::large_page_init() {
   // Always initialize the default large page size even if large pages are not being used.
   size_t large_page_size = Linux::setup_large_page_size();
+
+  // If THPs are unconditionally enabled (THP mode "always"), khugepaged may attempt to
+  // coalesce small pages in thread stacks to huge pages. That costs a lot of memory and
+  // is usually unwanted for thread stacks. Therefore we attempt to prevent THP formation in
+  // thread stacks unless the user explicitly allowed THP formation by manually disabling
+  // -XX:-THPStackMitigation.
+  if (is_thp_always_mode()) {
+    if(Verbose && PrintMiscellaneous) {
+      if (THPStackMitigation) {
+        tty->print_cr("JVM will attempt to prevent THPs in thread stacks.");
+      } else {
+        tty->print_cr("JVM will *not* prevent THPs in thread stacks. This may cause high RSS.");
+      }
+    }
+  } else {
+    FLAG_SET_ERGO(bool, THPStackMitigation, false); // Mitigation not needed
+  }
 
   // Handle the case where we do not want to use huge pages
   if (!UseLargePages &&

--- a/hotspot/src/os/linux/vm/os_linux.cpp
+++ b/hotspot/src/os/linux/vm/os_linux.cpp
@@ -3691,22 +3691,15 @@ static bool is_thp_always_mode() {
 }
 
 // JDK8-specific helper for os::large_page_init()
-static bool is_glibc_2_27_or_later(void) {
+static bool is_glibc_older_than_2_27(void) {
   int major = -1, minor = -1;
   const char *version_str = gnu_get_libc_version();
   assert(version_str != NULL, "gnu_get_libc_version returns null?");
 
   if (sscanf(version_str, "%d.%d", &major, &minor) != 2) {
-    // if unsure, just assume we are running on a newer glibc; that is
-    // the safer bet now (2026 and beyond)
-    return true;
+    return true; // prefer compatibility if unsure
   }
-
-  if (major > 2 || (major == 2 && minor >= 27)) {
-    return true;
-  }
-
-  return false;
+  return (major < 2 || (major == 2 && minor < 27));
 }
 
 // JDK8-specific helper for os::large_page_init()
@@ -3732,7 +3725,7 @@ void os::large_page_init() {
       // the stack size. Later JDKs deal with that. JDK8 lacks those patches (e.g. JDK-8229147).
       // This bug could cause SOE on glic<2.27 (eg RHEL 7) on platforms with large page sizes. To
       // mitigate this problem, we just disable THP mitigation on older glibc versions altogether.
-      if (!is_glibc_2_27_or_later()) {
+      if (is_glibc_older_than_2_27()) {
         log_info_os("THP mitigation not supported on glibc < 2.27.");
         FLAG_SET_ERGO(bool, THPStackMitigation, false);
       } else {

--- a/hotspot/src/os/linux/vm/os_linux.cpp
+++ b/hotspot/src/os/linux/vm/os_linux.cpp
@@ -951,7 +951,16 @@ bool os::create_thread(Thread* thread, ThreadType thr_type, size_t stack_size) {
     // Yes, this means we have two guard sections - the glibc and the JVM one - per thread. But the
     // cost for that one extra protected page is dwarfed from a large win in performance and memory
     // that avoiding interference by khugepaged buys us.
-    guard_size = MAX2((size_t)os::vm_page_size(), guard_size);
+
+    // Note JDK8-specific: Glibc<2.27 has a bug that causes the libc to *deduct* the guard size from
+    // the stack size. Later JDKs deal with that. JDK8 lacks those patches (e.g. JDK-8229147).
+    // This bug could cause SOE on glic<2.27 (eg RHEL 7) on platforms with large page sizes. To
+    // mitigate this problem, instead of unconditionally creating guard pages like we do in later
+    // releases - where it causes no harm - we avoid creating guard pages for stacks that are
+    // significantly smaller than a THP page size.
+    if (stack_size > (os::large_page_size() / 8)) {
+      guard_size = os::vm_page_size();
+    }
   }
   pthread_attr_setguardsize(&attr, guard_size);
 

--- a/hotspot/src/os/linux/vm/os_linux.cpp
+++ b/hotspot/src/os/linux/vm/os_linux.cpp
@@ -951,16 +951,7 @@ bool os::create_thread(Thread* thread, ThreadType thr_type, size_t stack_size) {
     // Yes, this means we have two guard sections - the glibc and the JVM one - per thread. But the
     // cost for that one extra protected page is dwarfed from a large win in performance and memory
     // that avoiding interference by khugepaged buys us.
-
-    // Note JDK8-specific: Glibc<2.27 has a bug that causes the libc to *deduct* the guard size from
-    // the stack size. Later JDKs deal with that. JDK8 lacks those patches (e.g. JDK-8229147).
-    // This bug could cause SOE on glic<2.27 (eg RHEL 7) on platforms with large page sizes. To
-    // mitigate this problem, instead of unconditionally creating guard pages like we do in later
-    // releases - where it causes no harm - we avoid creating guard pages for stacks that are
-    // significantly smaller than a THP page size.
-    if (stack_size > (os::large_page_size() / 8)) {
-      guard_size = os::vm_page_size();
-    }
+    guard_size = os::vm_page_size();
   }
   pthread_attr_setguardsize(&attr, guard_size);
 
@@ -3699,6 +3690,33 @@ static bool is_thp_always_mode() {
   return result;
 }
 
+// JDK8-specific helper for os::large_page_init()
+static bool is_glibc_2_27_or_later(void) {
+  int major = -1, minor = -1;
+  const char *version_str = gnu_get_libc_version();
+  assert(version_str != nullptr, "gnu_get_libc_version returns null?");
+
+  if (sscanf(version_str, "%d.%d", &major, &minor) != 2) {
+    // if unsure, just assume we are running on a newer glibc; that is
+    // the safer bet now (2026 and beyond)
+    return true;
+  }
+
+  if (major > 2 || (major == 2 && minor >= 27)) {
+    return true;
+  }
+
+  return false;
+}
+
+// JDK8-specific helper for os::large_page_init()
+// (replacement for log_info(os))
+static void log_info_os(const char* txt) {
+  if(Verbose && PrintMiscellaneous) {
+    tty->print_cr("%s");
+  }
+}
+
 void os::large_page_init() {
   // Always initialize the default large page size even if large pages are not being used.
   size_t large_page_size = Linux::setup_large_page_size();
@@ -3709,12 +3727,19 @@ void os::large_page_init() {
   // thread stacks unless the user explicitly allowed THP formation by manually disabling
   // -XX:-THPStackMitigation.
   if (is_thp_always_mode()) {
-    if(Verbose && PrintMiscellaneous) {
-      if (THPStackMitigation) {
-        tty->print_cr("JVM will attempt to prevent THPs in thread stacks.");
+    if (THPStackMitigation) {
+      // Note JDK8-specific: Glibc<2.27 has a bug that causes the libc to *deduct* the guard size from
+      // the stack size. Later JDKs deal with that. JDK8 lacks those patches (e.g. JDK-8229147).
+      // This bug could cause SOE on glic<2.27 (eg RHEL 7) on platforms with large page sizes. To
+      // mitigate this problem, we just disable THP mitigation on older glibc versions altogether.
+      if (!is_glibc_2_27_or_later()) {
+        log_info_os("THP mitigation not supported on glibc < 2.27.");
+        FLAG_SET_ERGO(bool, THPStackMitigation, false);
       } else {
-        tty->print_cr("JVM will *not* prevent THPs in thread stacks. This may cause high RSS.");
+        log_info_os("JVM will attempt to prevent THPs in thread stacks.");
       }
+    } else {
+      log_info_os("JVM will *not* prevent THPs in thread stacks. This may cause high RSS.");
     }
   } else {
     FLAG_SET_ERGO(bool, THPStackMitigation, false); // Mitigation not needed

--- a/hotspot/test/runtime/os/THPsInThreadStackPreventionTest.java
+++ b/hotspot/test/runtime/os/THPsInThreadStackPreventionTest.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Red Hat Inc.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test id=ENABLED
+ * @bug 8303215 8312182
+ * @summary On THP=always systems, we prevent THPs from forming within thread stacks
+ * @library /test/lib
+ * @requires os.family == "linux"
+ * @requires vm.debug
+ * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64"
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run driver THPsInThreadStackPreventionTest PATCH-ENABLED
+ */
+
+/*
+ * @test id=DISABLED
+ * @bug 8303215 8312182
+ * @summary On THP=always systems, we prevent THPs from forming within thread stacks (negative test)
+ * @library /test/lib
+ * @requires os.family == "linux"
+ * @requires vm.debug
+ * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64"
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run main/manual THPsInThreadStackPreventionTest  PATCH-DISABLED
+ */
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+import jtreg.SkippedException;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+
+public class THPsInThreadStackPreventionTest {
+
+    // We test the mitigation for "huge rss for THP=always" introduced with JDK-8312182 and JDK-8302015:
+    //
+    // We start a program that spawns a ton of threads with a stack size close to THP page size. The threads
+    // are idle and should not build up a lot of stack. The threads are started with an artificial delay
+    // between thread start and stack guardpage creation, which exacerbates the RSS bloat (for explanation
+    // please see 8312182).
+    //
+    // We then observe RSS of that program. We expect it to stay below a reasonable maximum. The unpatched
+    // version should show an RSS of ~2 GB (paying for the fully paged in thread stacks). The fixed variant should
+    // cost only ~200-400 MB.
+
+    static final int numThreads = 1000;
+    static final long threadStackSizeMB = 2; // must be 2M
+    static final long heapSizeMB = 64;
+    static final long basicRSSOverheadMB = heapSizeMB + 150;
+    // A successful completion of this test would show not more than X KB per thread stack.
+    static final long acceptableRSSPerThreadStack = 128 * 1024;
+    static final long acceptableRSSForAllThreadStacks = numThreads * acceptableRSSPerThreadStack;
+    static final long acceptableRSSLimitMB = (acceptableRSSForAllThreadStacks / (1024 * 1024)) + basicRSSOverheadMB;
+
+    /* JDK11-specific downporting helper */
+    private static boolean isThpAlwaysMode() {
+        boolean result = false;
+        String file = "/sys/kernel/mm/transparent_hugepage/enabled";
+        try (BufferedReader br = new BufferedReader(new FileReader(file))) {
+            String line = br.readLine(); // Reads only the first line
+            if (line != null && line.contains("[always]")) {
+                result = true;
+            }
+        } catch (IOException e) {
+            System.out.println(String.format("Failed to read %s; Test will be skipped.", file));
+        }
+        return result;
+    }
+
+    private static class TestMain {
+
+        static class Sleeper extends Thread {
+            CyclicBarrier barrier;
+            public Sleeper(CyclicBarrier barrier) {
+                this.barrier = barrier;
+            }
+            @Override
+            public void run() {
+                try {
+                    barrier.await(); // wait for all siblings
+                    barrier.await(); // wait main thread to print status
+                } catch (InterruptedException | BrokenBarrierException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+
+        public static void main(String[] args) throws BrokenBarrierException, InterruptedException {
+
+            // Fire up 1000 threads with 2M stack size each.
+            Sleeper[] threads = new Sleeper[numThreads];
+            CyclicBarrier barrier = new CyclicBarrier(numThreads + 1);
+
+            for (int i = 0; i < numThreads; i++) {
+                threads[i] = new Sleeper(barrier);
+                threads[i].start();
+            }
+
+            // Wait for all threads to come up
+            barrier.await();
+
+            // print status
+            String file = "/proc/self/status";
+            try (FileReader fr = new FileReader(file);
+                 BufferedReader reader = new BufferedReader(fr)) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    System.out.println(line);
+                }
+            } catch (IOException | NumberFormatException e) { /* ignored */ }
+
+            // Signal threads to stop
+            barrier.await();
+
+        }
+    }
+
+    static class ProcSelfStatus {
+
+        public long rssMB;
+        public long swapMB;
+        public int numLifeThreads;
+
+        // Parse output from /proc/self/status
+        public static ProcSelfStatus parse(OutputAnalyzer o) {
+            ProcSelfStatus status = new ProcSelfStatus();
+            String s = o.firstMatch("Threads:\\s*(\\d+)", 1);
+            Objects.requireNonNull(s);
+            status.numLifeThreads = Integer.parseInt(s);
+            s = o.firstMatch("VmRSS:\\s*(\\d+) kB", 1);
+            Objects.requireNonNull(s);
+            status.rssMB = Long.parseLong(s) / 1024;
+            s = o.firstMatch("VmSwap:\\s*(\\d+) kB", 1);
+            Objects.requireNonNull(s);
+            status.swapMB = Long.parseLong(s) / 1024;
+            return status;
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        // This issue is bound to THP=always
+        if (!isThpAlwaysMode()) {
+            throw new SkippedException("Test only makes sense in THP \"always\" mode");
+        }
+
+        String[] defaultArgs = {
+            "-Xlog:pagesize",
+            "-Xmx" + heapSizeMB + "m", "-Xms" + heapSizeMB + "m", "-XX:+AlwaysPreTouch", // stabilize RSS
+            "-Xss" + threadStackSizeMB + "m",
+            "-XX:-CreateCoredumpOnCrash",
+            // Limits the number of JVM-internal threads, which depends on the available cores of the
+            // machine. RSS+Swap could exceed acceptableRSSLimitMB when JVM creates many internal threads.
+            "-XX:ActiveProcessorCount=2",
+            // This will delay the child threads before they create guard pages, thereby greatly increasing the
+            // chance of large VMA formation + hugepage coalescation; see JDK-8312182
+            "-XX:+DelayThreadStartALot"
+        };
+        ArrayList<String> finalargs = new ArrayList<>(Arrays.asList(defaultArgs));
+
+        switch (args[0]) {
+            case "PATCH-ENABLED": {
+                finalargs.add(TestMain.class.getName());
+                ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(finalargs);
+
+                OutputAnalyzer output = new OutputAnalyzer(pb.start());
+                output.shouldHaveExitValue(0);
+
+                // this line indicates the mitigation is active:
+                output.shouldContain("[pagesize] JVM will attempt to prevent THPs in thread stacks.");
+
+                ProcSelfStatus status = ProcSelfStatus.parse(output);
+                if (status.numLifeThreads < numThreads) {
+                    throw new RuntimeException("Number of live threads lower than expected: " + status.numLifeThreads + ", expected " + numThreads);
+                } else {
+                    System.out.println("Found " + status.numLifeThreads + " to be alive. Ok.");
+                }
+
+                long rssPlusSwapMB = status.swapMB + status.rssMB;
+
+                if (rssPlusSwapMB > acceptableRSSLimitMB) {
+                    throw new RuntimeException("RSS+Swap larger than expected: " + rssPlusSwapMB + "m, expected at most " + acceptableRSSLimitMB + "m");
+                } else {
+                    if (rssPlusSwapMB < heapSizeMB) { // we pretouch the java heap, so we expect to see at least that:
+                        throw new RuntimeException("RSS+Swap suspiciously low: " + rssPlusSwapMB + "m, expected at least " + heapSizeMB + "m");
+                    }
+                    System.out.println("Okay: RSS+Swap=" + rssPlusSwapMB + ", within acceptable limit of " + acceptableRSSLimitMB);
+                }
+            }
+            break;
+
+            case "PATCH-DISABLED": {
+
+                // Only execute manually! this will allocate ~2gb of memory!
+
+                // explicitly disable the no-THP-workaround:
+                finalargs.add("-XX:+UnlockDiagnosticVMOptions");
+                finalargs.add("-XX:-THPStackMitigation");
+
+                finalargs.add(TestMain.class.getName());
+                ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(finalargs);
+                OutputAnalyzer output = new OutputAnalyzer(pb.start());
+
+                output.shouldHaveExitValue(0);
+
+                // We deliberately switched off mitigation, VM should tell us:
+                output.shouldContain("[pagesize] JVM will *not* prevent THPs in thread stacks. This may cause high RSS.");
+
+                // Parse output from self/status
+                ProcSelfStatus status = ProcSelfStatus.parse(output);
+                if (status.numLifeThreads < numThreads) {
+                    throw new RuntimeException("Number of live threads lower than expected (" + status.numLifeThreads + ", expected " + numThreads +")");
+                } else {
+                    System.out.println("Found " + status.numLifeThreads + " to be alive. Ok.");
+                }
+
+                long rssPlusSwapMB = status.swapMB + status.rssMB;
+
+                if (rssPlusSwapMB < acceptableRSSLimitMB) {
+                    throw new RuntimeException("RSS+Swap lower than expected: " + rssPlusSwapMB + "m, expected more than " + acceptableRSSLimitMB + "m");
+                }
+                break;
+            }
+
+            default: throw new RuntimeException("Bad argument: " + args[0]);
+        }
+    }
+}

--- a/hotspot/test/runtime/os/THPsInThreadStackPreventionTest.java
+++ b/hotspot/test/runtime/os/THPsInThreadStackPreventionTest.java
@@ -59,6 +59,9 @@ import java.util.Arrays;
 import java.util.Objects;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
+import java.io.InputStreamReader;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class THPsInThreadStackPreventionTest {
 
@@ -167,6 +170,28 @@ public class THPsInThreadStackPreventionTest {
         }
     }
 
+    // JDK8-specific helper
+    private static int glibcVersion = 0x0227;
+    static {
+        try {
+            Process process = Runtime.getRuntime().exec(new String[]{"getconf", "GNU_LIBC_VERSION"});
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                String line = reader.readLine();
+                if (line != null) {
+                    final Matcher mat = Pattern.compile("glibc\\s+(\\d+)\\.(\\d+)").matcher(line);
+                    if (mat.matches()) {
+                        int major = Integer.parseInt(mat.group(1));
+                        int minor = Integer.parseInt(mat.group(2));
+                        glibcVersion = (major << 8) + minor;
+                        System.out.println("glibcVersion: " + Integer.toHexString(glibcVersion));
+                    }
+                }
+            }
+        } catch (Exception e) {
+            System.out.println("Failed to determine glibc version");
+        }
+    }
+
     public static void main(String[] args) throws Exception {
 
         // This issue is bound to THP=always
@@ -195,6 +220,12 @@ public class THPsInThreadStackPreventionTest {
 
                 OutputAnalyzer output = new OutputAnalyzer(pb.start());
                 output.shouldHaveExitValue(0);
+
+                // JDK8-specific: We disabled the patch on glibc < 2.27
+                if (glibcVersion < 0x0227) {
+                    output.shouldContain("THP mitigation not supported on glibc < 2.27.");
+                    throw new SkippedException("Running on glibc < 2.27, skipping test");
+                }
 
                 // this line indicates the mitigation is active:
                 output.shouldContain("JVM will attempt to prevent THPs in thread stacks.");
@@ -234,7 +265,7 @@ public class THPsInThreadStackPreventionTest {
                 output.shouldHaveExitValue(0);
 
                 // We deliberately switched off mitigation, VM should tell us:
-                output.shouldContain("[pagesize] JVM will *not* prevent THPs in thread stacks. This may cause high RSS.");
+                output.shouldContain("JVM will *not* prevent THPs in thread stacks. This may cause high RSS.");
 
                 // Parse output from self/status
                 ProcSelfStatus status = ProcSelfStatus.parse(output);

--- a/hotspot/test/runtime/os/THPsInThreadStackPreventionTest.java
+++ b/hotspot/test/runtime/os/THPsInThreadStackPreventionTest.java
@@ -171,7 +171,8 @@ public class THPsInThreadStackPreventionTest {
     }
 
     // JDK8-specific helper
-    private static int glibcVersion = 0x0227;
+    private static int glibcMajor = 2;
+    private static int glibcMinor = 27;
     static {
         try {
             Process process = Runtime.getRuntime().exec(new String[]{"getconf", "GNU_LIBC_VERSION"});
@@ -180,10 +181,9 @@ public class THPsInThreadStackPreventionTest {
                 if (line != null) {
                     final Matcher mat = Pattern.compile("glibc\\s+(\\d+)\\.(\\d+)").matcher(line);
                     if (mat.matches()) {
-                        int major = Integer.parseInt(mat.group(1));
-                        int minor = Integer.parseInt(mat.group(2));
-                        glibcVersion = (major << 8) + minor;
-                        System.out.println("glibcVersion: " + Integer.toHexString(glibcVersion));
+                        glibcMajor = Integer.parseInt(mat.group(1));
+                        glibcMinor = Integer.parseInt(mat.group(2));
+                        System.out.println(String.format("glibcVersion: %d.%d", glibcMajor, glibcMinor));
                     }
                 }
             }
@@ -222,7 +222,7 @@ public class THPsInThreadStackPreventionTest {
                 output.shouldHaveExitValue(0);
 
                 // JDK8-specific: We disabled the patch on glibc < 2.27
-                if (glibcVersion < 0x0227) {
+                if (glibcMajor < 2 || (glibcMajor == 2 && glibcMinor < 27)) {
                     output.shouldContain("THP mitigation not supported on glibc < 2.27.");
                     throw new SkippedException("Running on glibc < 2.27, skipping test");
                 }

--- a/hotspot/test/runtime/os/THPsInThreadStackPreventionTest.java
+++ b/hotspot/test/runtime/os/THPsInThreadStackPreventionTest.java
@@ -174,11 +174,11 @@ public class THPsInThreadStackPreventionTest {
             throw new SkippedException("Test only makes sense in THP \"always\" mode");
         }
 
+        // JDK8-specific: no UL; use -XX:+Verbose -XX:+PrintMiscellaneous instead
         String[] defaultArgs = {
-            "-Xlog:pagesize",
+            "-XX:+Verbose", "-XX:+PrintMiscellaneous",
             "-Xmx" + heapSizeMB + "m", "-Xms" + heapSizeMB + "m", "-XX:+AlwaysPreTouch", // stabilize RSS
             "-Xss" + threadStackSizeMB + "m",
-            "-XX:-CreateCoredumpOnCrash",
             // Limits the number of JVM-internal threads, which depends on the available cores of the
             // machine. RSS+Swap could exceed acceptableRSSLimitMB when JVM creates many internal threads.
             "-XX:ActiveProcessorCount=2",
@@ -197,7 +197,7 @@ public class THPsInThreadStackPreventionTest {
                 output.shouldHaveExitValue(0);
 
                 // this line indicates the mitigation is active:
-                output.shouldContain("[pagesize] JVM will attempt to prevent THPs in thread stacks.");
+                output.shouldContain("JVM will attempt to prevent THPs in thread stacks.");
 
                 ProcSelfStatus status = ProcSelfStatus.parse(output);
                 if (status.numLifeThreads < numThreads) {

--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -316,7 +317,17 @@ public final class ProcessTools {
         return 42;
     }
 
-
+    /**
+     * Create ProcessBuilder using the java launcher from the jdk to be tested.
+     * <p>
+     * @param command Arguments to pass to the java command.
+     * @return The ProcessBuilder instance representing the java command.
+     */
+    public static ProcessBuilder createJavaProcessBuilder(List<String> command) {
+        String[] argsArr = new String[command.size()];
+        argsArr = command.toArray(argsArr);
+        return createJavaProcessBuilder(argsArr);
+    }
 
     /**
      * Create ProcessBuilder using the java launcher from the jdk to be tested and


### PR DESCRIPTION
This backports the THP-always memory bloat fix to JDK 8.

The JDK 11 patch (https://github.com/openjdk/jdk11u-dev/pull/3223) was a cut-down version of the original fix; see its lengthy PR description for details. This patch for JDK8 is the same patch but with JDK8-specific additions.

----

There is one important functional change to the JDK 11 version:

JDK 8 misses several patches that address an error in older glibc (<2.27) that can cause SOEs if glibc guard pages are used. In practice, this only affects very old EOL distros like RHEL 7.  JDK 11 and later handle this glibc bug transparently. For JDK 8, I chose the simplest route of disabling my patch when an older glibc is detected. This means that I had to add glibc version detection to hotspot and the jtreg regression test, but that is simple stuff.

For the curious, the patches missing in JDK 8 are:
- https://bugs.openjdk.org/browse/JDK-8229147 (Linux os::create_thread() overcounts guardpage size with newer glibc (>=2.27))
- https://bugs.openjdk.org/browse/JDK-8169373 (Work around linux NPTL stack guard error)
- https://bugs.openjdk.org/browse/JDK-8170655 "[posix] Fix minimum stack size computations"

----

Other than that, the rest of the changes to JDK 11 is trivial:

1) https://bugs.openjdk.org/browse/JDK-8305481 "gtest is_first_C_frame failing on ARM" missing in JDK8; causes trivial conflicts in globals_linux.hpp

2) The missing https://bugs.openjdk.org/browse/JDK-8169373 unified `os::Linux::default_guard_size()` for all Linuxes from the os_cpu branches into os. In JDK8, this function still lives in the various `os_<os>_<cpu>.cpp` files. I moved the guard-size determination into os::create_thread() (Hunk at 903ff) 

3) https://bugs.openjdk.org/browse/JDK-8244010 "Simplify usages of ProcessTools.createJavaProcessBuilder in our tests" is missing in 8u. It adds many convenience functions to ProcessTools. I therefore hand-picked the convenience function `ProcessTools::createJavaProcessBuilder(List<String> command)` from 8244010. Note that backporting 8244010 would be useful, but its out of scope for this patch.

4) Logging changed between JDK 8 and 11. JDK 11 introduces UL, which is used to log THP mitigation state. In JDK 8, I use PrintMiscelleanous+Verbose instead. This also changes the parsing in the regression test a bit (no "[pagesize]" decorators, since decorators are a feature of UL).

-----------

Testing

on RHEL7 (glibc 2.17) x64:
- Tested that patch is correctly disabled on this old glibc version
- ran jtreg regression test (tests the same thing)

on RHEL8 (glibc 2.28) x64:
- In THP-madvise mode, patch is correctly disabled. 
- In THP-always mode, I tested that the patch works (small app, 5000 threads with -Xss2mb, without patch uses 500-800 mb RSS, with patch 300 mb RSS)
- ran jtreg regression test in both modes


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] [JDK-8312182](https://bugs.openjdk.org/browse/JDK-8312182) needs maintainer approval

### Issue
 * [JDK-8312182](https://bugs.openjdk.org/browse/JDK-8312182): THPs cause huge RSS due to thread start timing issue (**Bug** - P3) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u-dev.git pull/847/head:pull/847` \
`$ git checkout pull/847`

Update a local copy of the PR: \
`$ git checkout pull/847` \
`$ git pull https://git.openjdk.org/jdk8u-dev.git pull/847/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 847`

View PR using the GUI difftool: \
`$ git pr show -t 847`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u-dev/pull/847.diff">https://git.openjdk.org/jdk8u-dev/pull/847.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u-dev/pull/847#issuecomment-5599948202)
</details>
